### PR TITLE
Revert: packaging: spec: require jaxb-api

### DIFF
--- a/ovirt-engine.spec.in
+++ b/ovirt-engine.spec.in
@@ -280,8 +280,6 @@ BuildRequires:	javapackages-local
 
 # backend
 BuildRequires:	%{name}-extensions-api >= 1.0.1
-# backend - aaa
-BuildRequires:	jaxb-api
 
 # findbugs filter
 BuildRequires:	maven-surefire-plugin


### PR DESCRIPTION
Reverting commit 47290a80a78af0ce79daac932ac442fcfdc168d2 because it
broke both github and COPR builds

Signed-off-by: Martin Perina <mperina@redhat.com>
