### PR TITLE
Block creation of a template from a snapshot with MBS disk(s)

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/AddVmTemplateFromSnapshotCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/AddVmTemplateFromSnapshotCommand.java
@@ -117,6 +117,7 @@ public class AddVmTemplateFromSnapshotCommand<T extends AddVmTemplateFromSnapsho
         List<DiskImage> disksFromDb =
                 DisksFilter.filterImageDisks(getVm().getDiskMap().values(), ONLY_SNAPABLE, ONLY_ACTIVE);
         disksFromDb.addAll(DisksFilter.filterCinderDisks(getVm().getDiskMap().values(), ONLY_PLUGGED));
+        disksFromDb.addAll(DisksFilter.filterManagedBlockStorageDisks(getVm().getDiskMap().values(), ONLY_PLUGGED));
         return disksFromDb;
     }
 

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/CreateAllTemplateDisksFromSnapshotCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/CreateAllTemplateDisksFromSnapshotCommand.java
@@ -43,6 +43,7 @@ public class CreateAllTemplateDisksFromSnapshotCommand<T extends CreateAllTempla
         List<DiskImage> disksFromDb =
                 DisksFilter.filterImageDisks(vmFromConfiguration.getDiskMap().values(), ONLY_SNAPABLE, ONLY_ACTIVE);
         disksFromDb.addAll(DisksFilter.filterCinderDisks(getVm().getDiskMap().values(), ONLY_PLUGGED));
+        disksFromDb.addAll(DisksFilter.filterManagedBlockStorageDisks(getVm().getDiskMap().values(), ONLY_PLUGGED));
         return disksFromDb;
     }
 


### PR DESCRIPTION
Currently, when creating a template from a snapshot which has MBS disks,
the operation is being completed successfully since the MBS disks are
being omitted from the resulted template.
As that operation isn't being currently supported for MBS disks, it should be blocked.
This patch avoids filtering out the MBS disks and leads to the deserved
outcome of blocking the operation.

Bug-Url: https://bugzilla.redhat.com/2004350
Signed-off-by: Shani Leviim <sleviim@redhat.com>