### PR TITLE
core: no gateway 0.0.0.0 should be in sync

### DIFF
--- a/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/NetworkInSyncWithVdsNetworkInterface.java
+++ b/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/NetworkInSyncWithVdsNetworkInterface.java
@@ -108,7 +108,8 @@ public class NetworkInSyncWithVdsNetworkInterface {
     private boolean isIpv4GatewayInSync() {
         String gatewayDesiredValue = getIpv4PrimaryAddress().getGateway();
         String gatewayActualValue = iface.getIpv4Gateway();
-        return Objects.equals(gatewayDesiredValue, gatewayActualValue);
+        boolean isNoGateway = "0.0.0.0".equals(gatewayDesiredValue) && gatewayActualValue == null;
+        return isNoGateway || Objects.equals(gatewayDesiredValue, gatewayActualValue);
     }
 
     private boolean isIpv6PrefixInSync() {

--- a/backend/manager/modules/utils/src/test/java/org/ovirt/engine/core/utils/NetworkInSyncWithVdsNetworkInterfaceTest.java
+++ b/backend/manager/modules/utils/src/test/java/org/ovirt/engine/core/utils/NetworkInSyncWithVdsNetworkInterfaceTest.java
@@ -636,6 +636,25 @@ public class NetworkInSyncWithVdsNetworkInterfaceTest {
     }
 
     /**
+     * vdsm reports a 0.0.0.0 gateway as an empty string which is converted in engine into null.
+     * User configuration of a 0.0.0.0 gateway is saved on the attachment as is.
+     */
+    @Test
+    public void testIsNetworkInSyncWhenIpv4GatewayNone(){
+        List<Object[]> tests = Arrays.asList(
+                // array of [network attachment address, interface address, expected sync]
+                new Object[] { null, "0.0.0.0" , Boolean.FALSE},
+                new Object[] { "0.0.0.0", null , Boolean.TRUE }
+        );
+        for (Object[] test : tests) {
+            initIpv4ConfigurationStaticBootProtocol(Ipv4BootProtocol.STATIC_IP);
+            ipv4Address.setGateway((String) test[0]);
+            iface.setIpv4Gateway((String) test[1]);
+            assertThat(createTestedInstance().isNetworkInSync(), is((Boolean) test[2]));
+        }
+    }
+
+    /**
      * @return method source for test with same name
      */
     static Stream<String[]> testIsNetworkInSyncForIpv6Synonyms() {


### PR DESCRIPTION
When a user configures a 0.0.0.0 gateway, vdsm reports it back as an
empty string which engine then converts into null. Comparing null to the
configured 0.0.0.0 results in reporting the attachment as out of sync
when actually null signifies 'no gateway' as is signified by 0.0.0.0
Therefore, align the comparison predicate with this corner case.

Change-Id: I48d6039dd1044ce5997f8bb152785ab0d78b4e54
Bug-Url: https://bugzilla.redhat.com/1993016
Signed-off-by: Eitan Raviv <eraviv@redhat.com>