### PR TITLE
i18n: bump zanata project version to ovirt-4.5

### DIFF
--- a/i18n/zanata.xml
+++ b/i18n/zanata.xml
@@ -2,7 +2,7 @@
 <config xmlns="http://zanata.org/namespace/config/">
     <url>https://zanata.ovirt.org/</url>
     <project>ovirt-engine</project>
-    <project-version>ovirt-4.4</project-version>
+    <project-version>ovirt-4.5</project-version>
     <project-type>properties</project-type>
 
     <src-dir>target/zanata</src-dir>


### PR DESCRIPTION
To support distinct translations between ovirt 4.4 and ovirt 4.5,
point zanata to the `ovirt-4.5` version [1] of the ovirt-engine
project in zanata.

[1] - https://zanata.ovirt.org/iteration/view/ovirt-engine/ovirt-4.5