### PR TITLE
Send grafana link with dashboard data

### DIFF
--- a/frontend/webadmin/modules/frontend/src/main/java/org/ovirt/engine/ui/frontend/server/dashboard/Dashboard.java
+++ b/frontend/webadmin/modules/frontend/src/main/java/org/ovirt/engine/ui/frontend/server/dashboard/Dashboard.java
@@ -20,6 +20,11 @@ public class Dashboard {
     private Inventory inventory;
 
     /**
+     * URL to the engine's grafana instance, or null if it is not configured.
+     */
+    private String engineGrafanaBaseUrl;
+
+    /**
      * @return {@code HeatMapData} object containing heatmap data for clusters and storage domains.
      */
     public HeatMapData getHeatMapData() {
@@ -63,5 +68,13 @@ public class Dashboard {
      */
     public void setInventory(Inventory inventory) {
         this.inventory = inventory;
+    }
+
+    public String getEngineGrafanaBaseUrl() {
+      return engineGrafanaBaseUrl;
+    }
+
+    public void setEngineGrafanaBaseUrl(String engineGrafanaBaseUrl) {
+      this.engineGrafanaBaseUrl = engineGrafanaBaseUrl;
     }
 }


### PR DESCRIPTION
To be able to display a link to the Montioring Portal on the
dashboard on `ovirt-engine-ui-extensions`, the link needs to be
passed along with the rest of the dashboard info.  If grafana is
not configured on the engine, null is returned.

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1991482