### PR TITLE
core: skiping snapshots for VMs with MBS disks and attaching MBS disks while cloning a VM

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/AddVmCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/AddVmCommand.java
@@ -193,7 +193,6 @@ public class AddVmCommand<T extends AddVmParameters> extends VmManagementCommand
     private VmBase vmDevicesSource;
     private List<StorageDomain> poolDomains;
 
-    private Map<Guid, Guid> srcDiskIdToTargetDiskIdMapping = new HashMap<>();
     private Map<Guid, Guid> srcVmNicIdToTargetVmNicIdMapping = new HashMap<>();
 
     @Inject
@@ -1439,7 +1438,7 @@ public class AddVmCommand<T extends AddVmParameters> extends VmManagementCommand
 
             diskImageMap.put(cinderDisk.getId(), imageId);
         }
-        srcDiskIdToTargetDiskIdMapping.putAll(diskImageMap);
+        getSrcDiskIdToTargetDiskIdMapping().putAll(diskImageMap);
     }
 
     protected void addManagedBlockDisks(Collection<DiskImage> templateDisks) {
@@ -1462,7 +1461,7 @@ public class AddVmCommand<T extends AddVmParameters> extends VmManagementCommand
             Guid imageId = actionReturnValue.getActionReturnValue();
             diskImageMap.put(managedBlockDisk.getId(), imageId);
         }
-        srcDiskIdToTargetDiskIdMapping.putAll(diskImageMap);
+        getSrcDiskIdToTargetDiskIdMapping().putAll(diskImageMap);
     }
 
     private ImagesContainterParametersBase buildImagesContainterParameters(DiskImage srcDisk) {
@@ -1708,7 +1707,7 @@ public class AddVmCommand<T extends AddVmParameters> extends VmManagementCommand
     }
 
     private void addDiskPermissions() {
-        List<Guid> newDiskImageIds = new ArrayList<>(srcDiskIdToTargetDiskIdMapping.values());
+        List<Guid> newDiskImageIds = new ArrayList<>(getSrcDiskIdToTargetDiskIdMapping().values());
         Permission[] permsArray = new Permission[newDiskImageIds.size()];
 
         for (int i = 0; i < newDiskImageIds.size(); i++) {

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/AddVmCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/AddVmCommand.java
@@ -505,7 +505,7 @@ public class AddVmCommand<T extends AddVmParameters> extends VmManagementCommand
      * Check if destination storage has enough space
      */
     protected boolean validateSpaceRequirements() {
-        for (Map.Entry<Guid, List<DiskImage>> sdImageEntry : storageToDisksMap.entrySet()) {
+        for (Map.Entry<Guid, List<DiskImage>> sdImageEntry : getStorageToDisksMap().entrySet()) {
             StorageDomain destStorageDomain = destStorages.get(sdImageEntry.getKey());
             List<DiskImage> disksList = sdImageEntry.getValue();
             StorageDomainValidator storageDomainValidator = createStorageDomainValidator(destStorageDomain);
@@ -628,11 +628,6 @@ public class AddVmCommand<T extends AddVmParameters> extends VmManagementCommand
         if (!validateQuota(getParameters().getVmStaticData().getQuotaId())) {
             return false;
         }
-
-        // otherwise..
-        storageToDisksMap =
-                ImagesHandler.buildStorageToDiskMap(getImagesToCheckDestinationStorageDomains(),
-                        diskInfoDestinationMap);
 
         if (!validateAddVmCommand()) {
             return false;
@@ -843,6 +838,14 @@ public class AddVmCommand<T extends AddVmParameters> extends VmManagementCommand
         return true;
     }
 
+    protected Map<Guid, List<DiskImage>> getStorageToDisksMap() {
+        if (storageToDisksMap == null) {
+            storageToDisksMap = ImagesHandler.buildStorageToDiskMap(getImagesToCheckDestinationStorageDomains(),
+                    diskInfoDestinationMap);
+        }
+        return storageToDisksMap;
+    }
+
     protected boolean isDisksVolumeFormatValid() {
         if (diskInfoDestinationMap.values()
                 .stream()
@@ -897,7 +900,7 @@ public class AddVmCommand<T extends AddVmParameters> extends VmManagementCommand
                     false,
                     true,
                     true,
-                    storageToDisksMap.get(storage.getId())))) {
+                    getStorageToDisksMap().get(storage.getId())))) {
                 return false;
             }
         }

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/CloneVmCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/CloneVmCommand.java
@@ -510,7 +510,9 @@ public class CloneVmCommand<T extends CloneVmParameters> extends AddVmAndCloneIm
 
     @Override
     protected VM getVmFromConfiguration() {
-        if (getParameters().getSourceSnapshotId() == null) {
+        // Get the VM from the database in case of cloning a VM with MBS disks
+        // because we don't create a snapshot in this case
+        if (getParameters().getSourceSnapshotId() == null || !isAllVmDisksSupportSnapshots()) {
             return getVm();
         }
         if (vmFromConfiguration == null) {

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/CloneVmParameters.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/CloneVmParameters.java
@@ -2,7 +2,6 @@ package org.ovirt.engine.core.common.action;
 
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import org.ovirt.engine.core.common.businessentities.VM;
@@ -20,7 +19,6 @@ public class CloneVmParameters extends AddVmParameters {
     private Guid destStorageDomainId;
     private CloneVmStage stage = CloneVmStage.CREATE_VM_SNAPSHOT;
     private Guid sourceSnapshotId;
-    private Map<Guid, List<DiskImage>> storageToDisksMap;
     private Collection<VmInterfacesModifyParameters.VnicWithProfile> vnicsWithProfiles;
 
     private boolean edited;
@@ -94,14 +92,6 @@ public class CloneVmParameters extends AddVmParameters {
 
     public void setSourceSnapshotId(Guid sourceSnapshotId) {
         this.sourceSnapshotId = sourceSnapshotId;
-    }
-
-    public Map<Guid, List<DiskImage>> getStorageToDisksMap() {
-        return storageToDisksMap;
-    }
-
-    public void setStorageToDisksMap(Map<Guid, List<DiskImage>> storageToDisksMap) {
-        this.storageToDisksMap = storageToDisksMap;
     }
 
     public Collection<VmInterfacesModifyParameters.VnicWithProfile> getVnicsWithProfiles() {


### PR DESCRIPTION
(Original fix: https://gerrit.ovirt.org/c/ovirt-engine/+/118343/ and https://gerrit.ovirt.org/c/ovirt-engine/+/118169).

When cloning a VM with an MBS disk, the method getSourceDisks() is being used for getting and filtering the target disks for cloning.
Currently, the MBS disks are filtered by their pluggability.
During the cloning process, a VM snapshot is being created, and its disks are marked as un-plugged and not active.
Therefore, the MBS disks are filtered out from the images' list.
When trying to remove the snapshot and retrieve the disks, there's an NPE, and the clone operation fails.

This patch skips the snapshots' creation (and removal) in case of a non-running VM with MBS disks.

Another issue is that the VM is being cloned without the MBS disks.
This patch deals with that issue by:

-  Avoid filtering out MBS disks while cloning.
- Gets the VM attributes for keeping the context before/after calling CloneSingleManagedBlockDiskCommand.
- Saves the relation between the source and cloned disk's ids.

