### PR TITLE
core: Extend time to warn of upcoming certificate expiration

### DIFF
--- a/packaging/dbscripts/upgrade/pre_upgrade/0000_config.sql
+++ b/packaging/dbscripts/upgrade/pre_upgrade/0000_config.sql
@@ -855,8 +855,8 @@ select fn_db_add_config_value('BootstrapCommand',
                               'general');
 select fn_db_add_config_value('BootstrapPackageDirectory', '/usr/share/ovirt-host-deploy/interface-3', 'general');
 select fn_db_add_config_value('BootstrapPackageName', 'ovirt-host-deploy.tar', 'general');
-select fn_db_add_config_value('CertExpirationAlertPeriodInDays', '7', 'general');
-select fn_db_add_config_value('CertExpirationWarnPeriodInDays', '30', 'general');
+select fn_db_add_config_value('CertExpirationAlertPeriodInDays', '30', 'general');
+select fn_db_add_config_value('CertExpirationWarnPeriodInDays', '120', 'general');
 select fn_db_add_config_value('DBI18NPrefix', '', 'general');
 select fn_db_add_config_value('DBLikeSyntax', 'ILIKE', 'general');
 select fn_db_add_config_value('DBPagingSyntax', ' WHERE RowNum BETWEEN %1$s AND %2$s', 'general');
@@ -1303,6 +1303,9 @@ select fn_db_update_config_value('ServerCPUList',
     '4.6');
 -- qemu-guest-agent is also a viable agent
 select fn_db_update_config_value('AgentAppName','ovirt-guest-agent-common,ovirt-guest-agent,qemu-guest-agent','general');
+
+select fn_db_update_config_value('CertExpirationAlertPeriodInDays', '30', 'general');
+select fn_db_update_config_value('CertExpirationWarnPeriodInDays', '120', 'general');
 
 ------------------------------------------------------------------------------------
 --   Update only if default not changed section


### PR DESCRIPTION
The time when event are created to warn of upcoming certificate
expiration were extended:

1. If a certificate is going to expire in the upcoming 120 days, then
   WARNING event is raised in the audit log
2. If a certificate is going to expired in the upcoming 30 days, then
   ALERT event is raised in the audit log

Bug-Url: https://bugzilla.redhat.com/2056126
Signed-off-by: Martin Perina <mperina@redhat.com>
