### PR TITLE
core: remove references to deleted dns configuration

### DIFF
--- a/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/RemoveVdsCommandTest.java
+++ b/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/RemoveVdsCommandTest.java
@@ -64,6 +64,8 @@ import org.ovirt.engine.core.dao.VmStaticDao;
 import org.ovirt.engine.core.dao.gluster.GlusterBrickDao;
 import org.ovirt.engine.core.dao.gluster.GlusterHooksDao;
 import org.ovirt.engine.core.dao.gluster.GlusterVolumeDao;
+import org.ovirt.engine.core.dao.network.DnsResolverConfigurationDao;
+import org.ovirt.engine.core.dao.network.NetworkAttachmentDao;
 
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class RemoveVdsCommandTest extends BaseCommandTest {
@@ -126,6 +128,12 @@ public class RemoveVdsCommandTest extends BaseCommandTest {
 
     @Mock
     private TagDao tagDao;
+
+    @Mock
+    private NetworkAttachmentDao networkAttachmentDao;
+
+    @Mock
+    private DnsResolverConfigurationDao dnsResolverConfigurationDao;
 
     /**
      * The command under test.
@@ -387,6 +395,7 @@ public class RemoveVdsCommandTest extends BaseCommandTest {
         VerificationMode multipleHostsRemovedVerificationMode = multipleHosts ? never() : times(1);
         verify(volumeDao, multipleHostsRemovedVerificationMode).removeByClusterId(any());
         verify(hooksDao, multipleHostsRemovedVerificationMode).removeAllInCluster(any());
+        verify(dnsResolverConfigurationDao, times(1)).removeAll(any());
     }
 
     private void mockVmsAssignedWithHostDevice(Guid vmId, List<VmDevice> devices) {

--- a/backend/manager/modules/dal/src/main/java/org/ovirt/engine/core/dao/network/DnsResolverConfigurationDao.java
+++ b/backend/manager/modules/dal/src/main/java/org/ovirt/engine/core/dao/network/DnsResolverConfigurationDao.java
@@ -3,8 +3,10 @@ package org.ovirt.engine.core.dao.network;
 import org.ovirt.engine.core.common.businessentities.network.DnsResolverConfiguration;
 import org.ovirt.engine.core.compat.Guid;
 import org.ovirt.engine.core.dao.GenericDao;
+import org.ovirt.engine.core.dao.MassOperationsDao;
 
-public interface DnsResolverConfigurationDao extends GenericDao<DnsResolverConfiguration, Guid> {
+public interface DnsResolverConfigurationDao
+        extends GenericDao<DnsResolverConfiguration, Guid>, MassOperationsDao<DnsResolverConfiguration, Guid> {
     void removeByNetworkAttachmentId(Guid id);
 
     void removeByNetworkId(Guid id);

--- a/backend/manager/modules/dal/src/main/java/org/ovirt/engine/core/dao/network/DnsResolverConfigurationDaoImpl.java
+++ b/backend/manager/modules/dal/src/main/java/org/ovirt/engine/core/dao/network/DnsResolverConfigurationDaoImpl.java
@@ -8,13 +8,14 @@ import javax.inject.Singleton;
 import org.ovirt.engine.core.common.businessentities.network.DnsResolverConfiguration;
 import org.ovirt.engine.core.common.businessentities.network.NameServer;
 import org.ovirt.engine.core.compat.Guid;
-import org.ovirt.engine.core.dao.DefaultGenericDao;
+import org.ovirt.engine.core.dao.MassOperationsGenericDao;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 
 @Named
 @Singleton
-public class DnsResolverConfigurationDaoImpl extends DefaultGenericDao<DnsResolverConfiguration, Guid> implements DnsResolverConfigurationDao {
+public class DnsResolverConfigurationDaoImpl
+        extends MassOperationsGenericDao<DnsResolverConfiguration, Guid> implements DnsResolverConfigurationDao {
 
     public DnsResolverConfigurationDaoImpl() {
         super("DnsResolverConfiguration");


### PR DESCRIPTION
When a host is removed from engine the DNS configurations of its network
attachments should be removed from the DB.

Change-Id: I7c66ac7ea8fca9c777ed9ab2c3d2dfc5546e0a4c
Bug-Url: https://bugzilla.redhat.com/1547040
Signed-off-by: Eitan Raviv <eraviv@redhat.com>