### PR TITLE
restapi: fix vm mapper

### DIFF
--- a/backend/manager/modules/restapi/types/src/main/java/org/ovirt/engine/api/restapi/types/VmMapper.java
+++ b/backend/manager/modules/restapi/types/src/main/java/org/ovirt/engine/api/restapi/types/VmMapper.java
@@ -291,16 +291,16 @@ public class VmMapper extends VmBaseMapper {
                 Boot boot = map(entity.getBootSequence(), null);
                 model.getOs().setBoot(boot);
             }
-            if (VmCpuCountHelper.isResizeAndPinPolicy(entity)) {
-                CpuTopology topology = new CpuTopology();
-                topology.setSockets(entity.getCurrentSockets());
-                topology.setCores(entity.getCurrentCoresPerSocket());
-                topology.setThreads(entity.getCurrentThreadsPerCore());
-                model.setDynamicCpu(new DynamicCpu());
-                model.getDynamicCpu().setTopology(topology);
-            }
             if (VmCpuCountHelper.isDynamicCpuPinning(entity)) {
+                model.setDynamicCpu(new DynamicCpu());
                 model.getDynamicCpu().setCpuTune(stringToCpuTune(entity.getCurrentCpuPinning()));
+                if (VmCpuCountHelper.isResizeAndPinPolicy(entity)) {
+                    CpuTopology topology = new CpuTopology();
+                    topology.setSockets(entity.getCurrentSockets());
+                    topology.setCores(entity.getCurrentCoresPerSocket());
+                    topology.setThreads(entity.getCurrentThreadsPerCore());
+                    model.getDynamicCpu().setTopology(topology);
+                }
             }
         } else {
             if (model.getOs() != null) {


### PR DESCRIPTION
The VM mapper was not creating DynamicCpu instance for dedicated CPUs which resulted in NPE.

This patch changes the order of filling the model - at first, if the cpu pinning policy is dynamic, the DynamicCpu is created. Then, if the dynamic pinning is numa resize and pin, the dynamic cpu topology is set.