### PR TITLE
Backport of #59 and #72

### DIFF
--- a/packaging/services/ovirt-engine/ovirt-engine.conf.in
+++ b/packaging/services/ovirt-engine/ovirt-engine.conf.in
@@ -688,7 +688,8 @@ SYSLOG_HANDLER_ENCODING=
 
 #
 # Formatter pattern to format the message to be sent to remote syslog
-SYSLOG_HANDLER_FORMATTER_PATTERN=
+# https://github.com/wildfly/wildfly/blob/main/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Logging_Formatters.adoc#pattern-formatter
+SYSLOG_HANDLER_FORMATTER_PATTERN="%-5p [%c] (%t) %s%e%n"
 
 #
 # The address of the syslog server.

--- a/packaging/services/ovirt-engine/ovirt-engine.conf.in
+++ b/packaging/services/ovirt-engine/ovirt-engine.conf.in
@@ -744,3 +744,12 @@ SYSLOG_HANDLER_TRUNCATE=
 #
 # The maximum length a log message, including the header, is allowed to be.
 SYSLOG_HANDLER_MAX_LENGTH=
+
+#
+# Whether we send engine.log to SYSLOG when SYSLOG_HANDLER_ENABLED=true
+# Default to true to have same behavior as with log4j syslog
+ENGINE_LOG_TO_SYSLOG=true
+
+#
+# Whether we send ui.log to SYSLOG when SYSLOG_HANDLER_ENABLED=true
+UI_LOG_TO_SYSLOG=false

--- a/packaging/services/ovirt-engine/ovirt-engine.conf.in
+++ b/packaging/services/ovirt-engine/ovirt-engine.conf.in
@@ -746,6 +746,11 @@ SYSLOG_HANDLER_TRUNCATE=
 SYSLOG_HANDLER_MAX_LENGTH=
 
 #
+# Whether we send server.log to SYSLOG when SYSLOG_HANDLER_ENABLED=true
+# Default to true to have same behavior as with log4j syslog
+SERVER_LOG_TO_SYSLOG=true
+
+#
 # Whether we send engine.log to SYSLOG when SYSLOG_HANDLER_ENABLED=true
 # Default to true to have same behavior as with log4j syslog
 ENGINE_LOG_TO_SYSLOG=true

--- a/packaging/services/ovirt-engine/ovirt-engine.xml.in
+++ b/packaging/services/ovirt-engine/ovirt-engine.xml.in
@@ -250,7 +250,7 @@
         <handlers>
           <handler name="ovirt-logger"/>
           <handler name="SERVER"/>
-          {% if config.getboolean('SYSLOG_HANDLER_ENABLED') %}
+          {% if config.getboolean('SYSLOG_HANDLER_ENABLED') and config.getboolean('SERVER_LOG_TO_SYSLOG') %}
           <handler name="SYSLOG"/>
           {% endif %}
         </handlers>

--- a/packaging/services/ovirt-engine/ovirt-engine.xml.in
+++ b/packaging/services/ovirt-engine/ovirt-engine.xml.in
@@ -223,6 +223,9 @@
           {% if config.getboolean('ENGINE_LOG_TO_CONSOLE') %}
           <handler name="CONSOLE"/>
           {% endif %}
+          {% if config.getboolean('SYSLOG_HANDLER_ENABLED') and config.getboolean('ENGINE_LOG_TO_SYSLOG') %}
+          <handler name="SYSLOG"/>
+          {% endif %}
         </handlers>
       </logger>
       <!-- Loggers for the UI -->
@@ -230,6 +233,9 @@
         <level name="INFO"/>
         <handlers>
           <handler name="UI"/>
+          {% if config.getboolean('SYSLOG_HANDLER_ENABLED') and config.getboolean('UI_LOG_TO_SYSLOG') %}
+          <handler name="SYSLOG"/>
+          {% endif %}
         </handlers>
       </logger>
        <logger category="org.ovirt.engine.core.bll">


### PR DESCRIPTION
Backport of #59 and #72 to ovirt-engine-4.4 branch

- Fix engine logs via syslog
- Add option to enable/disable sending server.log to remote syslog
- Do not pass log record timestamp to remote syslog

Bug-Url: https://bugzilla.redhat.com/2050218