### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,7 @@
 
     <!-- Plugins configurations-->
     <ovirt.surefire.reportsDirectory>${project.build.directory}/surefire-reports</ovirt.surefire.reportsDirectory>
+  	<closeTestReports>true</closeTestReports>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -610,6 +611,7 @@
           <configuration>
             <reportsDirectory>${ovirt.surefire.reportsDirectory}</reportsDirectory>
             <argLine>--illegal-access=permit</argLine>
+            	<disableXmlReport>${closeTestReports}</disableXmlReport>
           </configuration>
         </plugin>
         <plugin>
@@ -835,6 +837,9 @@
         <plugins>
           <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+            	<disableXmlReport>${closeTestReports}</disableXmlReport>
+            </configuration>
           </plugin>
         </plugins>
       </build>
@@ -847,6 +852,7 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <testFailureIgnore>true</testFailureIgnore>
+            	<disableXmlReport>${closeTestReports}</disableXmlReport>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION

That report generation takes time, slowing down the overall build. Reports are definitely useful, but do you need them every time you run the build. We can conditionally disable generating test reports by setting `<disableXmlReport>true<disableXmlReport>`. If you need to generate reports, just add `-DcloseTestReports=false` to the end of mvn build command.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
