### PR TITLE
Fix branch names for ovirt-engine-4.4 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,9 @@
 name: build
 on:
   push:
-    branches: [master]
+    branches: [ovirt-engine-4.4]
   pull_request:
-    branches: [master]
+    branches: [ovirt-engine-4.4]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Signed-off-by: Martin Perina <mperina@redhat.com>
