### PR TITLE
webadmin: add home page to Account Settings

### DIFF
--- a/frontend/webadmin/modules/frontend/src/main/java/org/ovirt/engine/ui/frontend/server/gwt/GwtDynamicHostPageServlet.java
+++ b/frontend/webadmin/modules/frontend/src/main/java/org/ovirt/engine/ui/frontend/server/gwt/GwtDynamicHostPageServlet.java
@@ -6,6 +6,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Locale;
+import java.util.Optional;
 
 import javax.ejb.EJB;
 import javax.servlet.RequestDispatcher;
@@ -60,7 +61,8 @@ public abstract class GwtDynamicHostPageServlet extends HttpServlet {
         ATTR_LOCALE(LocaleFilter.LOCALE),
         ATTR_APPLICATION_TYPE(BrandingFilter.APPLICATION_NAME),
         ATTR_ENGINE_RPM_VERSION("engineRpmVersion"), //$NON-NLS-1$
-        ATTR_DISPLAY_UNCAUGHT_UI_EXCEPTIONS("DISPLAY_UNCAUGHT_UI_EXCEPTIONS"); //$NON-NLS-1$
+        ATTR_DISPLAY_UNCAUGHT_UI_EXCEPTIONS("DISPLAY_UNCAUGHT_UI_EXCEPTIONS"), //$NON-NLS-1$
+        ATTR_CUSTOM_HOME_PAGE("customHomePage"); //$NON-NLS-1$
 
         private final String attributeKey;
 
@@ -84,6 +86,9 @@ public abstract class GwtDynamicHostPageServlet extends HttpServlet {
 
     private static final String HOST_JSP = "/GwtHostPage.jsp"; //$NON-NLS-1$
     private static final String UTF_CONTENT_TYPE = "text/html; charset=UTF-8"; //$NON-NLS-1$
+    private  static  final String USER_OPTION_WEBADMIN = "webAdmin"; //$NON-NLS-1$
+    private  static  final String USER_OPTION_USE_CUSTOM_HOME_PAGE = "webAdmin.useCustomHomePage"; //$NON-NLS-1$
+    private  static  final String USER_OPTION_CUSTOM_HOME_PAGE = "webAdmin.customHomePage"; //$NON-NLS-1$
 
     private BackendLocal backend;
     private ObjectMapper mapper;
@@ -125,9 +130,32 @@ public abstract class GwtDynamicHostPageServlet extends HttpServlet {
         DbUser loggedInUser = getLoggedInUser(engineSessionId);
         if (loggedInUser != null) {
             String ssoToken = getSsoToken(engineSessionId);
-            UserProfileProperty webAdminUserOptions = getWebAdminUserOptions(loggedInUser.getId(), engineSessionId);
+            UserProfileProperty webAdminUserOptions = getUserOption(
+                    loggedInUser.getId(),
+                    engineSessionId,
+                    USER_OPTION_WEBADMIN);
             request.setAttribute(MD5Attributes.ATTR_USER_INFO.getKey(),
                     getUserInfoObject(loggedInUser, ssoToken, webAdminUserOptions));
+
+            boolean useCustomHomePage = Boolean.parseBoolean(
+                    Optional.ofNullable(
+                            getUserOption(
+                                    loggedInUser.getId(),
+                                    engineSessionId,
+                                    USER_OPTION_USE_CUSTOM_HOME_PAGE))
+                            .map(UserProfileProperty::getContent)
+                            .orElse(null));
+            if (useCustomHomePage) {
+                request.setAttribute(
+                        MD5Attributes.ATTR_CUSTOM_HOME_PAGE.getKey(),
+                        Optional.ofNullable(
+                                getUserOption(
+                                        loggedInUser.getId(),
+                                        engineSessionId,
+                                        USER_OPTION_CUSTOM_HOME_PAGE))
+                                .map(UserProfileProperty::getContent)
+                                .orElse(null));
+            }
         }
 
         // Set attribute for engineRpmVersion object
@@ -163,10 +191,10 @@ public abstract class GwtDynamicHostPageServlet extends HttpServlet {
         return (String) runQuery(QueryType.GetEngineSessionIdToken, new QueryParametersBase(), engineSessionId);
     }
 
-    private UserProfileProperty getWebAdminUserOptions(final Guid userId, final String engineSessionId) {
+    private UserProfileProperty getUserOption(final Guid userId, final String engineSessionId, String name) {
         return (UserProfileProperty)runQuery(
                 QueryType.GetUserProfilePropertyByNameAndUserId,
-                new IdAndNameQueryParameters(userId, "webAdmin"), //$NON-NLS-1$
+                new IdAndNameQueryParameters(userId, name),
                 engineSessionId);
     }
 

--- a/frontend/webadmin/modules/frontend/src/main/resources/META-INF/resources/GwtHostPage.jsp
+++ b/frontend/webadmin/modules/frontend/src/main/resources/META-INF/resources/GwtHostPage.jsp
@@ -12,6 +12,13 @@
     <obrand:stylesheets />
     <obrand:javascripts />
     <script type="text/javascript">
+        <c:if test="${requestScope['customHomePage'] != null}">
+        (function() {
+          if (!window.location.hash) {
+            window.location.hash = <c:out value="${requestScope['customHomePage']}" escapeXml="false"/>;
+          }
+        })();
+        </c:if>
         <c:if test="${requestScope['userInfo'] != null}">
             var userInfo = <c:out value="${requestScope['userInfo']}" escapeXml="false"/>;
         </c:if>

--- a/frontend/webadmin/modules/gwt-common/src/main/java/org/ovirt/engine/ui/common/CommonApplicationConstants.java
+++ b/frontend/webadmin/modules/gwt-common/src/main/java/org/ovirt/engine/ui/common/CommonApplicationConstants.java
@@ -4,6 +4,12 @@ import com.google.gwt.i18n.client.Constants;
 
 public interface CommonApplicationConstants extends Constants {
 
+    String homePage();
+
+    String homePageFormat();
+
+    String homePageIgnoreInvalid();
+
     String resetGridSettings();
 
     String changeColumnsVisibilityOrder();

--- a/frontend/webadmin/modules/gwt-common/src/main/java/org/ovirt/engine/ui/common/CommonApplicationMessages.java
+++ b/frontend/webadmin/modules/gwt-common/src/main/java/org/ovirt/engine/ui/common/CommonApplicationMessages.java
@@ -203,5 +203,7 @@ public interface CommonApplicationMessages extends Messages {
     String vmGuestCpuTypeWarning(String cpuType);
 
     String biosTypeWarning(String bioType);
+
+    String homePageDefault(String currentDefault);
 }
 

--- a/frontend/webadmin/modules/gwt-common/src/main/java/org/ovirt/engine/ui/common/place/ApplicationPlaceManager.java
+++ b/frontend/webadmin/modules/gwt-common/src/main/java/org/ovirt/engine/ui/common/place/ApplicationPlaceManager.java
@@ -64,7 +64,7 @@ public abstract class ApplicationPlaceManager extends PlaceManagerImpl implement
         revealPlace(getDefaultPlace());
     }
 
-    protected PlaceRequest getDefaultPlace() {
+    public PlaceRequest getDefaultPlace() {
         return getDefaultMainSectionPlace();
     }
 

--- a/frontend/webadmin/modules/gwt-common/src/main/java/org/ovirt/engine/ui/common/section/main/presenter/OptionsPopupPresenterWidget.java
+++ b/frontend/webadmin/modules/gwt-common/src/main/java/org/ovirt/engine/ui/common/section/main/presenter/OptionsPopupPresenterWidget.java
@@ -2,20 +2,31 @@ package org.ovirt.engine.ui.common.section.main.presenter;
 
 import org.ovirt.engine.ui.common.presenter.AbstractModelBoundPopupPresenterWidget;
 import org.ovirt.engine.ui.uicommonweb.models.options.EditOptionsModel;
+import org.ovirt.engine.ui.uicompat.IEventListener;
+import org.ovirt.engine.ui.uicompat.PropertyChangedEventArgs;
 
 import com.google.gwt.event.dom.client.ChangeEvent;
 import com.google.gwt.event.dom.client.ChangeHandler;
 import com.google.gwt.event.dom.client.HasChangeHandlers;
+import com.google.gwt.event.logical.shared.HasValueChangeHandlers;
 import com.google.gwt.event.shared.EventBus;
 import com.google.gwt.user.client.ui.HasText;
 import com.google.gwt.user.client.ui.HasValue;
 import com.google.inject.Inject;
 
-public class OptionsPopupPresenterWidget
-        extends AbstractModelBoundPopupPresenterWidget<EditOptionsModel, OptionsPopupPresenterWidget.ViewDef> {
+public class OptionsPopupPresenterWidget extends AbstractModelBoundPopupPresenterWidget<EditOptionsModel, OptionsPopupPresenterWidget.ViewDef> {
 
     public interface ViewDef extends AbstractModelBoundPopupPresenterWidget.ViewDef<EditOptionsModel> {
-        <T extends HasChangeHandlers & HasValue<String> & HasText> T getPublicKeyEditor();
+        interface DelegateProvider {
+            HasChangeHandlers asHasChangeHandlers();
+            HasValue<String> asHasValue();
+            HasText asHasText();
+        }
+        DelegateProvider getPublicKeyEditor();
+
+        IEventListener<? super PropertyChangedEventArgs> createHomePageListener(EditOptionsModel model);
+
+        HasValueChangeHandlers<Boolean> getHomePageDefaultSwitch();
     }
 
     @Inject
@@ -27,15 +38,13 @@ public class OptionsPopupPresenterWidget
     public void init(EditOptionsModel model) {
         super.init(model);
 
-        // TODO-GWT work around https://github.com/gwtproject/gwt/issues/9476
-        registerHandler(((/*required-cast*/HasChangeHandlers) getView().getPublicKeyEditor()).addChangeHandler(new ChangeHandler() {
+        registerHandler(getView().getPublicKeyEditor().asHasChangeHandlers().addChangeHandler(new ChangeHandler() {
             /**
              * It replaces arbitrary number of '\n' by '\n\n' to visually separate lines.
              */
             @Override
             public void onChange(ChangeEvent event) {
-                // TODO-GWT work around https://github.com/gwtproject/gwt/issues/9476
-                final String originalValue = ((/*required-cast*/HasValue<String>) getView().getPublicKeyEditor()).getValue();
+                final String originalValue = getView().getPublicKeyEditor().asHasValue().getValue();
                 String valueWithoutEmptyLines = originalValue;
                 if (valueWithoutEmptyLines == null) {
                     return;
@@ -47,10 +56,16 @@ public class OptionsPopupPresenterWidget
                 }
                 final String lineSeparatedRecords = valueWithoutEmptyLines.replaceAll("\\n", "\n\n"); //$NON-NLS-1$ //$NON-NLS-2$
                 if (!originalValue.equals(lineSeparatedRecords)) {
-                    getView().getPublicKeyEditor().setText(lineSeparatedRecords);
+                    getView().getPublicKeyEditor().asHasText().setText(lineSeparatedRecords);
                 }
             }
         }));
+
+        IEventListener<? super PropertyChangedEventArgs> homePageListener = getView().createHomePageListener(model);
+        model.getIsHomePageCustom().getPropertyChangedEvent().addListener(homePageListener);
+        registerHandler(() -> model.getIsHomePageCustom().getPropertyChangedEvent().removeListener(homePageListener));
+
+        registerHandler(getView().getHomePageDefaultSwitch().addValueChangeHandler(event -> model.getIsHomePageCustom().setEntity(false)));
     }
 
     @Override

--- a/frontend/webadmin/modules/gwt-common/src/main/java/org/ovirt/engine/ui/common/view/popup/OptionsPopupView.ui.xml
+++ b/frontend/webadmin/modules/gwt-common/src/main/java/org/ovirt/engine/ui/common/view/popup/OptionsPopupView.ui.xml
@@ -20,9 +20,14 @@
             font-family: "Courier New", Courier, monospace;
         }
 
+        .customHomePageEditor {
+           height: 30px;
+           width: 100%;
+        }
+
         .inlineBlock {
             display: inline-block;
-            vertical-align: middle;
+            vertical-align: top;
             padding-right: 5px;
         }
 
@@ -51,7 +56,7 @@
         }
 
     </ui:style>
-    <d:SimpleDialogPanel width="800px" height="500px">
+    <d:SimpleDialogPanel width="800px" height="550px">
         <d:content>
             <t:DialogTabPanel ui:field="tabPanel" height="100%" width="100%">
                 <t:tab>
@@ -72,6 +77,34 @@
                                     </b:Column>
                                     <b:Column size="SM_6">
                                         <g:Label ui:field="email"/>
+                                    </b:Column>
+                                </b:Row>
+                                <b:Row>
+                                    <b:Column size="SM_6">
+                                        <g:Label text="{constants.homePage}"
+                                                 addStyleNames="{style.headerLabel} {style.verticalSpacing}"/>
+                                    </b:Column>
+                                </b:Row>
+                                <b:Row>
+                                    <b:Column size="SM_6">
+                                        <ge:EntityModelRadioButtonEditor ui:field="isHomePageDefault"
+                                                                         removeFormGroup="true"
+                                                                         usePatternFly="true"/>
+                                    </b:Column>
+                                </b:Row>
+                                <b:Row>
+                                    <b:Column size="SM_6">
+                                        <ge:EntityModelRadioButtonEditor ui:field="isHomePageCustom"
+                                                                         addStyleNames="{style.inlineBlock}"
+                                                                         removeFormGroup="true"
+                                                                         usePatternFly="true"/>
+                                        <d:InfoIcon ui:field="isHomePageCustomInfo"
+                                                    addStyleNames="{style.inlineBlock} {style.infoIcon}"/>
+                                    </b:Column>
+                                </b:Row>
+                                <b:Row addStyleNames="{style.verticalSpacing}">
+                                    <b:Column size="SM_12" addStyleNames="{style.indentation}">
+                                        <ge:StringEntityModelTextArea ui:field="customHomePage" addStyleNames="{style.customHomePageEditor}"/>
                                     </b:Column>
                                 </b:Row>
                                 <b:Row>

--- a/frontend/webadmin/modules/gwt-common/src/main/resources/org/ovirt/engine/ui/common/CommonApplicationConstants.properties
+++ b/frontend/webadmin/modules/gwt-common/src/main/resources/org/ovirt/engine/ui/common/CommonApplicationConstants.properties
@@ -335,6 +335,9 @@ highlyAvailableVm=Highly Available
 highlyAvailableVmPopup=Highly Available
 highPerformance=High Performance
 highPerformanceChanges=High Performance with newer configuration for next run
+homePage=Home Page
+homePageFormat=The fragment part of the URL i.e. #vms-snapshots;name=testVM.
+homePageIgnoreInvalid=Please note that invalid or malformed fragment is ignored.
 hostClusterTemplateGeneral=Host Cluster
 hostClusterVmPopup=Cluster
 hostKernelCmdlineBlacklistNouveau=Blacklist Nouveau

--- a/frontend/webadmin/modules/gwt-common/src/main/resources/org/ovirt/engine/ui/common/CommonApplicationMessages.properties
+++ b/frontend/webadmin/modules/gwt-common/src/main/resources/org/ovirt/engine/ui/common/CommonApplicationMessages.properties
@@ -24,6 +24,7 @@ fromIndexToIndex={0} - {1}
 fromIndexToIndexOfTotalCount={0} - {1} of {2}
 gibibytes={0} GiB
 globalVncKeyboardLayoutCaption=default [{0}]
+homePageDefault=Default ({0})
 hostDataCenter=Data Center\: {0}
 hotPlugUnplugCpuWarning=Hot add CPUs by changing the number of sockets. Please consult documentation for your guest operating system to ensure it has proper support for CPU Hot Add
 imageUploadProgress=Sent {0} MB

--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/options/CustomHomePageField.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/options/CustomHomePageField.java
@@ -1,0 +1,92 @@
+package org.ovirt.engine.ui.uicommonweb.models.options;
+
+import java.util.Objects;
+
+import org.ovirt.engine.core.common.businessentities.UserProfileProperty;
+import org.ovirt.engine.ui.uicommonweb.models.EntityModel;
+
+import com.google.gwt.core.client.JsonUtils;
+import com.google.gwt.json.client.JSONParser;
+import com.google.gwt.json.client.JSONString;
+
+public class CustomHomePageField implements Field<String> {
+    private static final String CUSTOM_HOME_PAGE = "webAdmin.customHomePage";//$NON-NLS-1$
+    private final EntityModel<String> customHomePage;
+    private final boolean resettable;
+    private String originalCustomHomePage;
+    private UserProfileProperty prop = UserProfileProperty.builder()
+            .withName(CUSTOM_HOME_PAGE)
+            .withTypeJson()
+            .build();
+    private final String defaultValue;
+
+    public CustomHomePageField(EntityModel<String> customHomePage, boolean resettable) {
+        this.customHomePage = customHomePage;
+        this.defaultValue = customHomePage.getEntity();
+        originalCustomHomePage = defaultValue;
+        this.resettable = resettable;
+    }
+
+    @Override
+    public EntityModel<String> getEntity() {
+        return customHomePage;
+    }
+
+    @Override
+    public boolean isUpdated() {
+        return !Objects.equals(originalCustomHomePage, getEditedValue())
+                && !getEditedValue().isEmpty();
+    }
+
+    @Override
+    public UserProfileProperty toProp() {
+        return UserProfileProperty.builder()
+                .from(prop)
+                .withContent(encode(getEditedValue()))
+                .build();
+    }
+
+    private String encode(String value) {
+        return JsonUtils.escapeValue(value);
+    }
+
+    @Override
+    public void fromProp(UserProfileProperty prop) {
+        this.prop = prop;
+        originalCustomHomePage = parse(prop.getContent());
+        customHomePage.setEntity(originalCustomHomePage);
+    }
+
+    private String parse(String json) {
+        if (json == null || json.isEmpty()) {
+            return defaultValue;
+        }
+        JSONString value = JSONParser.parseStrict(json).isString();
+        return value != null ? value.stringValue() : defaultValue;
+    }
+
+    @Override
+    public boolean isSupported(UserProfileProperty prop) {
+        return CUSTOM_HOME_PAGE.equals(prop.getName());
+    }
+
+    private String getEditedValue() {
+        return customHomePage.getEntity() == null ? defaultValue : customHomePage.getEntity().trim();
+    }
+
+    @Override
+    public boolean isRemoved() {
+        return !Objects.equals(originalCustomHomePage, getEditedValue())
+                && getEditedValue().isEmpty();
+    }
+
+    @Override
+    public boolean isResettable() {
+        return resettable;
+    }
+
+    @Override
+    public boolean isCustom() {
+        return !Objects.equals(defaultValue, originalCustomHomePage);
+    }
+}

--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/options/EditOptionsModel.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/options/EditOptionsModel.java
@@ -28,6 +28,9 @@ public class EditOptionsModel extends Model {
     private EntityModel<Boolean> confirmSuspendingVm = new EntityModel<>(constants.confirmSuspendingVm(), true);
     private final EntityModel<String> userName = new EntityModel<>("");
     private final EntityModel<String> email = new EntityModel<>("");
+    private final EntityModel<Boolean> isHomePageCustom = new EntityModel<>(constants.homePageCustom(), false);
+    // in the UI customHomePage(text area) shares the same label with radio button that enables it
+    private final EntityModel<String> customHomePage = new EntityModel<>(constants.homePageCustom(), "");
     private final UICommand okCommand;
     private final UICommand resetCommand;
 
@@ -38,6 +41,8 @@ public class EditOptionsModel extends Model {
             UICommand cancelCommand,
             UICommand resetCommand) {
         this.fields = Arrays.asList(
+                new UseCustomHomePageField(isHomePageCustom, true),
+                new CustomHomePageField(customHomePage, true),
                 new PublicSshKeyField(publicKey, UserProfileProperty.builder().withDefaultSshProp().build()),
                 new LocalStoragePersistenceField(localStoragePersistedOnServer, localStorage, true),
                 new ConfirmSuspendingVmField(confirmSuspendingVm, confirmationModelSettingsManager, true));
@@ -128,5 +133,13 @@ public class EditOptionsModel extends Model {
 
     public EntityModel<String> getEmail() {
         return email;
+    }
+
+    public EntityModel<Boolean> getIsHomePageCustom() {
+        return isHomePageCustom;
+    }
+
+    public EntityModel<String> getCustomHomePage() {
+        return customHomePage;
     }
 }

--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/options/OptionsModel.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/options/OptionsModel.java
@@ -149,6 +149,7 @@ public class OptionsModel extends EntityModel<EditOptionsModel> {
         model.setMessage(constants.areYouSureYouWantToResetTheFollowingSettings());
         model.setItems(removals.stream()
                 .map(Field::getLabel)
+                .distinct()
                 .collect(Collectors.toList()));
 
         List<Boolean> results = new ArrayList<>();

--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/options/UseCustomHomePageField.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/options/UseCustomHomePageField.java
@@ -1,0 +1,65 @@
+package org.ovirt.engine.ui.uicommonweb.models.options;
+
+import java.util.Objects;
+
+import org.ovirt.engine.core.common.businessentities.UserProfileProperty;
+import org.ovirt.engine.ui.uicommonweb.models.EntityModel;
+
+public class UseCustomHomePageField implements Field<Boolean> {
+    private static final String USE_CUSTOM_HOME_PAGE = "webAdmin.useCustomHomePage";//$NON-NLS-1$
+    private final EntityModel<Boolean> isCustom;
+    private final boolean resettable;
+    private boolean originalIsCustom;
+    private UserProfileProperty prop = UserProfileProperty.builder()
+            .withName(USE_CUSTOM_HOME_PAGE)
+            .withTypeJson()
+            .build();
+    private Boolean defaultValue;
+
+    public UseCustomHomePageField(EntityModel<Boolean> isCustom, boolean resettable) {
+        this.isCustom = isCustom;
+        this.resettable = resettable;
+        defaultValue = isCustom.getEntity();
+        originalIsCustom = defaultValue;
+    }
+
+    @Override
+    public EntityModel<Boolean> getEntity() {
+        return isCustom;
+    }
+
+    @Override
+    public boolean isUpdated() {
+        return !Objects.equals(originalIsCustom, isCustom.getEntity());
+    }
+
+    @Override
+    public UserProfileProperty toProp() {
+        return UserProfileProperty.builder()
+                .from(prop)
+                .withContent(Boolean.toString(isCustom.getEntity()))
+                .build();
+    }
+
+    @Override
+    public void fromProp(UserProfileProperty prop) {
+        this.prop = prop;
+        originalIsCustom = Boolean.parseBoolean(prop.getContent());
+        isCustom.setEntity(originalIsCustom);
+    }
+
+    @Override
+    public boolean isSupported(UserProfileProperty prop) {
+        return USE_CUSTOM_HOME_PAGE.equals(prop.getName());
+    }
+
+    @Override
+    public boolean isResettable() {
+        return resettable;
+    }
+
+    @Override
+    public boolean isCustom() {
+        return !Objects.equals(defaultValue, originalIsCustom);
+    }
+}

--- a/frontend/webadmin/modules/uicompat/src/main/java/org/ovirt/engine/ui/uicompat/UIConstants.java
+++ b/frontend/webadmin/modules/uicompat/src/main/java/org/ovirt/engine/ui/uicompat/UIConstants.java
@@ -2244,4 +2244,6 @@ public interface UIConstants extends Constants {
     String persistGridSettingsOnServer();
 
     String confirmSuspendingVm();
+
+    String homePageCustom();
 }

--- a/frontend/webadmin/modules/uicompat/src/main/resources/org/ovirt/engine/ui/uicompat/UIConstants.properties
+++ b/frontend/webadmin/modules/uicompat/src/main/resources/org/ovirt/engine/ui/uicompat/UIConstants.properties
@@ -405,6 +405,7 @@ highPerformancePopupRecommendationMsgForCpuSpecificHostPin=CPU PINNING:\r\nPleas
 highPerformancePopupRecommendationMsgForCpuPin=CPU PINNING:\r\nPlease set the \"CPU Pinning topology\" field and verify that the configuration fits pinned \
   host(s)'s configuration:\r\n  guest number of virtual sockets <= host's number of sockets.\r\n  guest number of cores per virtual socket <= host's number of \
   cores per socket.\r\n  guest number of threads per core <= host's number of threads per core.
+homePageCustom=Custom home page
 editOptionVolume=Edit Option
 editPolicyTitle=Edit Policy
 editPoolTitle=Edit Pool


### PR DESCRIPTION
Home page setting allows to customize the welcome page displayed when
UI is accessed via base URL (without the fragment part).

Key points:
1. the home page is described by a fragment part of the URL and
   contains encoded information about the screen to be displayed
2. two new properties were added for this feature:
   a) "webAdmin.useCustomHomePage" - boolean (default: false)
   b) "webAdmin.customHomePage" - string - the fragment to be used
3. the fallback for incorrect or obsolete home page is the default page
   (the dashboard if ui-extensions are used). The flow is the same as
   if an incorrect fragment was entered manually.