### PR TITLE
core: drop QXL from cluster level 4.7

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/UpdateClusterCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/UpdateClusterCommand.java
@@ -27,6 +27,7 @@ import org.ovirt.engine.core.bll.utils.CompensationUtils;
 import org.ovirt.engine.core.bll.utils.PermissionSubject;
 import org.ovirt.engine.core.bll.utils.RngDeviceUtils;
 import org.ovirt.engine.core.bll.utils.VersionSupport;
+import org.ovirt.engine.core.bll.utils.VmDeviceUtils;
 import org.ovirt.engine.core.bll.validator.ClusterValidator;
 import org.ovirt.engine.core.common.AuditLogType;
 import org.ovirt.engine.core.common.VdcObjectType;
@@ -124,6 +125,8 @@ public class UpdateClusterCommand<T extends ClusterOperationParameters> extends
     private VmInitDao vmInitDao;
     @Inject
     private OsRepository osRepository;
+    @Inject
+    private VmDeviceUtils vmDeviceUtils;
 
     private List<VDS> allHostsForCluster;
 
@@ -144,6 +147,7 @@ public class UpdateClusterCommand<T extends ClusterOperationParameters> extends
         if (oldCluster != null && shouldUpdateVmsAndTemplates()) {
             vmsLockedForUpdate = filterVmsInClusterNeedUpdate();
             templatesLockedForUpdate = filterTemplatesInClusterNeedUpdate();
+            fillDevices();
         }
 
         if (oldCluster == null || isCpuNameChanged() || isVersionChanged()) {
@@ -160,6 +164,11 @@ public class UpdateClusterCommand<T extends ClusterOperationParameters> extends
                 .filter(vm -> vm.getOrigin() != OriginType.EXTERNAL)
                 .sorted()
                 .collect(Collectors.toList());
+    }
+
+    private void fillDevices() {
+        vmsLockedForUpdate.forEach(vm -> vmDeviceUtils.setVmDevices(vm));
+        templatesLockedForUpdate.forEach(template -> vmDeviceUtils.setVmDevices(template));
     }
 
     private List<VmStatic> getAllVmsInCluster() {

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/utils/VmDeviceUtils.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/utils/VmDeviceUtils.java
@@ -92,7 +92,7 @@ public class VmDeviceUtils {
     private final VmHandler vmHandler;
     private final MacPoolPerCluster macPoolPerCluster;
     private final RngDeviceUtils rngDeviceUtils;
-    private final VideoDeviceSettings videoDeviceSettings;
+    private static VideoDeviceSettings videoDeviceSettings;
 
     private OsRepository osRepository;
 
@@ -621,7 +621,7 @@ public class VmDeviceUtils {
      *
      * @return a map of device parameters
      */
-    private Map<String, Object> getVideoDeviceSpecParams(VmBase vmBase) {
+    public static Map<String, Object> getVideoDeviceSpecParams(VmBase vmBase) {
         return videoDeviceSettings.getVideoDeviceSpecParams(vmBase, VmDeviceCommonUtils.isSingleQxlPci(vmBase));
     }
 

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/FeatureSupported.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/FeatureSupported.java
@@ -393,4 +393,14 @@ public class FeatureSupported {
         return Version.v4_7.lessOrEquals(version);
     }
 
+    /**
+     * Checks if QXL display support disabled for the cluster version
+     *
+     * @param version Compatibility version to check for.
+     * @return true, if QXL is supported.
+     */
+    public static boolean isQxlDisplayDisabled(Version version) {
+        return supportedInConfig(ConfigValues.isQxlDisplayDisabled, version);
+    }
+
 }

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/config/ConfigValues.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/config/ConfigValues.java
@@ -1606,6 +1606,9 @@ public enum ConfigValues {
     @TypeConverterAttribute(Integer.class)
     HostMonitoringWatchdogInactivityThresholdInSeconds,
 
+    @TypeConverterAttribute(Boolean.class)
+    isQxlDisplayDisabled,
+
     Invalid;
 
     private ClientAccessLevel accessLevel;

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/utils/VmDeviceCommonUtils.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/utils/VmDeviceCommonUtils.java
@@ -72,6 +72,10 @@ public class VmDeviceCommonUtils {
         return device.getType() == VmDeviceGeneralType.GRAPHICS;
     }
 
+    public static boolean isVideo(VmDevice device) {
+        return device.getType() == VmDeviceGeneralType.VIDEO;
+    }
+
     public static boolean isBridge(VmDevice device) {
         return device.getType() == VmDeviceGeneralType.INTERFACE
                 && device.getDevice().equals(VmDeviceType.BRIDGE.getName());

--- a/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/OsRepositoryImpl.java
+++ b/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/OsRepositoryImpl.java
@@ -396,6 +396,10 @@ public enum OsRepositoryImpl implements OsRepository {
                 GraphicsType graphics = GraphicsType.fromString(pair.getFirst());
                 DisplayType display = DisplayType.valueOf(pair.getSecond());
 
+                if (display == DisplayType.qxl && version != null && !version.isNotValid() && FeatureSupported.isQxlDisplayDisabled(version)) {
+                    continue;
+                }
+
                 if (display != DisplayType.bochs ||
                         (version != null && !version.isNotValid() && FeatureSupported.isBochsDisplayEnabled(version))) {
                     graphicsAndDisplays.add(new Pair<>(graphics, display));

--- a/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfReader.java
+++ b/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfReader.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.function.Consumer;
 
 import org.apache.commons.lang.StringUtils;
+import org.ovirt.engine.core.common.FeatureSupported;
 import org.ovirt.engine.core.common.businessentities.BiosType;
 import org.ovirt.engine.core.common.businessentities.BootSequence;
 import org.ovirt.engine.core.common.businessentities.ConsoleDisconnectAction;

--- a/packaging/dbscripts/upgrade/pre_upgrade/0000_config.sql
+++ b/packaging/dbscripts/upgrade/pre_upgrade/0000_config.sql
@@ -925,6 +925,8 @@ select fn_db_add_config_value_for_versions_up_to('NvramPersistenceSupported', 'f
 select fn_db_add_config_value_for_versions_up_to('NvramPersistenceSupported', 'true', '4.7');
 select fn_db_add_config_value_for_versions_up_to('EnableBochsDisplay','false','4.5');
 select fn_db_add_config_value_for_versions_up_to('EnableBochsDisplay','true','4.7');
+select fn_db_add_config_value_for_versions_up_to('isQxlDisplayDisabled','false','4.6');
+select fn_db_add_config_value_for_versions_up_to('isQxlDisplayDisabled','true','4.7');
 
 -- Incremental backup
 select fn_db_add_config_value_for_versions_up_to('IsIncrementalBackupSupported', 'false', '4.4');

--- a/packaging/etc/engine-config/engine-config.properties
+++ b/packaging/etc/engine-config/engine-config.properties
@@ -587,3 +587,5 @@ HostMonitoringWatchdogInactivityThresholdInSeconds.type=Integer
 HostMonitoringWatchdogInactivityThresholdInSeconds.description="Warning threshold value of the host monitoring inactivity. Warning will printed in the logs (ie. engine.log) when reached."
 NumOfPciExpressPorts.description="Determines the number of PCI Express ports virtual machines are configured with"
 NumOfPciExpressPorts.type=Integer
+isQxlDisplayDisabled.type=Boolean
+isQxlDisplayDisabled.description="Disables QXL display type."


### PR DESCRIPTION
Since cluster level 4.7 going to use EL9 as hosts and they don't support
SPICE we need to drop it from the engine.

Change-Id: Icf2627252c49cf65d1854c4f620b3911514ee7bf
Bug-Url: https://bugzilla.redhat.com/1976607
Signed-off-by: Liran Rotenberg <lrotenbe@redhat.com>