### PR TITLE
Fix the build

### DIFF
--- a/.automation/build-rpm.sh
+++ b/.automation/build-rpm.sh
@@ -5,26 +5,20 @@ source $(dirname "$(readlink -f "$0")")/build-srpm.sh
 # Install build dependencies
 dnf builddep -y rpmbuild/SRPMS/*src.rpm
 
-# build minimal rpms for CI, fuller ones for releases
+# Perform reasonable quick build with unit tests execution
 BUILD_UT=0
 BUILD_ALL_USER_AGENTS=0
 BUILD_LOCALES=0
 
-if [ -z "${MILESTONE}" ] || { [ -n "${MILESTONE}" ] && [ "${MILESTONE}" != "master" ]; }; then
-	BUILD_UT=1
-	BUILD_ALL_USER_AGENTS=1
-	BUILD_LOCALES=1
-fi
-
 # Build binary package
 rpmbuild \
-    --define "_topmdir rpmbuild" \
-    --define "_rpmdir rpmbuild" \
-    ${SUFFIX:+-D "release_suffix ${SUFFIX}"} \
+    -D "_topmdir rpmbuild" \
+    -D "_rpmdir rpmbuild" \
+    ${RELEASE:+-D "release_suffix ${RELEASE}"} \
     -D "ovirt_build_ut ${BUILD_UT}" \
     -D "ovirt_build_all_user_agents ${BUILD_ALL_USER_AGENTS}" \
     -D "ovirt_build_locales ${BUILD_LOCALES}" \
-    -D "ovirt_build_extra_flags $EXTRA_BUILD_FLAGS" \
+    -D "ovirt_build_extra_flags ${EXTRA_BUILD_FLAGS}" \
     --rebuild rpmbuild/SRPMS/*src.rpm
 
 # Move RPMs to exported artifacts

--- a/.automation/build-srpm.sh
+++ b/.automation/build-srpm.sh
@@ -10,52 +10,35 @@ fi
 # Directory, where build artifacts will be stored, should be passed as the 1st parameter
 ARTIFACTS_DIR=${1:-exported-artifacts}
 
-# Get the MILESTONE from version.mak, so that we know if we build for a
-# non-release milestone, such as master, alpha, beta, etc., or for a
-# release (and then MILESTONE is empty).
-# Do this methodically, by generating a shell script snippet using make
-# and writing it there, instead of parsing version.mak ourselves.
-make generated-files
-. source $(dirname "$(readlink -f "$0")")/../automation/milestone-config.sh
+# Prepare the version string (with support for SNAPSHOT versioning)
+VERSION=$(mvn help:evaluate  -q -DforceStdout -Dexpression=project.version)
+VERSION=${VERSION/-SNAPSHOT/-0.${GIT_HASH}.$(date +%04Y%02m%02d%02H%02M)}
+IFS='-' read -ra VERSION <<< "$VERSION"
+RELEASE=${VERSION[1]-1}
+MILESTONE=master
 
-# Set SUFFIX only for MILESTONEs
-SUFFIX=
-[ -n "${MILESTONE}" ] && SUFFIX=".git${GIT_HASH}"
+# GH RPM builds will be used only for OST so Firefox and Chrome are enough
+# GWT build memory needs to be limited
+EXTRA_BUILD_FLAGS=""
+EXTRA_BUILD_FLAGS="${EXTRA_BUILD_FLAGS} -Dgwt.userAgent=gecko1_8,safari"
+EXTRA_BUILD_FLAGS="${EXTRA_BUILD_FLAGS} -Dgwt.compiler.localWorkers=1"
+EXTRA_BUILD_FLAGS="${EXTRA_BUILD_FLAGS} -Dgwt.jvmArgs='-Xms1G -Xmx3G'"
 
-source automation/jvm-opts.sh
-
-MAVEN_OPTS="$MAVEN_OPTS $JVM_MEM_OPTS"
-export MAVEN_OPTS
-
-
-export BUILD_JAVA_OPTS_MAVEN="\
-    -Dgwt.compiler.localWorkers=1 \
-    -Dovirt.surefire.reportsDirectory=${ARTIFACTS_DIR}/tests \
-"
-
-# For milestone (non-release) master builds, build permutations for chrome and firefox
-if [ -n "${MILESTONE}" ] && [ "${MILESTONE}" == "master" ]; then
-	export EXTRA_BUILD_FLAGS="-D gwt.userAgent=gecko1_8,safari"
-else
-	export EXTRA_BUILD_FLAGS=""
-fi
-
-export BUILD_JAVA_OPTS_GWT="$JVM_MEM_OPTS"
+export MAVEN_OPTS="-Xms1G -Xmx2G"
 
 # Set the location of the JDK that will be used for compilation:
 export JAVA_HOME="${JAVA_HOME:=/usr/lib/jvm/java-11}"
 
-[ -d ${ARTIFACTS_DIR}/tests ] || mkdir -p ${ARTIFACTS_DIR}/tests
+[ -d ${ARTIFACTS_DIR} ] || mkdir -p ${ARTIFACTS_DIR}
+[ -d rpmbuild/SOURCES ] || mkdir -p rpmbuild/SOURCES
 
-make clean \
-    "EXTRA_BUILD_FLAGS=$EXTRA_BUILD_FLAGS"
+make generated-files
 
 # Get the tarball
 make dist
+mv *.tar.gz rpmbuild/SOURCES
 
 # create the src.rpm
 rpmbuild \
-    -D "_topmdir rpmbuild" \
-    ${SUFFIX:+-D "release_suffix ${SUFFIX}"} \
-    -D "ovirt_build_extra_flags $EXTRA_BUILD_FLAGS" \
-    -ts ./*.gz
+    -D "_topdir rpmbuild" \
+    -ts rpmbuild/SOURCES/*.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,6 @@ jobs:
       run: |
         # Install oVirt repositories
         dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-8
-        dnf install -y ovirt-release-master
 
         # Requried for python3-ansible-lint and python3-isort
         dnf copr enable -y sbonazzo/EL8_collection
@@ -52,11 +51,9 @@ jobs:
 
         # Install oVirt repositories
         dnf copr enable -y ovirt/ovirt-master-snapshot
-        dnf install -y ovirt-release-master
 
         # Requried for python3-ansible-lint and python3-isort
         dnf copr enable -y sbonazzo/EL9_collection
-
 
         # Configure CS9 repositories
         dnf config-manager --enable crb
@@ -71,10 +68,8 @@ jobs:
           java-11-openjdk-devel \
           make \
           maven \
-          python3-ansible-lint \
           python3-pycodestyle \
           python3-pytest \
-          python3-pytest-mock \
           python3-devel \
           python3-isort \
           python3-pyflakes \
@@ -97,13 +92,11 @@ jobs:
 
     - name: Perform build
       run: |
-        make all-dev \
-          BUILD_GWT=1 \
-          DEV_BUILD_GWT_DRAFT=1 \
-          BUILD_UT=1 \
-          BUILD_JAVA_OPTS_GWT="-Xms1G -Xmx4G" \
-          DEV_EXTRA_BUILD_FLAGS_GWT_DEFAULTS="-Dgwt.userAgent=gecko1_8,safari" \
-          DEV_EXTRA_BUILD_FLAGS="-Dgwt.compiler.localWorkers=1"
+        .automation/build-rpm.sh $ARTIFACTS_DIR
+
+    - name: Create DNF repository
+      run: |
+        createrepo_c $ARTIFACTS_DIR
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v2

--- a/frontend/webadmin/modules/frontend-assemblies/src/main/resources/assemblies/gwt-symbols.xml
+++ b/frontend/webadmin/modules/frontend-assemblies/src/main/resources/assemblies/gwt-symbols.xml
@@ -1,6 +1,6 @@
-<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+  xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
   <id>gwt-symbols</id>
   <formats>
     <format>zip</format>


### PR DESCRIPTION
1. Add sbonazzo/ELi{8,9}_collection to satisfy build dependencies
2. Fix the script name invoked from GH workflow
3. Don't add Virt SIG repo, which contains newer xmvn until we remove
   %add_maven_depmap macro

Signed-off-by: Martin Perina <mperina@redhat.com>
