### PR TITLE
core: default VGA video for new VMs

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/AddGraphicsAndVideoDevicesCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/AddGraphicsAndVideoDevicesCommand.java
@@ -51,7 +51,7 @@ public class AddGraphicsAndVideoDevicesCommand extends AddGraphicsDeviceCommand 
             return;
         }
         if (vmStatic.getDefaultDisplayType() == DisplayType.none) {
-            vmStatic.setDefaultDisplayType(DisplayType.qxl);
+            vmStatic.setDefaultDisplayType(DisplayType.vga);
             resourceManager.getVmManager(getVmBaseId()).update(vmStatic);
         }
 
@@ -64,7 +64,7 @@ public class AddGraphicsAndVideoDevicesCommand extends AddGraphicsDeviceCommand 
             return;
         }
         if (vmTemplate.getDefaultDisplayType() == DisplayType.none) {
-            vmTemplate.setDefaultDisplayType(DisplayType.qxl);
+            vmTemplate.setDefaultDisplayType(DisplayType.vga);
             vmTemplateDao.update(vmTemplate);
         }
 

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/VmHandler.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/VmHandler.java
@@ -1435,10 +1435,19 @@ public class VmHandler implements BackendService {
 
         if (defaultDisplayType == null) {
             if (!displayGraphicsSupport.isEmpty()) {// when not found otherwise, let's take osinfo's record as the default
-                Map.Entry<DisplayType, Set<GraphicsType>> entry = displayGraphicsSupport.entrySet().iterator().next();
-                defaultDisplayType = entry.getKey();
+                for (Map.Entry<DisplayType, Set<GraphicsType>> entry : displayGraphicsSupport.entrySet()) {
+                    if (defaultDisplayType == null) {
+                        // prioritize first display type based on osinfo
+                        defaultDisplayType = entry.getKey();
+                    }
+                    if (entry.getKey() != DisplayType.qxl) {
+                        // since QXL is deprecated, the first non-QXL display type we see, take it and stop iterating
+                        defaultDisplayType = entry.getKey();
+                        break;
+                    }
+                }
             } else {// no osinfo record
-                defaultDisplayType = DisplayType.qxl;
+                defaultDisplayType = DisplayType.vga;
             }
         }
 

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/DisplayType.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/DisplayType.java
@@ -5,6 +5,7 @@ import org.ovirt.engine.core.common.utils.VmDeviceType;
 public enum DisplayType {
     @Deprecated
     cirrus(VmDeviceType.CIRRUS),
+    @Deprecated
     qxl(VmDeviceType.QXL),
     vga(VmDeviceType.VGA),
     bochs(VmDeviceType.BOCHS),

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/VmBase.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/VmBase.java
@@ -426,7 +426,7 @@ public class VmBase implements Queryable, BusinessEntity<Guid>, Nameable, Commen
         defaultBootSequence = BootSequence.C;
         migrationSupport = MigrationSupport.MIGRATABLE;
         vmType = VmType.Server;
-        defaultDisplayType = DisplayType.qxl;
+        defaultDisplayType = DisplayType.vga;
         ssoMethod = SsoMethod.GUEST_AGENT;
         spiceFileTransferEnabled = true;
         spiceCopyPasteEnabled = true;

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/VmStatic.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/VmStatic.java
@@ -41,7 +41,7 @@ public class VmStatic extends VmBase {
         setNiceLevel(0);
         setCpuShares(0);
         setDefaultBootSequence(BootSequence.C);
-        setDefaultDisplayType(DisplayType.qxl);
+        setDefaultDisplayType(DisplayType.vga);
         setVmType(VmType.Server);
         vmtGuid = Guid.Empty;
     }

--- a/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfReader.java
+++ b/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfReader.java
@@ -885,11 +885,11 @@ public abstract class OvfReader implements IOvfBuilder {
                             DisplayType firstDisplayType = supportedGraphicsAndDisplays.get(0).getSecond();
                             vmDevice.setDevice(firstDisplayType.getDefaultVmDeviceType().getName());
                         } else {
-                            vmDevice.setDevice(VmDeviceType.QXL.getName());
+                            vmDevice.setDevice(VmDeviceType.VGA.getName());
                         }
                     }
-                } else { // default to spice if quantity not found
-                    vmDevice.setDevice(VmDeviceType.QXL.getName());
+                } else { // default to VNC if quantity not found
+                    vmDevice.setDevice(VmDeviceType.VGA.getName());
                 }
             } else {
                 vmDevice.setDevice(VmDeviceType.getoVirtDevice(Integer.parseInt(resourceType)).getName());

--- a/packaging/dbscripts/upgrade/04_05_0290_change_default_display.sql
+++ b/packaging/dbscripts/upgrade/04_05_0290_change_default_display.sql
@@ -1,0 +1,32 @@
+-- Removing all graphics from blank template
+DELETE FROM vm_device
+WHERE type = 'graphics'
+    AND vm_id = '00000000-0000-0000-0000-000000000000'
+    AND EXISTS (select 1 from vm_static where vm_guid = '00000000-0000-0000-0000-000000000000' AND default_display_type = 1);
+
+-- Add VNC graphics to blank template
+INSERT INTO vm_device (device_id, vm_id, type, device, address, spec_params, is_managed, is_plugged, is_readonly)
+SELECT uuid_generate_v1(), '00000000-0000-0000-0000-000000000000', 'graphics', 'vnc', '', '', true, true, false
+WHERE EXISTS (select 1 from vm_static where vm_guid = '00000000-0000-0000-0000-000000000000' AND default_display_type = 1);
+
+-- Removing all video devices from blank template
+DELETE FROM vm_device
+WHERE type = 'video'
+    AND vm_id = '00000000-0000-0000-0000-000000000000'
+    AND EXISTS (select 1 from vm_static where vm_guid = '00000000-0000-0000-0000-000000000000' AND default_display_type = 1);
+
+-- Add VGA video device to blank template
+INSERT INTO vm_device (device_id, vm_id, type, device, address, spec_params, is_managed, is_plugged, is_readonly)
+SELECT uuid_generate_v1(), '00000000-0000-0000-0000-000000000000', 'video', 'vga', '', '{"vram" : "16384"}', true, true, false
+WHERE EXISTS (select 1 from vm_static where vm_guid = '00000000-0000-0000-0000-000000000000' AND default_display_type = 1);
+
+-- Change InstanceType's and Blank template default display type from QXL (1) to VGA (2)
+UPDATE vm_static
+SET default_display_type = 2
+WHERE vm_guid in ('00000000-0000-0000-0000-000000000000',
+    '00000003-0003-0003-0003-0000000000be',
+    '00000005-0005-0005-0005-0000000002e6',
+    '00000007-0007-0007-0007-00000000010a',
+    '00000009-0009-0009-0009-0000000000f1',
+    '0000000b-000b-000b-000b-00000000021f')
+    AND default_display_type = 1;


### PR DESCRIPTION
Until now the default video device was QXL, and the graphics were set to
SPICE+VNC. But, in the future QXL won't be supported - both on EL9 and
if one wishes to migrate to Openshift Virtualization.

In the API, QXL is left for now. As we have only one video device and
QXL supports both VNC and SPICE inputs. On a following patch, the
default display will change in API based on whether it supported.

Currently missing some corner cases for blank template, if it's set with a
different video/graphic devices than QXL.

Change-Id: Id96b469144a87454b882744bc798aa83aa9ae715
Bug-Url: https://bugzilla.redhat.com/1976605
Signed-off-by: Liran Rotenberg <lrotenbe@redhat.com>