### PR TITLE
fix manage events form email display

### DIFF
--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/users/UserEventNotifierListModel.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/users/UserEventNotifierListModel.java
@@ -132,10 +132,10 @@ public class UserEventNotifierListModel extends SearchableListModel<DbUser, Even
         }
 
         model.setEventGroupModels(list);
-        if (!StringHelper.isNullOrEmpty(getEntity().getEmail())) {
-            model.getEmail().setEntity(getEntity().getEmail());
-        } else if (items.size() > 0) {
+        if (items.size() > 0) {
             model.getEmail().setEntity(items.iterator().next().getMethodAddress());
+        } else if (!StringHelper.isNullOrEmpty(getEntity().getEmail())) {
+            model.getEmail().setEntity(getEntity().getEmail());
         }
 
         model.setOldEmail(model.getEmail().getEntity());


### PR DESCRIPTION
This patch fixes the displayed email for event notification when
selecting a user details in Administration->Users and on the "Event
Notifier" tab clicking on the "Manage Events" button.
In the opened popup form the field "Mail Recipient" should contain the
mail for notification sending, by default this is the mail that the user
has in the database "users" table but can be set to any other email
address.
The "Mail Recipient" field should display any other mail set for
subscription and only if it is not set then the value from the "users"
table should be used.
The bug was that the code used the email from the "users" table without
checking if it was overridden for event notifications.

Signed-off-by: Eli Mesika <emasika@redhat.com>
Bug-Url: https://bugzilla.redhat.com/1994144