### PR TITLE
CODEOWNERS: Remove almusil from default

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Default to all maintainers if nothing more specific matches
-*    @almusil @ahadas @bennyz @emesika @mwperina @michalskrivanek @oliel @sgratch @smelamud @didib
+*    @ahadas @bennyz @emesika @mwperina @michalskrivanek @oliel @sgratch @smelamud @didib
 
 packaging/dbscripts/    @emesika @mwperina
 *Dao*.java              @emesika @mwperina


### PR DESCRIPTION
Remove myself (almusil) from the default maintainers,
while still being mentioned on network related code.

Signed-off-by: Ales Musil <amusil@redhat.com>