### PR TITLE
packaging: fapolicyd allow Wildfly/EAP runtime tmp

### DIFF
--- a/ovirt-engine.spec.in
+++ b/ovirt-engine.spec.in
@@ -329,6 +329,16 @@ Requires:	ovirt-cockpit-sso
 Obsoletes:	ovirt-engine-api-explorer
 %endif
 
+%if 0%{?rhel} < 9
+# fapolicyd should be installed but does not have to be running
+# needed for OpenScap DISA STIG compliance
+#
+# TODO: remove condition when fapolicyd-1.1 is available on CS9
+Requires:	fapolicyd >= 1.1
+%else
+Requires:	fapolicyd
+%endif
+
 # Metrics stuff
 Requires:	collectd
 Requires:	collectd-postgresql
@@ -1222,6 +1232,7 @@ fi
 %config %{_sysconfdir}/ovirt-engine-setup.conf.d/10-packaging.conf
 %{_bindir}/engine-upgrade-check
 %{engine_data}/conf/ovirt-engine-proxy.conf.v2.in
+%{engine_data}/conf/fapolicyd-55-allow-ovirt-jboss.rules.in
 %{engine_data}/conf/ovirt-engine-root-redirect.conf.in
 %{engine_data}/firewalld/ovirt-engine/
 %{engine_data}/setup/bin/ovirt-engine-upgrade-check

--- a/packaging/conf/fapolicyd-55-allow-ovirt-jboss.rules.in
+++ b/packaging/conf/fapolicyd-55-allow-ovirt-jboss.rules.in
@@ -1,0 +1,5 @@
+#
+# This is Ovirt Engine configuration and MUST NOT be changed manually
+#
+%java_lang=application/java-archive,text/x-java,application/x-java-applet,application/javascript,text/javascript
+allow perm=any trust=1 : dir=@JBOSS_RUNTIME_TMP_DIR@ ftype=%java_lang

--- a/packaging/setup/ovirt_engine_setup/engine_common/constants.py
+++ b/packaging/setup/ovirt_engine_setup/engine_common/constants.py
@@ -79,6 +79,17 @@ class FileLocations(object):
         OVIRT_ENGINE_PKIKEYSDIR,
         'apache.key.nopass',
     )
+    FAPOLICYD_ALLOW_OVIRT_JBOSS_RULE_TEMPLATE = os.path.join(
+        osetupcons.FileLocations.OVIRT_SETUP_DATADIR,
+        'conf',
+        'fapolicyd-55-allow-ovirt-jboss.rules.in',
+    )
+    FAPOLICYD_ALLOW_OVIRT_JBOSS_RULE = os.path.join(
+        SYSCONFDIR,
+        'fapolicyd',
+        'rules.d',
+        '55-allow-ovirt-jboss.rules',
+    )
 
 
 @util.export
@@ -110,6 +121,8 @@ class Defaults(object):
     DEFAULT_NETWORK_JBOSS_DEBUG_ADDRESS = '127.0.0.1:8787'
 
     DEFAULT_HTTPD_SERVICE = 'httpd'
+
+    DEFAULT_FAPOLICYD_SERVICE = 'fapolicyd'
 
     DEFAULT_POSTGRES_PROVISIONING_PGDATA_DIR = os.path.join(
         osetupcons.FileLocations.LOCALSTATEDIR,
@@ -149,6 +162,7 @@ class Defaults(object):
 class Stages(object):
     ADMIN_PASSWORD_SET = 'osetup.admin.password.set'
     APACHE_RESTART = 'osetup.apache.core.restart'
+    FAPOLICYD_RESTART = 'osetup.fapolicyd.core.restart'
 
     CORE_ENGINE_START = 'osetup.core.engine.start'
 
@@ -353,6 +367,29 @@ class ApacheEnv(object):
     HTTPD_CONF_SSL = 'OVESETUP_APACHE/configFileSsl'
     HTTPD_SERVICE = 'OVESETUP_APACHE/httpdService'
     NEED_RESTART = 'OVESETUP_APACHE/needRestart'
+
+
+@util.export
+@util.codegen
+@osetupattrsclass
+class FapolicydEnv(object):
+    @osetupattrs(
+        postinstallfile=True,
+    )
+    def CONFIGURED(self):
+        return 'OVESETUP_FAPOLICYD/configured'
+
+    @osetupattrs(
+        answerfile=True,
+        summary=True,
+        description=_('Allow ovirt engine jboss tmp directory access'),
+    )
+    def ALLOW_JBOSS_TMP_FOLDER_ACCESS(self):
+        return 'OVESETUP_FAPOLICYD/allowJbossTmpFolderAccess'
+
+    FAPOLICYD_ALLOW_OVIRT_RULE = "OVESETUP_FAPOLICYD/configAllowOvirtRule"
+    FAPOLICYD_SERVICE = 'OVESETUP_FAPOLICYD/fapolicydService'
+    NEED_RESTART = 'OVESETUP_FAPOLICYD/needRestart'
 
 
 @util.export

--- a/packaging/setup/plugins/ovirt-engine-common/ovirt-engine-common/system/__init__.py
+++ b/packaging/setup/plugins/ovirt-engine-common/ovirt-engine-common/system/__init__.py
@@ -14,12 +14,14 @@ from otopi import util
 
 from . import apache
 from . import environment
+from . import fapolicyd
 
 
 @util.export
 def createPlugins(context):
     environment.Plugin(context=context)
     apache.Plugin(context=context)
+    fapolicyd.Plugin(context=context)
 
 
 # vim: expandtab tabstop=4 shiftwidth=4

--- a/packaging/setup/plugins/ovirt-engine-common/ovirt-engine-common/system/fapolicyd.py
+++ b/packaging/setup/plugins/ovirt-engine-common/ovirt-engine-common/system/fapolicyd.py
@@ -1,0 +1,86 @@
+#
+# ovirt-engine-setup -- ovirt engine setup
+#
+# Copyright oVirt Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+
+
+"""Fapolicyd misc plugin."""
+
+
+import gettext
+from otopi import plugin
+from otopi import util
+from ovirt_engine_setup.engine_common import constants as oengcommcons
+
+
+def _(m):
+    return gettext.dgettext(message=m, domain='ovirt-engine-setup')
+
+
+@util.export
+class Plugin(plugin.PluginBase):
+    """Fapolicyd misc plugin."""
+
+    def __init__(self, context):
+        super(Plugin, self).__init__(context=context)
+        self._enabled = False
+
+    @plugin.event(
+        stage=plugin.Stages.STAGE_INIT
+    )
+    def _init(self):
+        self.environment.setdefault(
+            oengcommcons.FapolicydEnv.FAPOLICYD_SERVICE,
+            oengcommcons.Defaults.DEFAULT_FAPOLICYD_SERVICE
+        )
+        self.environment.setdefault(
+            oengcommcons.FapolicydEnv.NEED_RESTART,
+            False,
+        )
+
+    @plugin.event(
+        stage=plugin.Stages.STAGE_SETUP,
+    )
+    def _setup(self):
+        self._enabled = True
+
+    @plugin.event(
+        stage=plugin.Stages.STAGE_CLOSEUP,
+        name=oengcommcons.Stages.FAPOLICYD_RESTART,
+        before=(
+                oengcommcons.Stages.CORE_ENGINE_START,
+        ),
+        condition=lambda self: (
+                self._enabled and
+                self.environment[
+                    oengcommcons.FapolicydEnv.NEED_RESTART
+                ]
+        ),
+    )
+    def _closeup(self):
+        fapolicyd_service = self.environment[
+            oengcommcons.FapolicydEnv.FAPOLICYD_SERVICE
+        ]
+        service_status = self.services.status(
+            fapolicyd_service
+        )
+        if service_status:
+            self.logger.info(
+                _('Restarting {service}').format(
+                    service=fapolicyd_service,
+                )
+            )
+            self.services.restart(fapolicyd_service)
+        else:
+            self.logger.info(
+                _('No need to restart {service} because it is not running.'
+                  ).format(
+                    service=fapolicyd_service,
+                )
+            )
+
+
+# vim: expandtab tabstop=4 shiftwidth=4

--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/config/__init__.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/config/__init__.py
@@ -21,6 +21,7 @@ from . import appmode
 from . import ca
 from . import database
 from . import domain_type
+from . import jboss_fapolicyd
 from . import firewall
 from . import java
 from . import jboss
@@ -54,6 +55,7 @@ def createPlugins(context):
     storage.Plugin(context=context)
     sso.Plugin(context=context)
     notifier.Plugin(context=context)
+    jboss_fapolicyd.Plugin(context=context)
 
 
 # vim: expandtab tabstop=4 shiftwidth=4

--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/config/jboss_fapolicyd.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/config/jboss_fapolicyd.py
@@ -1,0 +1,88 @@
+#
+# ovirt-engine-setup -- ovirt engine setup
+#
+# Copyright oVirt Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+
+
+"""Jboss fapolicyd plugin."""
+
+
+import gettext
+import os
+
+from otopi import constants as otopicons
+from otopi import filetransaction
+from otopi import plugin
+from otopi import util
+
+
+from ovirt_engine import configfile
+from ovirt_engine import util as outil
+from ovirt_engine_setup import constants as osetupcons
+from ovirt_engine_setup.engine import constants as oenginecons
+from ovirt_engine_setup.engine_common import constants as oengcommcons
+
+
+def _(m):
+    return gettext.dgettext(message=m, domain='ovirt-engine-setup')
+
+
+@util.export
+class Plugin(plugin.PluginBase):
+    """JBoss fapolicyd plugin."""
+
+    def __init__(self, context):
+        super(Plugin, self).__init__(context=context)
+
+    @plugin.event(
+        stage=plugin.Stages.STAGE_INIT,
+    )
+    def _init(self):
+        self.environment.setdefault(
+            oengcommcons.FapolicydEnv.FAPOLICYD_ALLOW_OVIRT_RULE,
+            oengcommcons.FileLocations.FAPOLICYD_ALLOW_OVIRT_JBOSS_RULE
+        )
+
+    @plugin.event(
+        stage=plugin.Stages.STAGE_MISC,
+        condition=lambda self: (
+                self.environment[oenginecons.CoreEnv.ENABLE] and
+                not os.path.exists(oengcommcons.FileLocations.FAPOLICYD_ALLOW_OVIRT_JBOSS_RULE),
+                not self.environment[osetupcons.CoreEnv.DEVELOPER_MODE],
+        )
+    )
+    def _misc(self):
+        config = configfile.ConfigFile([
+            oenginecons.FileLocations.OVIRT_ENGINE_SERVICE_CONFIG_DEFAULTS,
+            oenginecons.FileLocations.OVIRT_ENGINE_SERVICE_CONFIG
+        ])
+        engine_tmp_dir = os.path.join(
+            config.get('JBOSS_RUNTIME'),
+            'tmp'
+        )
+
+        self.environment[oengcommcons.FapolicydEnv.NEED_RESTART] = True
+        self.environment[otopicons.CoreEnv.MAIN_TRANSACTION].append(
+            filetransaction.FileTransaction(
+                name=self.environment[
+                    oengcommcons.FapolicydEnv.FAPOLICYD_ALLOW_OVIRT_RULE
+                ],
+                content=outil.processTemplate(
+                    template=(
+                        oengcommcons.FileLocations.FAPOLICYD_ALLOW_OVIRT_JBOSS_RULE_TEMPLATE
+                    ),
+                    subst={
+                        '@JBOSS_RUNTIME_TMP_DIR@': engine_tmp_dir,
+                    },
+                ),
+                modifiedList=self.environment[
+                    otopicons.CoreEnv.MODIFIED_FILES
+                ],
+            )
+        )
+
+
+# vim: expandtab tabstop=4 shiftwidth=4


### PR DESCRIPTION
In order to be able to run Ovirt Engine on host with enabled fapolicyd
rules the custom Wildfly/EAP runtime temporary dir had to allowed. It
was achieved using newly added fapolicyd support for rules.d [1]

This change is also required for DISA STIG

[1] https://github.com/linux-application-whitelisting/fapolicyd/issues/117

Signed-off-by: Artur Socha <asocha@redhat.com>