### PR TITLE
Fix refreshing of mdev devices when VMs with run-once configuration stop

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/VdsEventListener.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/VdsEventListener.java
@@ -258,17 +258,13 @@ public class VdsEventListener implements IVdsEventListener {
         }
 
         vmJobsMonitoring.removeJobsByVmIds(vmIds);
-        ThreadPoolUtil.execute(() -> processOnVmStopInternal(vmIds, hostId));
-    }
-
-    private void processOnVmStopInternal(final Collection<Guid> vmIds, final Guid hostId) {
-        for (Guid vmId : vmIds) {
-            backend.runInternalAction(ActionType.ProcessDownVm,
-                    new ProcessDownVmParameters(vmId, true, hostId));
-        }
-
-        HostDeviceManager hostDeviceManager = Injector.get(HostDeviceManager.class);
-        hostDeviceManager.refreshHostIfAnyVmHasHostDevices(vmIds, hostId);
+        ThreadPoolUtil.execute(() -> {
+            vmIds.forEach(vmId -> backend.runInternalAction(
+                    ActionType.ProcessDownVm,
+                    new ProcessDownVmParameters(vmId, true, hostId)));
+            HostDeviceManager hostDeviceManager = Injector.get(HostDeviceManager.class);
+            hostDeviceManager.refreshHostIfAnyVmHasHostDevices(vmIds, hostId);
+        });
     }
 
     /**

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/VdsEventListener.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/VdsEventListener.java
@@ -266,10 +266,9 @@ public class VdsEventListener implements IVdsEventListener {
      */
     @Override
     public void syncStorageDomainsLuns(Guid vdsId, Collection<Guid> storageDomainsToSync) {
-        ThreadPoolUtil.execute(() -> {
-            backend.runInternalAction(ActionType.SyncStorageDomainsLuns, new SyncStorageDomainsLunsParameters(
-                    vdsId, storageDomainsToSync));
-        });
+        ThreadPoolUtil.execute(() -> backend.runInternalAction(
+                ActionType.SyncStorageDomainsLuns,
+                new SyncStorageDomainsLunsParameters(vdsId, storageDomainsToSync)));
     }
 
     @Override
@@ -447,7 +446,7 @@ public class VdsEventListener implements IVdsEventListener {
         if (command != null) {
             // The command will be invoked in a different VDS in its rerun method, so we're calling
             // its rerun method from a new thread so that it won't be executed within our current VDSM lock
-            ThreadPoolUtil.execute(() -> command.rerun());
+            ThreadPoolUtil.execute(command::rerun);
         }
     }
 

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/hostdev/HostDeviceManager.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/hostdev/HostDeviceManager.java
@@ -1,6 +1,5 @@
 package org.ovirt.engine.core.bll.hostdev;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -108,7 +107,10 @@ public class HostDeviceManager implements BackendService {
         return vmDeviceDao.existsVmDeviceByVmIdAndType(vmId, VmDeviceGeneralType.HOSTDEV);
     }
 
-    private boolean checkVmNeedsHostDevices(Guid vmId) {
+    /**
+     * Checks whether the VM uses host devices (that were attached directly or via the SRIOV scheduling)
+     */
+    public boolean checkVmNeedsHostDevices(Guid vmId) {
         List<VmDevice> vfs = vmDeviceDao.getVmDeviceByVmIdTypeAndDevice(vmId,
                 VmDeviceGeneralType.INTERFACE,
                 VmDeviceType.HOST_DEVICE);
@@ -139,18 +141,5 @@ public class HostDeviceManager implements BackendService {
 
     public void freeVmHostDevices(Guid vmId) {
         hostDeviceDao.freeHostDevicesUsedByVmId(vmId);
-    }
-
-    /**
-     * Calls <code>ActionType.RefreshHost</code> on the specified host, in case any of the specified vms contain
-     * host devices (that were attached directly or via the SRIOV scheduling)
-     */
-    public void refreshHostIfAnyVmHasHostDevices(Collection<Guid> vmIds, Guid hostId) {
-        for (Guid vmId : vmIds) {
-            if (checkVmNeedsHostDevices(vmId)) {
-                backend.runInternalAction(ActionType.RefreshHost, new VdsActionParameters(hostId));
-                return;
-            }
-        }
     }
 }

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/IVdsEventListener.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/IVdsEventListener.java
@@ -82,7 +82,7 @@ public interface IVdsEventListener {
      */
     void updateSlaPolicies(List<Guid> vmIds, Guid vdsId);
 
-    void refreshHostIfAnyVmHasHostDevices(List<Guid> vmIds, Guid hostId);
+    void refreshHostIfAnyVmHasHostDevices(List<Guid> succeededToRunVms, List<Guid> movedToDownVms, Guid hostId);
 
     void refreshHostCapabilities(Guid hostId);
 

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/monitoring/VmsMonitoring.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/monitoring/VmsMonitoring.java
@@ -190,7 +190,7 @@ public class VmsMonitoring {
     }
 
     private void postFlush(List<VmAnalyzer> vmAnalyzers, VdsManager vdsManager, long fetchTime) {
-        Collection<Guid> movedToDownVms = new ArrayList<>();
+        List<Guid> movedToDownVms = new ArrayList<>();
         List<Guid> succeededToRunVms = new ArrayList<>();
         List<Guid> autoVmsToRun = new ArrayList<>();
         List<Guid> coldRebootVmsToRun = new ArrayList<>();

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/monitoring/VmsMonitoring.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/monitoring/VmsMonitoring.java
@@ -254,6 +254,9 @@ public class VmsMonitoring {
 
         getVdsEventListener().updateSlaPolicies(succeededToRunVms, vdsManager.getVdsId());
 
+        // need to execute this before processOnVmStop that might remove unmanaged devices
+        getVdsEventListener().refreshHostIfAnyVmHasHostDevices(succeededToRunVms, movedToDownVms, vdsManager.getVdsId());
+
         // process all vms that went down
         getVdsEventListener().processOnVmStop(movedToDownVms, vdsManager.getVdsId());
 
@@ -262,8 +265,6 @@ public class VmsMonitoring {
 
         // run all vms that went down as a part of cold reboot process
         getVdsEventListener().runColdRebootVms(coldRebootVmsToRun);
-
-        getVdsEventListener().refreshHostIfAnyVmHasHostDevices(succeededToRunVms, vdsManager.getVdsId());
 
         // Looping only over powering up VMs as LUN device size
         // is updated by VDSM only once when running a VM.


### PR DESCRIPTION
ProcessDownVm removes unmanaged devices of stateless VMs and VMs that were started in run-once mode. Therefore, we now check whether VMs are set with host devices, in order to determine whether the host should be refreshed, before calling ProcessDownVm. 