### PR TITLE
webadmin: Add an action panel to host device tab

### DIFF
--- a/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/gin/PresenterModule.java
+++ b/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/gin/PresenterModule.java
@@ -2205,6 +2205,8 @@ public class PresenterModule extends BasePresenterModule {
             new TypeLiteral<DetailActionPanelView<VM, HostDeviceView>>(){});
         bindActionPanel(new TypeLiteral<DetailActionPanelPresenterWidget.ViewDef<VDS, HostInterfaceLineModel>>(){},
             new TypeLiteral<DetailActionPanelView<VDS, HostInterfaceLineModel>>(){});
+        bindActionPanel(new TypeLiteral<DetailActionPanelPresenterWidget.ViewDef<VDS, HostDeviceView>>(){},
+                new TypeLiteral<DetailActionPanelView<VDS, HostDeviceView>>(){});
         bindActionPanel(new TypeLiteral<DetailActionPanelPresenterWidget.ViewDef<StoragePool, StorageQos>>(){},
             new TypeLiteral<DetailActionPanelView<StoragePool, StorageQos>>(){});
         bindActionPanel(new TypeLiteral<DetailActionPanelPresenterWidget.ViewDef<Cluster, VDS>>(){},

--- a/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/section/main/presenter/tab/host/HostDeviceActionPanelPresenterWidget.java
+++ b/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/section/main/presenter/tab/host/HostDeviceActionPanelPresenterWidget.java
@@ -1,0 +1,28 @@
+package org.ovirt.engine.ui.webadmin.section.main.presenter.tab.host;
+
+import javax.inject.Inject;
+
+import org.ovirt.engine.core.common.businessentities.HostDeviceView;
+import org.ovirt.engine.core.common.businessentities.VDS;
+import org.ovirt.engine.ui.common.presenter.DetailActionPanelPresenterWidget;
+import org.ovirt.engine.ui.common.uicommon.model.SearchableDetailModelProvider;
+import org.ovirt.engine.ui.uicommonweb.models.hosts.HostListModel;
+import org.ovirt.engine.ui.uicommonweb.models.vms.hostdev.HostDeviceListModel;
+
+import com.google.web.bindery.event.shared.EventBus;
+
+public class HostDeviceActionPanelPresenterWidget extends
+    DetailActionPanelPresenterWidget<VDS, HostDeviceView, HostListModel<Void>, HostDeviceListModel> {
+
+    @Inject
+    public HostDeviceActionPanelPresenterWidget(EventBus eventBus,
+            DetailActionPanelPresenterWidget.ViewDef<VDS, HostDeviceView> view,
+            SearchableDetailModelProvider<HostDeviceView, HostListModel<Void>, HostDeviceListModel> dataProvider) {
+        super(eventBus, view, dataProvider);
+    }
+
+    @Override
+    protected void initializeButtons() {
+        // no GWT action buttons
+    }
+}

--- a/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/section/main/presenter/tab/host/SubTabHostDevicePresenter.java
+++ b/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/section/main/presenter/tab/host/SubTabHostDevicePresenter.java
@@ -38,9 +38,9 @@ public class SubTabHostDevicePresenter
     @Inject
     public SubTabHostDevicePresenter(EventBus eventBus, ViewDef view, ProxyDef proxy,
             PlaceManager placeManager, HostMainSelectedItems selectedItems,
-            SearchableDetailModelProvider<HostDeviceView, HostListModel<Void>, HostDeviceListModel> modelProvider) {
-        // No action buttons, pass null.
-        super(eventBus, view, proxy, placeManager, modelProvider, selectedItems, null,
+            SearchableDetailModelProvider<HostDeviceView, HostListModel<Void>, HostDeviceListModel> modelProvider,
+            HostDeviceActionPanelPresenterWidget actionPanel) {
+        super(eventBus, view, proxy, placeManager, modelProvider, selectedItems, actionPanel,
                 HostSubTabPanelPresenter.TYPE_SetTabContent);
     }
 

--- a/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/section/main/view/tab/host/SubTabHostDeviceView.java
+++ b/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/section/main/view/tab/host/SubTabHostDeviceView.java
@@ -3,6 +3,7 @@ package org.ovirt.engine.ui.webadmin.section.main.view.tab.host;
 import org.ovirt.engine.core.common.businessentities.HostDeviceView;
 import org.ovirt.engine.core.common.businessentities.VDS;
 import org.ovirt.engine.ui.common.idhandler.ElementIdHandler;
+import org.ovirt.engine.ui.common.presenter.AbstractSubTabPresenter;
 import org.ovirt.engine.ui.common.system.ClientStorage;
 import org.ovirt.engine.ui.common.uicommon.model.SearchableDetailModelProvider;
 import org.ovirt.engine.ui.common.view.AbstractSubTabTableWidgetView;
@@ -30,5 +31,6 @@ public class SubTabHostDeviceView
         ViewIdHandler.idHandler.generateAndSetIds(this);
         initTable();
         initWidget(getModelBoundTableWidget());
+        bindSlot(AbstractSubTabPresenter.TYPE_SetActionPanel, getModelBoundTableWidget().getActionPanelContainer());
     }
 }


### PR DESCRIPTION
In order for the ui-extensions to be able to add the action button to the host devices tab, the action panel needs to be present.

This patch creates and injects the action panel presenter to the host devices tab.