### PR TITLE
github: Fix code owners patterns

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,17 +7,17 @@
 packaging/dbscripts/    @emesika @mwperina
 *Dao*.java              @emesika @mwperina
 
-backend/manager/modules/*/org/ovirt/engine/core/bll/pm/    @emesika @mwperina
+backend/manager/modules/**/org/ovirt/engine/core/bll/pm/    @emesika @mwperina
 
 **/*network*   @almusil @eraviv
 
-backend/manager/modules/*/org/ovirt/engine/core/*/hostdeploy/   @dangel101 @mwperina
-backend/manager/modules/*/org/ovirt/engine/core/bll/host/       @dangel101 @mwperina
+backend/manager/modules/**/org/ovirt/engine/core/*/hostdeploy/   @dangel101 @mwperina
+backend/manager/modules/**/org/ovirt/engine/core/bll/host/       @dangel101 @mwperina
 
-backend/manager/modules/*/org/ovirt/engine/core/*/job/          @arso @mwperina
+backend/manager/modules/**/org/ovirt/engine/core/*/job/          @arso @mwperina
 
-backend/manager/modules/*/org/ovirt/engine/core/bll/storage/    @bennyz @ahadas
-backend/manager/modules/*/org/ovirt/engine/core/bll/snapshots/  @bennyz @ahadas
+backend/manager/modules/**/org/ovirt/engine/core/bll/storage/    @bennyz @ahadas
+backend/manager/modules/**/org/ovirt/engine/core/bll/snapshots/  @bennyz @ahadas
 
 **/*vms*    @ahadas
 
@@ -34,6 +34,3 @@ pom.xml    @arso @mwperina
 packaging/ansible-runner-service-project/    @dangel101 @mwperina
 
 frontend    @sgratch
-
-
-


### PR DESCRIPTION
Looking at #53, there are too many owners.

The file:
backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/backup/CreateScratchDisksCommand.java

Does not match:
backend/manager/modules/*/org/ovirt/engine/core/bll/storage/

So we get the default (*) owners.

Add "**" to match the missing "main/java/org", based on other patterns
in this file.

Signed-off-by: Nir Soffer <nsoffer@redhat.com>