### PR TITLE
Fixes the build on Linux ARM64

### DIFF
--- a/backend/manager/modules/restapi/interface/definition/pom.xml
+++ b/backend/manager/modules/restapi/interface/definition/pom.xml
@@ -191,7 +191,7 @@
               <goal>exec</goal>
             </goals>
             <configuration>
-              <executable>/usr/lib/jvm/java-11-openjdk/bin/java</executable>
+              <executable>${java.home}/bin/java</executable>
               <classpathScope>runtime</classpathScope>
               <arguments>
                 <argument>-classpath</argument>
@@ -216,7 +216,7 @@
               <goal>exec</goal>
             </goals>
             <configuration>
-              <executable>/usr/lib/jvm/java-11-openjdk/bin/java</executable>
+              <executable>${java.home}/bin/java</executable>
               <classpathScope>runtime</classpathScope>
               <arguments>
                 <argument>-classpath</argument>

--- a/frontend/brands/ovirt-brand/pom.xml
+++ b/frontend/brands/ovirt-brand/pom.xml
@@ -23,6 +23,7 @@
       <plugin>
          <groupId>com.github.warmuuh</groupId>
          <artifactId>libsass-maven-plugin</artifactId>
+         <version>0.2.10-libsass_3.5.3</version>
          <executions>
            <execution>
              <phase>generate-resources</phase>
@@ -36,6 +37,13 @@
            <outputPath>${project.basedir}/target/generated-resources</outputPath>
            <generateSourceMap>false</generateSourceMap>
          </configuration>
+         <dependencies>
+          <dependency>
+            <groupId>io.bit3</groupId>
+            <artifactId>jsass</artifactId>
+            <version>5.10.4</version>
+          </dependency>
+         </dependencies>
       </plugin>
 
       <plugin>
@@ -73,11 +81,19 @@
           <plugin>
             <groupId>com.github.warmuuh</groupId>
             <artifactId>libsass-maven-plugin</artifactId>
+             <version>0.2.10-libsass_3.5.3</version>
             <configuration>
               <generateSourceMap>true</generateSourceMap>
               <sourceMapOutputPath>${project.basedir}/target/generated-resources</sourceMapOutputPath>
               <embedSourceContentsInSourceMap>true</embedSourceContentsInSourceMap>
             </configuration>
+            <dependencies>
+              <dependency>
+                <groupId>io.bit3</groupId>
+                <artifactId>jsass</artifactId>
+                <version>5.10.4</version>
+              </dependency>
+            </dependencies>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
This PR fixes the build on Linux ARM64/aarch64.

1) Fixes the hardcoded path to JDK_HOME
2) Updates io.bit3:jsass to a newer version that supports Linux aarch64 (see https://github.com/warmuuh/libsass-maven-plugin/pull/88 and https://github.com/warmuuh/libsass-maven-plugin/issues/82#issuecomment-981566618)