### PR TITLE
core: set disk_id when downloading snapshots

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/GetDiskIdBySnapshotIdQuery.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/GetDiskIdBySnapshotIdQuery.java
@@ -1,0 +1,30 @@
+package org.ovirt.engine.core.bll;
+
+import javax.inject.Inject;
+
+import org.ovirt.engine.core.bll.context.EngineContext;
+import org.ovirt.engine.core.common.businessentities.storage.Image;
+import org.ovirt.engine.core.common.queries.IdQueryParameters;
+import org.ovirt.engine.core.compat.Guid;
+import org.ovirt.engine.core.dao.ImageDao;
+
+public class GetDiskIdBySnapshotIdQuery extends QueriesCommandBase<IdQueryParameters> {
+
+    @Inject
+    private ImageDao imageDao;
+
+    public GetDiskIdBySnapshotIdQuery(IdQueryParameters parameters, EngineContext engineContext) {
+        super(parameters, engineContext);
+    }
+
+    @Override
+    protected void executeQueryCommand() {
+        Image image = imageDao.get(getParameters().getId());
+        if (image != null) {
+            getQueryReturnValue().setReturnValue(image.getDiskId());
+        } else {
+            getQueryReturnValue().setReturnValue(Guid.Empty);
+        }
+    }
+
+}

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/TransferDiskImageCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/TransferDiskImageCommand.java
@@ -628,12 +628,9 @@ public class TransferDiskImageCommand<T extends TransferDiskImageParameters> ext
 
         log.info("Successfully added {} for image transfer '{}'", getTransferDescription(), getCommandId());
 
-        // ImageGroup is empty when downloading a disk snapshot
-        if (!Guid.isNullOrEmpty(getParameters().getImageGroupID())) {
-            ImageTransfer updates = new ImageTransfer();
-            updates.setDiskId(getParameters().getImageGroupID());
-            updateEntity(updates);
-        }
+        ImageTransfer updates = new ImageTransfer();
+        updates.setDiskId(getParameters().getImageGroupID());
+        updateEntity(updates);
 
         // The image will remain locked until the transfer command has completed.
         lockImage();

--- a/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/storage/disk/image/TransferDiskImageCommandTest.java
+++ b/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/storage/disk/image/TransferDiskImageCommandTest.java
@@ -76,6 +76,9 @@ public class TransferDiskImageCommandTest extends BaseCommandTest {
     @Mock
     private VmBackupDao vmBackupDao;
 
+    @Mock
+    private ImageTransferUpdater imageTransferUpdater;
+
     @Spy
     @InjectMocks
     private  TransferDiskImageCommand<TransferDiskImageParameters> transferImageCommand =

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/queries/QueryType.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/queries/QueryType.java
@@ -228,7 +228,7 @@ public enum QueryType implements Serializable {
     GetAllImageTransfers(QueryAuthType.Admin),
     GetDiskImageByDiskAndImageIds(QueryAuthType.User),
     GetNumberOfImagesByStorageDomainId(QueryAuthType.Admin),
-
+    GetDiskIdBySnapshotId(QueryAuthType.User),
     GetDiskVmElementById(QueryAuthType.User),
     GetDiskVmElementsByVmId(QueryAuthType.User),
 

--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendImageTransfersResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendImageTransfersResource.java
@@ -19,6 +19,7 @@ import org.ovirt.engine.core.common.businessentities.storage.TransferClientType;
 import org.ovirt.engine.core.common.businessentities.storage.TransferType;
 import org.ovirt.engine.core.common.queries.IdQueryParameters;
 import org.ovirt.engine.core.common.queries.QueryParametersBase;
+import org.ovirt.engine.core.common.queries.QueryReturnValue;
 import org.ovirt.engine.core.common.queries.QueryType;
 import org.ovirt.engine.core.compat.Guid;
 
@@ -52,6 +53,8 @@ public class BackendImageTransfersResource
     public Response addForSnapshot(ImageTransfer imageTransfer) {
         TransferDiskImageParameters params = new TransferDiskImageParameters();
         params.setImageId(GuidUtils.asGuid(imageTransfer.getSnapshot().getId()));
+        QueryReturnValue value = runQuery(QueryType.GetDiskIdBySnapshotId, new IdQueryParameters(params.getImageId()));
+        params.setImageGroupID(value.getReturnValue());
         return performCreate(imageTransfer, params);
     }
 


### PR DESCRIPTION
Currently when downloading snapshots the disk_id would remain empty.
This may cause issues if this field is accessed, which happens when
moving a host to maintenance and will lead to NPEs.

Since snapshots in the system are always part of a disk, this patch sets
the snapshot's disk_id when transfer request is made.

Bug-Url: https://bugzilla.redhat.com/2043984
Signed-off-by: Benny Zlotnik <bzlotnik@redhat.com>