### PR TITLE
ansible: Add async with timeout for OVA related tasks

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/AnsiblePackOvaCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/AnsiblePackOvaCommand.java
@@ -7,6 +7,7 @@ import org.ovirt.engine.core.bll.context.CommandContext;
 import org.ovirt.engine.core.common.action.AnsibleCommandParameters;
 import org.ovirt.engine.core.common.utils.ansible.AnsibleCommandConfig;
 import org.ovirt.engine.core.common.utils.ansible.AnsibleConstants;
+import org.ovirt.engine.core.utils.EngineLocalConfig;
 
 @NonTransactiveCommandAttribute
 public class AnsiblePackOvaCommand <T extends AnsibleCommandParameters> extends AnsibleCommandBase<T> {
@@ -18,6 +19,7 @@ public class AnsiblePackOvaCommand <T extends AnsibleCommandParameters> extends 
 
     @Override
     protected AnsibleCommandConfig createCommand() {
+        int timeout = EngineLocalConfig.getInstance().getInteger("ANSIBLE_PLAYBOOK_EXEC_DEFAULT_TIMEOUT");
         Map<String, Object> vars = getParameters().getVariables();
         return new AnsibleCommandConfig()
                 .hosts(getVds())
@@ -30,6 +32,7 @@ public class AnsiblePackOvaCommand <T extends AnsibleCommandParameters> extends 
                 .variable("ovirt_ova_pack_tpm", vars.get("ovirt_ova_pack_tpm"))
                 .variable("ovirt_ova_pack_nvram", vars.get("ovirt_ova_pack_nvram"))
                 .variable("ovirt_ova_pack_padding", vars.get("ovirt_ova_pack_padding"))
+                .variable("ansible_timeout", timeout)
                 // /var/log/ovirt-engine/ova/ovirt-export-ova-ansible-{hostname}-{correlationid}-{timestamp}.log
                 .logFileDirectory(CREATE_OVA_LOG_DIRECTORY)
                 .logFilePrefix("ovirt-export-ova-ansible")

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/GetFromOvaQuery.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/GetFromOvaQuery.java
@@ -22,6 +22,7 @@ import org.ovirt.engine.core.common.utils.ansible.AnsibleReturnCode;
 import org.ovirt.engine.core.common.utils.ansible.AnsibleReturnValue;
 import org.ovirt.engine.core.common.utils.ansible.AnsibleRunnerHttpClient;
 import org.ovirt.engine.core.dao.VdsDao;
+import org.ovirt.engine.core.utils.EngineLocalConfig;
 
 public abstract class GetFromOvaQuery <T, P extends GetVmFromOvaQueryParameters> extends QueriesCommandBase<P> {
 
@@ -46,12 +47,14 @@ public abstract class GetFromOvaQuery <T, P extends GetVmFromOvaQueryParameters>
     }
 
     private String runAnsibleQueryOvaInfoPlaybook() {
+        int timeout = EngineLocalConfig.getInstance().getInteger("ANSIBLE_PLAYBOOK_EXEC_DEFAULT_TIMEOUT");
         VDS host = vdsDao.get(getParameters().getVdsId());
         AnsibleCommandConfig command = new AnsibleCommandConfig()
                 .hosts(host)
                 .variable("ovirt_query_ova_path", getParameters().getPath())
                 .variable("list_directory", getParameters().isListDirectory() ? "True" : "False")
                 .variable("entity_type", getEntityType().name().toLowerCase())
+                .variable("ansible_timeout", timeout)
                 // /var/log/ovirt-engine/ova/ovirt-query-ova-ansible-{hostname}-{timestamp}.log
                 .logFileDirectory(ExtractOvaCommand.IMPORT_OVA_LOG_DIRECTORY)
                 .logFilePrefix("ovirt-query-ova-ansible")

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ExportOvaCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ExportOvaCommand.java
@@ -30,6 +30,7 @@ import org.ovirt.engine.core.common.utils.ansible.AnsibleConstants;
 import org.ovirt.engine.core.common.utils.ansible.AnsibleExecutor;
 import org.ovirt.engine.core.common.utils.ansible.AnsibleReturnCode;
 import org.ovirt.engine.core.dao.VmDeviceDao;
+import org.ovirt.engine.core.utils.EngineLocalConfig;
 
 public abstract class ExportOvaCommand<T extends ExportOvaParameters> extends CommandBase<T> {
 
@@ -93,10 +94,12 @@ public abstract class ExportOvaCommand<T extends ExportOvaParameters> extends Co
     }
 
     private ValidationResult validateTargetFolder() {
+        int timeout = EngineLocalConfig.getInstance().getInteger("ANSIBLE_PLAYBOOK_EXEC_DEFAULT_TIMEOUT");
         AnsibleCommandConfig commandConfig = new AnsibleCommandConfig()
                 .hosts(getVds())
                 .variable("target_directory", getParameters().getDirectory())
                 .variable("validate_only", "True")
+                .variable("ansible_timeout", timeout)
                 // /var/log/ovirt-engine/ova/ovirt-export-ova-validate-ansible-{hostname}-{correlationid}-{timestamp}.log
                 .logFileDirectory(CreateOvaCommand.CREATE_OVA_LOG_DIRECTORY)
                 .logFilePrefix("ovirt-export-ova-validate-ansible")

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ExtractOvaCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ExtractOvaCommand.java
@@ -36,6 +36,7 @@ import org.ovirt.engine.core.common.vdscommands.VDSReturnValue;
 import org.ovirt.engine.core.compat.CommandStatus;
 import org.ovirt.engine.core.compat.Guid;
 import org.ovirt.engine.core.dao.VmDao;
+import org.ovirt.engine.core.utils.EngineLocalConfig;
 import org.ovirt.engine.core.vdsbroker.vdsbroker.PrepareImageReturn;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -112,6 +113,7 @@ public class ExtractOvaCommand<T extends ConvertOvaParameters> extends VmCommand
     }
 
     private boolean runAnsibleImportOvaPlaybook(String disksPathToFormat) {
+        int timeout = EngineLocalConfig.getInstance().getInteger("ANSIBLE_PLAYBOOK_EXEC_DEFAULT_TIMEOUT");
         AnsibleCommandConfig commandConfig = new AnsibleCommandConfig()
                 .hosts(getVds())
                 .variable("ovirt_import_ova_path", getParameters().getOvaPath())
@@ -122,6 +124,7 @@ public class ExtractOvaCommand<T extends ConvertOvaParameters> extends VmCommand
                                 .map(e -> String
                                         .format("\\\"%s\\\": \\\"%s\\\"", e.getValue().toString(), e.getKey().toString()))
                                 .collect(Collectors.joining(", ", "{", "}")))
+                .variable("ansible_timeout", timeout)
                 // /var/log/ovirt-engine/ova/ovirt-import-ova-ansible-{hostname}-{correlationid}-{timestamp}.log
                 .logFileDirectory(IMPORT_OVA_LOG_DIRECTORY)
                 .logFilePrefix("ovirt-import-ova-ansible")

--- a/packaging/ansible-runner-service-project/project/roles/ovirt-ova-export-post-pack/tasks/main.yml
+++ b/packaging/ansible-runner-service-project/project/roles/ovirt-ova-export-post-pack/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 - name: Rename the OVA file
   command: mv "{{ ova_file.dest }}" "{{ target_directory }}/{{ ova_name }}"
+  async: "{{ ansible_timeout }}"
+  poll: 15
   when: packing_result.rc is defined and packing_result.rc == 0
 
 - name: Remove the temporary file

--- a/packaging/ansible-runner-service-project/project/roles/ovirt-ova-export-pre-pack/tasks/main.yml
+++ b/packaging/ansible-runner-service-project/project/roles/ovirt-ova-export-pre-pack/tasks/main.yml
@@ -27,6 +27,8 @@
 
 - name: Allocating the temporary path for the OVA file
   command: xfs_mkfile -n "{{ ova_size }}" "{{ target_directory }}/{{ ova_name }}.tmp"
+  async: "{{ ansible_timeout }}"
+  poll: 15
   when: validate_only is not defined
 
 - name: Retrieving the temporary path for the OVA file

--- a/packaging/ansible-runner-service-project/project/roles/ovirt-ova-extract/tasks/main.yml
+++ b/packaging/ansible-runner-service-project/project/roles/ovirt-ova-extract/tasks/main.yml
@@ -1,15 +1,33 @@
 ---
-- name: Run extraction script
-  script: >
-    extract_ova.py
-    "{{ ovirt_import_ova_path }}"
-    "{{ ovirt_import_ova_disks }}"
-    "{{ ovirt_import_ova_image_mappings }}"
-  args:
-    executable: "{{ ansible_python_interpreter }}"
-  register: extraction_result
+- block:
+  - name: Create temporary directory
+    tempfile:
+      state: directory
+      suffix: ova
+    register: ova_temp
 
-- name: Check OVA extraction process result
-  fail:
-    msg: "Failed to extract OVA file"
-  when: extraction_result.rc is defined and extraction_result.rc != 0
+  - name: Copy extract_ova.py to temp directory
+    copy:
+      src: extract_ova.py
+      dest: "{{ ova_temp.path }}/extract_ova.py"
+
+  - name: Run extraction script
+    command: >
+      "{{ ansible_python_interpreter }}"
+      "{{ ova_temp.path }}/extract_ova.py"
+      "{{ ovirt_import_ova_path }}"
+      "{{ ovirt_import_ova_disks }}"
+      "{{ ovirt_import_ova_image_mappings }}"
+    async: "{{ ansible_timeout }}"
+    poll: 15
+    register: extraction_result
+
+  - name: Check OVA extraction process result
+    fail:
+      msg: "Failed to extract OVA file"
+    when: extraction_result.rc is defined and extraction_result.rc != 0
+  always:
+  - name: Remove temp directory
+    file:
+      state: absent
+      path: "{{ ova_temp.path }}"

--- a/packaging/ansible-runner-service-project/project/roles/ovirt-ova-pack/tasks/main.yml
+++ b/packaging/ansible-runner-service-project/project/roles/ovirt-ova-pack/tasks/main.yml
@@ -1,16 +1,34 @@
 ---
-- name: Run packing script
-  script: >
-    pack_ova.py
-    "{{ entity_type }}"
-    "{{ ova_file.dest }}"
-    "{{ ovirt_ova_pack_ovf }}"
-    "{{ ovirt_ova_pack_disks }}"
-    "{{ ovirt_ova_pack_tpm }}"
-    "{{ ovirt_ova_pack_nvram }}"
-    "{{ ovirt_ova_pack_padding }}"
-  args:
-    executable: "{{ ansible_python_interpreter }}"
-  register: packing_result
-  ignore_errors: yes
-  when: ova_file is defined and ova_file.dest is defined
+- block:
+  - name: Create temporary directory
+    tempfile:
+      state: directory
+      suffix: ova
+    register: ova_temp
+
+  - name: Copy pack_ova.py to temp directory
+    copy:
+      src: pack_ova.py
+      dest: "{{ ova_temp.path }}/pack_ova.py"
+
+  - name: Run packing script
+    command: >
+      "{{ ansible_python_interpreter }}"
+      "{{ ova_temp.path }}/pack_ova.py"
+      "{{ entity_type }}"
+      "{{ ova_file.dest }}"
+      "{{ ovirt_ova_pack_ovf }}"
+      "{{ ovirt_ova_pack_disks }}"
+      "{{ ovirt_ova_pack_tpm }}"
+      "{{ ovirt_ova_pack_nvram }}"
+      "{{ ovirt_ova_pack_padding }}"
+    register: packing_result
+    ignore_errors: yes
+    async: "{{ ansible_timeout }}"
+    poll: 15
+    when: ova_file is defined and ova_file.dest is defined
+  always:
+  - name: Remove temp directory
+    file:
+      state: absent
+      path: "{{ ova_temp.path }}"

--- a/packaging/ansible-runner-service-project/project/roles/ovirt-ova-query/tasks/main.yml
+++ b/packaging/ansible-runner-service-project/project/roles/ovirt-ova-query/tasks/main.yml
@@ -1,10 +1,28 @@
 ---
-- name: Run query script
-  script: >
-    query_ova.py
-    "{{ entity_type }}"
-    "{{ ovirt_query_ova_path }}"
-    "{{ list_directory }}"
-  args:
-    executable: "{{ ansible_python_interpreter }}"
-  register: extraction_result
+- block:
+  - name: Create temporary directory
+    tempfile:
+      state: directory
+      suffix: ova
+    register: ova_temp
+
+  - name: Copy query_ova.py to temp directory
+    copy:
+      src: query_ova.py
+      dest: "{{ ova_temp.path }}/query_ova.py"
+
+  - name: Run query script
+    command: >
+      "{{ ansible_python_interpreter }}"
+      "{{ ova_temp.path }}/query_ova.py"
+      "{{ entity_type }}"
+      "{{ ovirt_query_ova_path }}"
+      "{{ list_directory }}"
+    async: "{{ ansible_timeout }}"
+    poll: 15
+    register: extraction_result
+  always:
+  - name: Remove temp directory
+    file:
+      state: absent
+      path: "{{ ova_temp.path }}"


### PR DESCRIPTION
OVA is invoking tasks that are running for a long time
as script or command, this can result in ssh closing connection
before the task has a chance to finish. Use async on those
commands which makes ansible to poll every 15 seconds to check
if the command succeeded.

Bug-Url: https://bugzilla.redhat.com/2056052
Signed-off-by: Ales Musil <amusil@redhat.com>