### PR TITLE
ovirt-host-setup-vnc-sasl: Update to scram-sha-256

### DIFF
--- a/packaging/ansible-runner-service-project/project/roles/ovirt-host-setup-vnc-sasl/README.md
+++ b/packaging/ansible-runner-service-project/project/roles/ovirt-host-setup-vnc-sasl/README.md
@@ -2,7 +2,7 @@ oVirt host setup - VNC SASL authentication
 =============================
 
 This role is used for configuration of SASL authentication for VNC on oVirt
-hosts (with scram-sha-1 mechanism).
+hosts (with scram-sha-256 mechanism).
 
 IMPORTANT: This role restarts libvirtd, and that's safe to perform only on
 hosts which are in maintenance mode and not running any VMs.

--- a/packaging/ansible-runner-service-project/project/roles/ovirt-host-setup-vnc-sasl/tasks/main.yml
+++ b/packaging/ansible-runner-service-project/project/roles/ovirt-host-setup-vnc-sasl/tasks/main.yml
@@ -5,7 +5,7 @@
     state: present
     create: yes
     block: |
-      mech_list: scram-sha-1
+      mech_list: scram-sha-256
       sasldb_path: /etc/sasl2/vnc_passwd.db
 
 - name: Use saslpasswd2 to create file with dummy user


### PR DESCRIPTION
currently Passwd use sha-1 which is deprecated, we should move to
sha-256.