### PR TITLE
add storage codeowenrs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,6 +16,9 @@ backend/manager/modules/*/org/ovirt/engine/core/bll/host/       @dangel101 @mwpe
 
 backend/manager/modules/*/org/ovirt/engine/core/*/job/          @arso @mwperina
 
+backend/manager/modules/*/org/ovirt/engine/core/bll/storage/    @bennyz @ahadas
+backend/manager/modules/*/org/ovirt/engine/core/bll/snapshots/  @bennyz @ahadas
+
 **/*vms*    @ahadas
 
 restapi/    @oliel @mwperina


### PR DESCRIPTION
Add codeowners for paths owned by the storage team

Signed-off-by: Benny Zlotnik <bzlotnik@redhat.com>