### PR TITLE
automation: Run validations

### DIFF
--- a/.automation/build-srpm.sh
+++ b/.automation/build-srpm.sh
@@ -32,7 +32,7 @@ export JAVA_HOME="${JAVA_HOME:=/usr/lib/jvm/java-11}"
 [ -d ${ARTIFACTS_DIR} ] || mkdir -p ${ARTIFACTS_DIR}
 [ -d rpmbuild/SOURCES ] || mkdir -p rpmbuild/SOURCES
 
-make generated-files
+make validations
 
 # Get the tarball
 make dist

--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/config/jboss_fapolicyd.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/config/jboss_fapolicyd.py
@@ -50,9 +50,12 @@ class Plugin(plugin.PluginBase):
         stage=plugin.Stages.STAGE_MISC,
         condition=lambda self: (
                 self.environment[oenginecons.CoreEnv.ENABLE] and
-                not os.path.exists(oengcommcons.FileLocations.FAPOLICYD_ALLOW_OVIRT_JBOSS_RULE) and
-                not self.environment[osetupcons.CoreEnv.DEVELOPER_MODE]
-        )
+                not os.path.exists(
+                    oengcommcons.FileLocations.FAPOLICYD_ALLOW_OVIRT_JBOSS_RULE
+                ) and not self.environment[
+                    osetupcons.CoreEnv.DEVELOPER_MODE
+                ]
+        ),
     )
     def _misc(self):
         config = configfile.ConfigFile([
@@ -72,7 +75,8 @@ class Plugin(plugin.PluginBase):
                 ],
                 content=outil.processTemplate(
                     template=(
-                        oengcommcons.FileLocations.FAPOLICYD_ALLOW_OVIRT_JBOSS_RULE_TEMPLATE
+                        oengcommcons.FileLocations.
+                        FAPOLICYD_ALLOW_OVIRT_JBOSS_RULE_TEMPLATE
                     ),
                     subst={
                         '@JBOSS_RUNTIME_TMP_DIR@': engine_tmp_dir,


### PR DESCRIPTION
Replace 'make generated-files' with 'make validations', so that we run
code validations per build.

'validations' already depends on 'generated-files' so we do not need
both.

Change-Id: I227bdd71af7dcf9a692c025c77525cb57aec2e0d
Signed-off-by: Yedidyah Bar David <didi@redhat.com>