### PR TITLE
automation: enable ost trigger

### DIFF
--- a/.github/workflows/ost.yaml
+++ b/.github/workflows/ost.yaml
@@ -1,0 +1,19 @@
+name: OST trigger
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  trigger-ost:
+    if: |
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/ost') &&
+      (
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'
+      )
+    uses: oVirt/ovirt-system-tests/.github/workflows/ost.yaml@master
+    with:
+      pr_url: ${{ github.event.issue.pull_request.url }}
+


### PR DESCRIPTION
Enabling /ost trigger to run system tests

Signed-off-by: Artur Socha <asocha@redhat.com>
