### PR TITLE
Add parameters to minimize scratch disk initial size

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/backup/CreateScratchDisksCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/backup/CreateScratchDisksCommand.java
@@ -64,9 +64,9 @@ public class CreateScratchDisksCommand<T extends VmBackupParameters> extends VmC
             }
 
             Guid scratchDiskId = returnValue.getActionReturnValue();
+            log.info("Created scratch disk '{}' for disk ID '{}'", scratchDiskId, disk.getId());
             DiskImage scratchDisk = (DiskImage) diskDao.get(scratchDiskId);
-            // Note, that the scratch disk path will be updated after preparing the scratch disk.
-            getParameters().getScratchDisksMap().put(disk.getId(), new Pair<>(scratchDisk, null));
+            getParameters().getScratchDisksMap().put(disk.getId(), scratchDisk);
         }
 
         persistCommandIfNeeded();

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/backup/RemoveScratchDisksCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/backup/RemoveScratchDisksCommand.java
@@ -1,8 +1,8 @@
 package org.ovirt.engine.core.bll.storage.backup;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -44,11 +44,7 @@ public class RemoveScratchDisksCommand<T extends VmBackupParameters> extends VmC
 
     @Override
     protected void executeCommand() {
-        List<DiskImage> scratchDisks = getParameters().getScratchDisksMap()
-                .values()
-                .stream()
-                .map(Pair::getFirst)
-                .collect(Collectors.toList());
+        Collection<DiskImage> scratchDisks = getParameters().getScratchDisksMap().values();
 
         // Scratch disks remain locked throughout the backup.
         // In order to remove the scratch disks they should be unlocked.

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/backup/StartVmBackupCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/backup/StartVmBackupCommand.java
@@ -302,17 +302,8 @@ public class StartVmBackupCommand<T extends VmBackupParameters> extends VmComman
             switch (getParameters().getVmBackup().getPhase()) {
                 case CREATING_SCRATCH_DISKS:
                     if (createScratchDisks()) {
-                        updateVmBackupPhase(VmBackupPhase.PREPARING_SCRATCH_DISK);
-                        log.info("Scratch disks created for the backup");
-                    } else {
-                        updateVmBackupPhase(VmBackupPhase.FINALIZING_FAILURE);
-                    }
-                    break;
-
-                case PREPARING_SCRATCH_DISK:
-                    if (prepareScratchDisks()) {
                         updateVmBackupPhase(VmBackupPhase.STARTING);
-                        log.info("Scratch disks prepared for the backup");
+                        log.info("Scratch disks created for the backup");
                     } else {
                         updateVmBackupPhase(VmBackupPhase.FINALIZING_FAILURE);
                     }
@@ -330,6 +321,12 @@ public class StartVmBackupCommand<T extends VmBackupParameters> extends VmComman
                     break;
 
                 case STARTING:
+                    if (!prepareScratchDisks()) {
+                        updateVmBackupPhase(VmBackupPhase.FINALIZING_FAILURE);
+                        break;
+                    }
+                    log.info("Scratch disks prepared for the backup");
+
                     if (!runLiveVmBackup()) {
                         updateVmBackupPhase(VmBackupPhase.FINALIZING_FAILURE);
                         break;

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/VmBackupParameters.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/VmBackupParameters.java
@@ -9,7 +9,6 @@ import javax.validation.constraints.NotNull;
 
 import org.ovirt.engine.core.common.businessentities.VmBackup;
 import org.ovirt.engine.core.common.businessentities.storage.DiskImage;
-import org.ovirt.engine.core.common.utils.Pair;
 import org.ovirt.engine.core.compat.Guid;
 
 public class VmBackupParameters extends VmOperationParameterBase implements Serializable {
@@ -21,9 +20,8 @@ public class VmBackupParameters extends VmOperationParameterBase implements Seri
     private boolean backupInitiated;
     private Guid toCheckpointId;
     private boolean requireConsistency;
-    // Map between the backed-up disk ID to the created scratch disk image
-    // and the path to it after the scratch disk prepared.
-    private Map<Guid, Pair<DiskImage, String>> scratchDisksMap = new HashMap<>();
+    // Map between the backed-up disk ID to the created scratch disk image.
+    private Map<Guid, DiskImage> scratchDisksMap = new HashMap<>();
 
     public VmBackupParameters() {
     }
@@ -65,11 +63,11 @@ public class VmBackupParameters extends VmOperationParameterBase implements Seri
         return requireConsistency;
     }
 
-    public Map<Guid, Pair<DiskImage, String>> getScratchDisksMap() {
+    public Map<Guid, DiskImage> getScratchDisksMap() {
         return scratchDisksMap;
     }
 
-    public void setScratchDisksMap(Map<Guid, Pair<DiskImage, String>> scratchDisksMap) {
+    public void setScratchDisksMap(Map<Guid, DiskImage> scratchDisksMap) {
         this.scratchDisksMap = scratchDisksMap;
     }
 

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/VmBackupPhase.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/VmBackupPhase.java
@@ -6,7 +6,6 @@ public enum VmBackupPhase {
 
     INITIALIZING("Initializing"),
     CREATING_SCRATCH_DISKS("Creating scratch disks"),
-    PREPARING_SCRATCH_DISK("Preparing scratch disks"),
     STARTING("Starting"),
     ADDING_BITMAPS("Adding volume bitmaps"),
     WAITING_FOR_BITMAPS("Waiting for bitmaps"),

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/vdscommands/ScratchDiskInfo.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/vdscommands/ScratchDiskInfo.java
@@ -1,0 +1,37 @@
+package org.ovirt.engine.core.common.vdscommands;
+
+
+import org.ovirt.engine.core.common.businessentities.storage.DiskImage;
+
+public class ScratchDiskInfo {
+
+    // Created scratch disk image.
+    private DiskImage disk;
+    // Path to the scratch disk image after it was prepared.
+    private String path;
+
+    @SuppressWarnings("unused")
+    private ScratchDiskInfo() {
+    }
+
+    public ScratchDiskInfo(DiskImage scratchDisk, String scratchDiskPath) {
+        this.disk = scratchDisk;
+        this.path = scratchDiskPath;
+    }
+
+    public DiskImage getDisk() {
+        return disk;
+    }
+
+    public void setDisk(DiskImage disk) {
+        this.disk = disk;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+}

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/vdscommands/VmBackupVDSParameters.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/vdscommands/VmBackupVDSParameters.java
@@ -1,5 +1,6 @@
 package org.ovirt.engine.core.common.vdscommands;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.ovirt.engine.core.common.businessentities.VmBackup;
@@ -10,20 +11,25 @@ public class VmBackupVDSParameters extends VdsIdVDSCommandParametersBase {
 
     private VmBackup vmBackup;
     private boolean requireConsistency;
-    // Map between the backed-up disk ID to the created scratch disk image path.
-    private Map<Guid, String> scratchDisksMap;
+    // Map between the backed-up disk ID to the created scratch disk image
+    // and the path to it after the scratch disk was prepared.
+    private Map<Guid, ScratchDiskInfo> scratchDisksMap;
 
     public VmBackupVDSParameters() {
     }
 
     public VmBackupVDSParameters(Guid vdsId, VmBackup vmBackup) {
-        this(vdsId, vmBackup, false);
+        this(vdsId, vmBackup, false, new HashMap<>());
     }
 
-    public VmBackupVDSParameters(Guid vdsId, VmBackup vmBackup, boolean requireConsistency) {
+    public VmBackupVDSParameters(Guid vdsId,
+            VmBackup vmBackup,
+            boolean requireConsistency,
+            Map<Guid, ScratchDiskInfo> scratchDisksMap) {
         super(vdsId);
         this.vmBackup = vmBackup;
         this.requireConsistency = requireConsistency;
+        this.scratchDisksMap = scratchDisksMap;
     }
 
     public VmBackup getVmBackup() {
@@ -38,11 +44,11 @@ public class VmBackupVDSParameters extends VdsIdVDSCommandParametersBase {
         return requireConsistency;
     }
 
-    public Map<Guid, String> getScratchDisksMap() {
+    public Map<Guid, ScratchDiskInfo> getScratchDisksMap() {
         return scratchDisksMap;
     }
 
-    public void setScratchDisksMap(Map<Guid, String> scratchDisksMap) {
+    public void setScratchDisksMap(Map<Guid, ScratchDiskInfo> scratchDisksMap) {
         this.scratchDisksMap = scratchDisksMap;
     }
 

--- a/backend/manager/modules/restapi/types/src/main/java/org/ovirt/engine/api/restapi/types/VmBackupMapper.java
+++ b/backend/manager/modules/restapi/types/src/main/java/org/ovirt/engine/api/restapi/types/VmBackupMapper.java
@@ -77,7 +77,6 @@ public class VmBackupMapper {
         // should be created before the backup can start.
         case INITIALIZING:
         case CREATING_SCRATCH_DISKS:
-        case PREPARING_SCRATCH_DISK:
         case ADDING_BITMAPS:
         case WAITING_FOR_BITMAPS:
             return BackupPhase.INITIALIZING;

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/VmBackupConfigVDSCommandBase.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/VmBackupConfigVDSCommandBase.java
@@ -46,10 +46,15 @@ public abstract class VmBackupConfigVDSCommandBase<P extends VmBackupVDSParamete
             Map<Guid, ScratchDiskInfo> scratchDisksMap = getParameters().getScratchDisksMap();
             if (scratchDisksMap != null && scratchDisksMap.containsKey(diskImage.getId())) {
                 Map<String, Object> scratchDiskParams = new HashMap<>();
-                scratchDiskParams.put(VdsProperties.Path, scratchDisksMap.get(diskImage.getId()).getPath());
+                ScratchDiskInfo scratchDiskInfo = scratchDisksMap.get(diskImage.getId());
+                DiskImage scratchDisk = scratchDiskInfo.getDisk();
+                scratchDiskParams.put(VdsProperties.Path, scratchDiskInfo.getPath());
                 StorageDomainStatic sourceDomain = storageDomainStaticDao.get(diskImage.getStorageIds().get(0));
                 DiskType diskType = sourceDomain.getStorageType().isBlockDomain() ? DiskType.Block : DiskType.File;
                 scratchDiskParams.put(VdsProperties.Type, diskType.getName());
+                scratchDiskParams.put(VdsProperties.DomainId, scratchDisk.getStorageIds().get(0).toString());
+                scratchDiskParams.put(VdsProperties.ImageId, scratchDisk.getId().toString());
+                scratchDiskParams.put(VdsProperties.VolumeId, scratchDisk.getImageId().toString());
                 imageParams.put(VdsProperties.SCRATCH_DISK, scratchDiskParams);
             }
             return imageParams;

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/VmBackupConfigVDSCommandBase.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/VmBackupConfigVDSCommandBase.java
@@ -11,6 +11,7 @@ import org.ovirt.engine.core.common.businessentities.StorageDomainStatic;
 import org.ovirt.engine.core.common.businessentities.VmCheckpoint;
 import org.ovirt.engine.core.common.businessentities.storage.DiskImage;
 import org.ovirt.engine.core.common.businessentities.storage.DiskType;
+import org.ovirt.engine.core.common.vdscommands.ScratchDiskInfo;
 import org.ovirt.engine.core.common.vdscommands.VmBackupVDSParameters;
 import org.ovirt.engine.core.compat.Guid;
 import org.ovirt.engine.core.dao.StorageDomainStaticDao;
@@ -42,10 +43,10 @@ public abstract class VmBackupConfigVDSCommandBase<P extends VmBackupVDSParamete
                 imageParams.put(VdsProperties.BACKUP_MODE, backupMode);
             }
 
-            Map<Guid, String> scratchDisksMap = getParameters().getScratchDisksMap();
+            Map<Guid, ScratchDiskInfo> scratchDisksMap = getParameters().getScratchDisksMap();
             if (scratchDisksMap != null && scratchDisksMap.containsKey(diskImage.getId())) {
                 Map<String, Object> scratchDiskParams = new HashMap<>();
-                scratchDiskParams.put(VdsProperties.Path, scratchDisksMap.get(diskImage.getId()));
+                scratchDiskParams.put(VdsProperties.Path, scratchDisksMap.get(diskImage.getId()).getPath());
                 StorageDomainStatic sourceDomain = storageDomainStaticDao.get(diskImage.getStorageIds().get(0));
                 DiskType diskType = sourceDomain.getStorageType().isBlockDomain() ? DiskType.Block : DiskType.File;
                 scratchDiskParams.put(VdsProperties.Type, diskType.getName());


### PR DESCRIPTION
In order to minimize scratch disk initial size VDSM requires a few additional parameters
that previously were not passed to it at the scratch disk map.
This patch adds the required parameters to make the initial disk allocation more efficient.

This PR consists of 2 gerrit patches that were pretty much code-reviewed in gerrit with all comments resolved:
1) Some refactoring to pass full scratch disk info in 'VmBackupVDSParameters'.
https://gerrit.ovirt.org/c/ovirt-engine/+/118402
2) Using the scratch disk info to generate the required "scratch_disk" configuration object for VDSM:
https://gerrit.ovirt.org/c/ovirt-engine/+/118305

Another 2 commits were added as the 1st and 2nd ones that contain a code refactoring to unite 'PREPARING_SCRATCH_DISK' & 'STARTING' phases into a single one.

Signed-off-by: Pavel Bar <pbar@redhat.com>
Bug-Url: https://bugzilla.redhat.com/1913389
Change-Id: I4841d69c72a8c82cd4b257bf7402a4574818070b