### PR TITLE
core: fix space validation for MoveOrCopyDiskCommand

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/MoveOrCopyDiskCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/MoveOrCopyDiskCommand.java
@@ -276,7 +276,7 @@ public class MoveOrCopyDiskCommand<T extends MoveOrCopyImageGroupParameters> ext
             } else {
                 getImage().getSnapshots().addAll(diskImageDao.getAllSnapshotsForLeaf(getImage().getImageId()));
             }
-            return validate(storageDomainsValidator.allDomainsHaveSpaceForDisksWithSnapshots(Collections.singletonList(getImage())));
+            return validate(storageDomainsValidator.targetDomainHasSpaceForDisks(Collections.singletonList(getImage())));
         }
         return false;
     }

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/validator/storage/MultipleStorageDomainsValidator.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/validator/storage/MultipleStorageDomainsValidator.java
@@ -162,6 +162,15 @@ public class MultipleStorageDomainsValidator {
     }
 
     /**
+     * Validates that all target domains have enough space for the copied disks.
+     * @return {@link ValidationResult#VALID} if the target domain has enough free space, or a {@link ValidationResult}
+     * if the domain is low on space.
+     */
+    public ValidationResult targetDomainHasSpaceForDisks(Collection<DiskImage> diskImages) {
+        return validOrFirstFailure(entry -> getStorageDomainValidator(entry).hasSpaceForDisksWithSnapshots(diskImages));
+    }
+
+    /**
      * Validates if there is a managed block storage domain and if it supports the operation.
      * @return {@link ValidationResult#VALID} if there are managed block storage domains that support the operation,
      * or a {@link ValidationResult} in case there is a managed block storage domain that doesn't support the operation.

--- a/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/storage/disk/MoveOrCopyDiskCommandTest.java
+++ b/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/storage/disk/MoveOrCopyDiskCommandTest.java
@@ -367,7 +367,7 @@ public class MoveOrCopyDiskCommandTest extends BaseCommandTest {
     }
 
     private void mockStorageDomainValidatorWithoutSpace() {
-        when(multipleStorageDomainsValidator.allDomainsHaveSpaceForDisksWithSnapshots(any())).thenReturn(
+        when(multipleStorageDomainsValidator.targetDomainHasSpaceForDisks(any())).thenReturn(
                 new ValidationResult(EngineMessage.ACTION_TYPE_FAILED_DISK_SPACE_LOW_ON_STORAGE_DOMAIN));
     }
 


### PR DESCRIPTION
The current validation, allDomainsHaveSpaceForDisksWithSnapshots, does not check for space on the target domain.

This PR introduces a new validation allTargetDomainsHaveSpaceForDisks method that validates the space on the target domain.

Bug: https://bugzilla.redhat.com/1913429
