### PR TITLE
core: dedicated cpus - parse and save cpu topology

### DIFF
--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/VDS.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/VDS.java
@@ -1890,4 +1890,20 @@ public class VDS implements Queryable, BusinessEntityWithStatus<Guid, VDSStatus>
     public void setCdChangePdiv(boolean cdChangePdiv) {
         vdsDynamic.setCdChangePdiv(cdChangePdiv);
     }
+
+    public List<VdsCpuUnit> getCpuTopology() {
+        return vdsDynamic.getCpuTopology();
+    }
+
+    public void setCpuTopology(List<VdsCpuUnit> value) {
+        vdsDynamic.setCpuTopology(value);
+    }
+
+    public String getVdsmCpusAffinity() {
+        return vdsDynamic.getVdsmCpusAffinity();
+    }
+
+    public void setVdsmCpusAffinity(String value) {
+        vdsDynamic.setVdsmCpusAffinity(value);
+    }
 }

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/VdsCpuUnit.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/VdsCpuUnit.java
@@ -1,0 +1,63 @@
+package org.ovirt.engine.core.common.businessentities;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+public class VdsCpuUnit implements Serializable {
+
+    private static final long serialVersionUID = -397254497953366129L;
+    private int core;
+    private int socket;
+    private int cpu;
+
+    public VdsCpuUnit() {
+
+    }
+
+    public VdsCpuUnit(int socket, int core, int cpu) {
+        this.socket = socket;
+        this.core = core;
+        this.cpu = cpu;
+    }
+
+    public int getSocket() {
+        return socket;
+    }
+
+    public void setSocket(int socket) {
+        this.socket = socket;
+    }
+
+    public int getCore() {
+        return core;
+    }
+
+    public void setCore(int core) {
+        this.core = core;
+    }
+
+    public int getCpu() {
+        return cpu;
+    }
+
+    public void setCpu(int cpu) {
+        this.cpu = cpu;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof VdsCpuUnit)) {
+            return false;
+        }
+        VdsCpuUnit other = (VdsCpuUnit) obj;
+        return socket == other.socket && core == other.core && cpu == other.cpu;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(socket, core, cpu);
+    }
+}

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/VdsDynamic.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/VdsDynamic.java
@@ -237,6 +237,10 @@ public class VdsDynamic implements BusinessEntityWithStatus<Guid, VDSStatus> {
 
     private boolean ovnConfigured;
 
+    private List<VdsCpuUnit> cpuTopology;
+
+    private String vdsmCpusAffinity;
+
     public VdsDynamic() {
         rpmVersion = new RpmVersion();
         libvirtVersion = new RpmVersion();
@@ -267,6 +271,7 @@ public class VdsDynamic implements BusinessEntityWithStatus<Guid, VDSStatus> {
 
         // By default we support these storage versions (for older vdsm that do not report it).
         supportedDomainVersions = StorageFormatType.getDefaultSupportedVersions();
+        cpuTopology = new ArrayList<>();
     }
 
     public Integer getCpuCores() {
@@ -1007,6 +1012,22 @@ public class VdsDynamic implements BusinessEntityWithStatus<Guid, VDSStatus> {
         this.ovnConfigured = ovnConfigured;
     }
 
+    public void setCpuTopology(List<VdsCpuUnit> value) {
+        cpuTopology = value;
+    }
+
+    public List<VdsCpuUnit> getCpuTopology() {
+        return cpuTopology;
+    }
+
+    public void setVdsmCpusAffinity(String value) {
+        vdsmCpusAffinity = value;
+    }
+
+    public String getVdsmCpusAffinity() {
+        return vdsmCpusAffinity;
+    }
+
 
     @Override
     public int hashCode() {
@@ -1090,7 +1111,9 @@ public class VdsDynamic implements BusinessEntityWithStatus<Guid, VDSStatus> {
                 fipsEnabled,
                 bootUuid,
                 cdChangePdiv,
-                ovnConfigured
+                ovnConfigured,
+                cpuTopology,
+                vdsmCpusAffinity
         );
     }
 
@@ -1184,6 +1207,8 @@ public class VdsDynamic implements BusinessEntityWithStatus<Guid, VDSStatus> {
                 && fipsEnabled == other.fipsEnabled
                 && Objects.equals(bootUuid, other.bootUuid)
                 && cdChangePdiv == other.cdChangePdiv
-                && ovnConfigured == other.ovnConfigured;
+                && ovnConfigured == other.ovnConfigured
+                && Objects.equals(cpuTopology, other.cpuTopology)
+                && Objects.equals(vdsmCpusAffinity, other.vdsmCpusAffinity);
     }
 }

--- a/backend/manager/modules/dal/src/main/java/org/ovirt/engine/core/dao/VdsDaoImpl.java
+++ b/backend/manager/modules/dal/src/main/java/org/ovirt/engine/core/dao/VdsDaoImpl.java
@@ -31,6 +31,7 @@ import org.ovirt.engine.core.compat.RpmVersion;
 import org.ovirt.engine.core.dal.dbbroker.DbFacadeUtils;
 import org.ovirt.engine.core.dao.network.DnsResolverConfigurationDao;
 import org.ovirt.engine.core.utils.JsonHelper;
+import org.ovirt.engine.core.utils.SerializationFactory;
 import org.ovirt.engine.core.utils.serialization.json.JsonObjectDeserializer;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -418,6 +419,8 @@ public class VdsDaoImpl extends BaseDao implements VdsDao {
         entity.setBootUuid(rs.getString("boot_uuid"));
         entity.setCdChangePdiv(rs.getBoolean("cd_change_pdiv"));
         entity.setOvnConfigured(rs.getBoolean("ovn_configured"));
+        entity.setCpuTopology(SerializationFactory.getDeserializer().deserialize(rs.getString("cpu_topology"), ArrayList.class));
+        entity.setVdsmCpusAffinity(rs.getString("vdsm_cpus_affinity"));
         return entity;
     };
 }

--- a/backend/manager/modules/dal/src/main/java/org/ovirt/engine/core/dao/VdsDynamicDaoImpl.java
+++ b/backend/manager/modules/dal/src/main/java/org/ovirt/engine/core/dao/VdsDynamicDaoImpl.java
@@ -1,5 +1,6 @@
 package org.ovirt.engine.core.dao;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
@@ -23,6 +24,7 @@ import org.ovirt.engine.core.compat.Guid;
 import org.ovirt.engine.core.compat.RpmVersion;
 import org.ovirt.engine.core.dao.network.DnsResolverConfigurationDao;
 import org.ovirt.engine.core.utils.JsonHelper;
+import org.ovirt.engine.core.utils.SerializationFactory;
 import org.ovirt.engine.core.utils.serialization.json.JsonObjectDeserializer;
 import org.ovirt.engine.core.utils.serialization.json.JsonObjectSerializer;
 import org.slf4j.Logger;
@@ -138,6 +140,8 @@ public class VdsDynamicDaoImpl extends MassOperationsGenericDao<VdsDynamic, Guid
         entity.setBootUuid(rs.getString("boot_uuid"));
         entity.setCdChangePdiv(rs.getBoolean("cd_change_pdiv"));
         entity.setOvnConfigured(rs.getBoolean("ovn_configured"));
+        entity.setCpuTopology(SerializationFactory.getDeserializer().deserialize(rs.getString("cpu_topology"), ArrayList.class));
+        entity.setVdsmCpusAffinity(rs.getString("vdsm_cpus_affinity"));
 
         return entity;
     };
@@ -346,7 +350,9 @@ public class VdsDynamicDaoImpl extends MassOperationsGenericDao<VdsDynamic, Guid
                 .addValue("fips_enabled", vds.isFipsEnabled())
                 .addValue("boot_uuid", vds.getBootUuid())
                 .addValue("cd_change_pdiv", vds.isCdChangePdiv())
-                .addValue("ovn_configured", vds.isOvnConfigured());
+                .addValue("ovn_configured", vds.isOvnConfigured())
+                .addValue("cpu_topology", SerializationFactory.getSerializer().serialize(vds.getCpuTopology()))
+                .addValue("vdsm_cpus_affinity", vds.getVdsmCpusAffinity());
     }
 
     @Override

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/VdsManager.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/VdsManager.java
@@ -32,6 +32,7 @@ import org.ovirt.engine.core.common.businessentities.VDSStatus;
 import org.ovirt.engine.core.common.businessentities.VDSType;
 import org.ovirt.engine.core.common.businessentities.VM;
 import org.ovirt.engine.core.common.businessentities.VMStatus;
+import org.ovirt.engine.core.common.businessentities.VdsCpuUnit;
 import org.ovirt.engine.core.common.businessentities.VdsDynamic;
 import org.ovirt.engine.core.common.businessentities.VdsNumaNode;
 import org.ovirt.engine.core.common.businessentities.VdsSpmStatus;
@@ -178,6 +179,7 @@ public class VdsManager {
     protected final int NUMBER_HOST_REFRESHES_BEFORE_SAVE;
     private HostConnectionRefresherInterface hostRefresher;
     private volatile boolean inServerRebootTimeout;
+    private List<VdsCpuUnit> cpuTopology;
 
     VdsManager(VDS vds, ResourceManager resourceManager) {
         this.resourceManager = resourceManager;
@@ -199,6 +201,7 @@ public class VdsManager {
         handlePreviousStatus();
         handleSecureSetup();
         initVdsBroker();
+        initAvailableCpus();
     }
 
     public void handleSecureSetup() {
@@ -1288,5 +1291,13 @@ public class VdsManager {
                 }
             }
         }
+    }
+
+    private void initAvailableCpus() {
+        List<VdsCpuUnit> cpuTopology = cachedVds.getCpuTopology();
+        if (cpuTopology == null) {
+            return;
+        }
+        this.cpuTopology = cpuTopology;
     }
 }

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/VdsProperties.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/VdsProperties.java
@@ -20,6 +20,11 @@ public final class VdsProperties {
     public static final String cpu_sockets = "cpuSockets";
     public static final String cpu_model = "cpuModel";
     public static final String online_cpus = "onlineCpus";
+    public static final String cpu_topology = "cpuTopology";
+    public static final String socket_id = "socket_id";
+    public static final String core_id = "core_id";
+    public static final String cpu_id = "cpu_id";
+    public static final String vdsm_cpus_affinity = "vdsmToCpusAffinity";
     public static final String cpu_speed_mh = "cpuSpeed";
     public static final String kvm_enabled = "kvmEnabled";
     public static final String physical_mem_mb = "memSize";

--- a/backend/manager/modules/vdsbroker/src/test/java/org/ovirt/engine/core/vdsbroker/vdsbroker/VdsBrokerObjectsBuilderTest.java
+++ b/backend/manager/modules/vdsbroker/src/test/java/org/ovirt/engine/core/vdsbroker/vdsbroker/VdsBrokerObjectsBuilderTest.java
@@ -1,6 +1,7 @@
 package org.ovirt.engine.core.vdsbroker.vdsbroker;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -19,6 +20,7 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.ovirt.engine.core.common.businessentities.LeaseStatus;
 import org.ovirt.engine.core.common.businessentities.VDS;
+import org.ovirt.engine.core.common.businessentities.VdsCpuUnit;
 import org.ovirt.engine.core.common.businessentities.VmStatistics;
 import org.ovirt.engine.core.common.businessentities.network.VmInterfaceType;
 import org.ovirt.engine.core.common.businessentities.network.VmNetworkInterface;
@@ -421,5 +423,38 @@ public class VdsBrokerObjectsBuilderTest {
     @Test
     public void testExtractIpv4GatewayEmptyString() {
         assertThat(vdsBrokerObjectsBuilder.extractGateway(Collections.singletonMap(VdsProperties.GLOBAL_GATEWAY, "")), nullValue());
+    }
+
+    @Test
+    public void testCpuTopology() {
+        Map<String, Object> vmStruct = createCpuTopologyStruct();
+        VDS vds = getVds();
+        vdsBrokerObjectsBuilder.updateCpuTopology(vds, vmStruct);
+        assertEquals(4, vds.getCpuTopology().size());
+        assertThat(vds.getCpuTopology(), contains(new VdsCpuUnit(0, 0, 0), new VdsCpuUnit(0, 0, 1),
+                new VdsCpuUnit(0, 1, 2), new VdsCpuUnit(1, 0, 3)));
+    }
+
+    private Map<String, Object> createCpuTopologyStruct() {
+        Map<String, Integer> cpuCapability1 = new HashMap<>();
+        cpuCapability1.put(VdsProperties.cpu_id, 0);
+        cpuCapability1.put(VdsProperties.core_id, 0);
+        cpuCapability1.put(VdsProperties.socket_id, 0);
+        Map<String, Integer> cpuCapability2 = new HashMap<>();
+        cpuCapability2.put(VdsProperties.cpu_id, 1);
+        cpuCapability2.put(VdsProperties.core_id, 0);
+        cpuCapability2.put(VdsProperties.socket_id, 0);
+        Map<String, Integer> cpuCapability3 = new HashMap<>();
+        cpuCapability3.put(VdsProperties.cpu_id, 2);
+        cpuCapability3.put(VdsProperties.core_id, 1);
+        cpuCapability3.put(VdsProperties.socket_id, 0);
+        Map<String, Integer> cpuCapability4 = new HashMap<>();
+        cpuCapability4.put(VdsProperties.cpu_id, 3);
+        cpuCapability4.put(VdsProperties.core_id, 0);
+        cpuCapability4.put(VdsProperties.socket_id, 1);
+        Map<String, Object> struct = new HashMap<>();
+        struct.put(VdsProperties.cpu_topology,
+                new Object[] { cpuCapability1, cpuCapability2, cpuCapability3, cpuCapability4 });
+        return struct;
     }
 }

--- a/frontend/webadmin/modules/gwt-common/src/main/resources/org/ovirt/engine/core/Common.gwt.xml
+++ b/frontend/webadmin/modules/gwt-common/src/main/resources/org/ovirt/engine/core/Common.gwt.xml
@@ -539,6 +539,9 @@
         <include name="common/migration/NoMigrationPolicy.java"/>
         <include name="common/migration/ParallelMigrationsType.java"/>
 
+        <!-- Cpu topology -->
+        <include name="common/businessentities/VdsCpuUnit.java"/>
+
     </source>
 
     <super-source path="ui/uioverrides" />

--- a/packaging/dbscripts/create_views.sql
+++ b/packaging/dbscripts/create_views.sql
@@ -1912,7 +1912,9 @@ SELECT cluster.cluster_id AS cluster_id,
     vds_dynamic.boot_uuid AS boot_uuid,
     vds_dynamic.cd_change_pdiv AS cd_change_pdiv,
     vds_dynamic.ovn_configured AS ovn_configured,
-    vds_static.ssh_public_key AS ssh_public_key
+    vds_static.ssh_public_key AS ssh_public_key,
+    vds_dynamic.cpu_topology AS cpu_topology,
+    vds_dynamic.vdsm_cpus_affinity AS vdsm_cpus_affinity
 FROM cluster
 INNER JOIN vds_static
     ON cluster.cluster_id = vds_static.cluster_id
@@ -2086,7 +2088,9 @@ SELECT cluster.cluster_id,
     vds_dynamic.boot_uuid AS boot_uuid,
     vds_dynamic.cd_change_pdiv AS cd_change_pdiv,
     vds_dynamic.ovn_configured AS ovn_configured,
-    vds_static.ssh_public_key AS ssh_public_key
+    vds_static.ssh_public_key AS ssh_public_key,
+    vds_dynamic.cpu_topology AS cpu_topology,
+    vds_dynamic.vdsm_cpus_affinity AS vdsm_cpus_affinity
 FROM cluster
 INNER JOIN vds_static
     ON cluster.cluster_id = vds_static.cluster_id

--- a/packaging/dbscripts/upgrade/04_05_0160_add_cpu_topology_to_vds_dynamic.sql
+++ b/packaging/dbscripts/upgrade/04_05_0160_add_cpu_topology_to_vds_dynamic.sql
@@ -1,0 +1,2 @@
+select fn_db_add_column('vds_dynamic', 'cpu_topology', 'JSONB NULL');
+select fn_db_add_column('vds_dynamic', 'vdsm_cpus_affinity', 'varchar(256)');

--- a/packaging/dbscripts/vds_sp.sql
+++ b/packaging/dbscripts/vds_sp.sql
@@ -275,7 +275,9 @@ CREATE OR REPLACE FUNCTION InsertVdsDynamic (
     v_fips_enabled BOOLEAN,
     v_boot_uuid VARCHAR(64),
     v_cd_change_pdiv BOOLEAN,
-    v_ovn_configured BOOLEAN
+    v_ovn_configured BOOLEAN,
+    v_cpu_topology JSONB,
+    v_vdsm_cpus_affinity VARCHAR(256)
     )
 RETURNS VOID AS $PROCEDURE$
 BEGIN
@@ -356,7 +358,9 @@ BEGIN
             fips_enabled,
             boot_uuid,
             cd_change_pdiv,
-            ovn_configured
+            ovn_configured,
+            cpu_topology,
+            vdsm_cpus_affinity
             )
         VALUES (
             v_cpu_cores,
@@ -434,7 +438,9 @@ BEGIN
             v_fips_enabled,
             v_boot_uuid,
             v_cd_change_pdiv,
-            v_ovn_configured
+            v_ovn_configured,
+            v_cpu_topology,
+            v_vdsm_cpus_affinity
             );
     END;
 
@@ -537,7 +543,9 @@ CREATE OR REPLACE FUNCTION UpdateVdsDynamic (
     v_fips_enabled BOOLEAN,
     v_boot_uuid VARCHAR(64),
     v_cd_change_pdiv BOOLEAN,
-    v_ovn_configured BOOLEAN
+    v_ovn_configured BOOLEAN,
+    v_cpu_topology JSONB,
+    v_vdsm_cpus_affinity VARCHAR(256)
     )
 RETURNS VOID
     --The [vds_dynamic] table doesn't have a timestamp column. Optimistic concurrency logic cannot be generated
@@ -623,7 +631,9 @@ BEGIN
             fips_enabled = v_fips_enabled,
             boot_uuid = v_boot_uuid,
             cd_change_pdiv = v_cd_change_pdiv,
-            ovn_configured = v_ovn_configured
+            ovn_configured = v_ovn_configured,
+            cpu_topology = v_cpu_topology,
+            vdsm_cpus_affinity = v_vdsm_cpus_affinity
         WHERE vds_id = v_vds_id;
     END;
 


### PR DESCRIPTION
Parse cpu topology received from VDSM
and save it into vds_dynamic

This patch also retrieve the new vdsmToCpusAffinity, which let us know
on which pCPUs the VDSM is running on.

feature page: https://github.com/oVirt/ovirt-site/pull/2669

Change-Id: Ib77d4961eaf4e48e063d3448306d8570abb56972
Bug-Url: https://bugzilla.redhat.com/1782077
Signed-off-by: Liran Rotenberg <lrotenbe@redhat.com>
Signed-off-by: Saif Abu Saleh <sabusale@redhat.com>