### PR TITLE
packaging: setup: httpd/ssl: Clear SSLProtocol

### DIFF
--- a/packaging/setup/ovirt_engine_setup/engine_common/constants.py
+++ b/packaging/setup/ovirt_engine_setup/engine_common/constants.py
@@ -203,14 +203,6 @@ class Stages(object):
 
 @util.export
 @util.codegen
-class Const(object):
-    # Enable only TLSv1.2 protocol. More information at
-    # https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslprotocol
-    HTTPD_SSL_PROTOCOLS = '-all +TLSv1.2'
-
-
-@util.export
-@util.codegen
 @osetupattrsclass
 class DBEnvKeysConst(object):
     HOST = 'host'

--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine-common/apache/ssl.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine-common/apache/ssl.py
@@ -67,7 +67,7 @@ _HTTPD_CONF_PARAMS_DB = (
     },
     {
         'name': 'SSLProtocol',
-        'value': oengcommcons.Const.HTTPD_SSL_PROTOCOLS,
+        'value': None,
         'only_if_unconfigured': False,
     },
 )


### PR DESCRIPTION
In EL8, SSLProtocol is best handled by crypto-policies - no need to
hard-code any specific values in our own code.

In new setups - where SSLProtocol is already not set by default in
ssl.conf, relying on crypto-policies - just do nothing.

In upgrades from previous setups, where we did set SSLProtocol, comment
out the SSLProtocol line.

I wanted to keep using editConfigContent for this, relying on its
docstring saying that params set to (python) None are removed. But this
does not work - was never used, so not noticed so far.

Trying to fix this using the existing code was hard, and the code was
too complex and hard to understand in my opinion, so I mostly rewrote
it. I hope the new code is easier to understand and maintain.

Bug-Url: https://bugzilla.redhat.com/1999698
Change-Id: I01fc6e8f1e775ee69ee09bcbcc1169a54d704af6
Signed-off-by: Yedidyah Bar David <didi@redhat.com>