### PR TITLE
Dropping myself from default codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Default to all maintainers if nothing more specific matches
-*    @almusil @ahadas @bennyz @emesika @ljelinkova @mwperina @michalskrivanek @oliel @sandrobonazzola @sgratch @smelamud @didib
+*    @almusil @ahadas @bennyz @emesika @ljelinkova @mwperina @michalskrivanek @oliel @sgratch @smelamud @didib
 
 packaging/dbscripts/    @emesika @mwperina
 *Dao*.java              @emesika @mwperina


### PR DESCRIPTION
Most of the work on ovirt-engine is not in my area of competence,
dropping myself as default codeowner.
I'm already listed as codeowner in the specific area which requires my
attention.

Signed-off-by: Sandro Bonazzola <sbonazzo@redhat.com>