### PR TITLE
ArrayList is not thread safe. The existing synchronized (nonCountableQutoaVmStatusesList) is too small, should be extended to cover the surrounding code.

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/quota/QuotaManager.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/quota/QuotaManager.java
@@ -399,13 +399,13 @@ public class QuotaManager implements BackendService {
     }
 
     public boolean isVmStatusQuotaCountable(VMStatus status) {
-        if (nonCountableQutoaVmStatusesList.size() == 0) {
-            synchronized (nonCountableQutoaVmStatusesList) {
-                nonCountableQutoaVmStatusesList.addAll(
-                        getQuotaDao().getNonCountableQutoaVmStatuses());
-            }
+        synchronized (nonCountableQutoaVmStatusesList) {
+            if (nonCountableQutoaVmStatusesList.size() == 0) {
+                    nonCountableQutoaVmStatusesList.addAll(
+                            getQuotaDao().getNonCountableQutoaVmStatuses());
+                }
+            return !nonCountableQutoaVmStatusesList.contains(status.getValue());
         }
-        return !nonCountableQutoaVmStatusesList.contains(status.getValue());
     }
 
     public Guid getDefaultQuotaId(Guid storagePoolId) {


### PR DESCRIPTION
The current 

```synchronized (nonCountableQutoaVmStatusesList) {```

https://github.com/oVirt/ovirt-engine/blob/master/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/quota/QuotaManager.java#L403-L406

does not also protect

```nonCountableQutoaVmStatusesList.contains()```

https://github.com/oVirt/ovirt-engine/blob/master/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/quota/QuotaManager.java#L408

and ```nonCountableQutoaVmStatusesList.size()```

https://github.com/oVirt/ovirt-engine/blob/master/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/quota/QuotaManager.java#L402

```nonCountableQutoaVmStatusesList``` is an ```ArrayList```, which is
not thread-safe.

```ArrayList.contains()``` searches the entire ```ArrayList``` and is
not thread safe.

```ArrayList.size()``` seems simple (returns the field
```ArrayList.size```), but the field ```ArrayList.size``` is not
```volatile``` and therefore even ```ArrayList.size()``` is not
thread-safe.

The ```synchronized (nonCountableQutoaVmStatusesList)``` should be
extended to cover ```nonCountableQutoaVmStatusesList.contains()``` and
```nonCountableQutoaVmStatusesList.size()``` too, i.e., one line above
and one line below.


The CR seems big because the indentation changes.

However, this CR is simple: it moves the ```synchronized
(nonCountableQutoaVmStatusesList)``` to cover 2 more lines.
