### PR TITLE
restapi: Support reducing a custom image

### DIFF
--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendDiskResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendDiskResource.java
@@ -171,8 +171,11 @@ public class BackendDiskResource
 
     @Override
     public Response reduce(Action action) {
-        Disk disk = get();
-        Guid imageId = getDiskImageId(disk.getImageId());
+        Guid imageId = Guid.createGuidFromString(action.getDisk().getImageId());
+        if (imageId == null) {
+            Disk disk = get();
+            imageId = getDiskImageId(disk.getImageId());
+        }
         ImagesActionsParametersBase params = new ImagesActionsParametersBase(imageId);
         return doAction(ActionType.ReduceImage, params, action);
     }


### PR DESCRIPTION
Currently it's only possible to reduce the top image, which is not
possible for running VMs.

This patch enables choosing which image to reduce.
Example request:
```
POST http://engine:8080/ovirt-engine/api/disks/<disk_id>/reduce
<action>
    <disk>
        <image_id>09a3e05e-12e7-4b11-93a2-66173e7148e2</image_id>
    </disk>
</action>
```

Related-To: https://bugzilla.redhat.com/1993235
Change-Id: I6b1e299e62acc6d6932ed7d3c45f15a725e97468
Signed-off-by: Benny Zlotnik <bzlotnik@redhat.com>