### PR TITLE
core: fix NPE on cpuTopology

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/utils/VdsCpuUnitPinningHelper.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/utils/VdsCpuUnitPinningHelper.java
@@ -103,6 +103,9 @@ public class VdsCpuUnitPinningHelper {
             return new ArrayList<>();
         }
         List<VdsCpuUnit> cpuTopology = resourceManager.getVdsManager(host.getId()).getCpuTopology();
+        if (cpuTopology.isEmpty()) {
+            return new ArrayList<>();
+        }
 
         previewPinOfPendingExclusiveCpus(cpuTopology, vmToPendingPinnings, vm.getCpuPinningPolicy());
 
@@ -178,6 +181,9 @@ public class VdsCpuUnitPinningHelper {
 
     public int countTakenCores(VDS host) {
         List<VdsCpuUnit> cpuTopology = resourceManager.getVdsManager(host.getId()).getCpuTopology();
+        if (cpuTopology.isEmpty()) {
+            return 0;
+        }
         int hostCoresPerSocket = host.getCpuCores() / host.getCpuSockets();
         int numOfTakenCores = 0;
         for (int socket = 0; socket < host.getCpuSockets(); socket++) {

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/VdsManager.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/VdsManager.java
@@ -192,6 +192,7 @@ public class VdsManager {
         vdsId = vds.getId();
         unrespondedAttempts = new AtomicInteger();
         autoStartVmsWithLeasesLock = new ReentrantLock();
+        cpuTopology = new ArrayList<>();
     }
 
     @PostConstruct
@@ -1330,7 +1331,8 @@ public class VdsManager {
             return;
         }
         this.cpuTopology = cpuTopology;
-        this.cpuTopology.stream().filter(cpu -> cpu.getCpu() == Integer.parseInt(cachedVds.getVdsmCpusAffinity()))
+        int vdsmCpu = Integer.parseInt(cachedVds.getVdsmCpusAffinity());
+        this.cpuTopology.stream().filter(cpu -> cpu.getCpu() == vdsmCpu)
                 .forEach(cpu -> cpu.pinVm(Guid.SYSTEM, CpuPinningPolicy.MANUAL));
     }
 


### PR DESCRIPTION
When using older hosts, the cpu_topology is not reported from the host
caps. This caused a NullPointerException when streaming over the list,
as the list is a null and not an empty list.
On the VdsCpuUnitPinningHelper, when using manual pinning and by the
CpuPolicyUnit a caution about empty CPU topology needed.

This patch will initiate the VdsManager cpuTopology, to have an empty
list instead of null. Also, when entering some flows in the helper if
the cpuTopology is empty we should return immediately.

Change-Id: I6801dbbf4c63f96061a4c16dd001fb7260c717a1
Bug-Url: https://bugzilla.redhat.com/1782077
Signed-off-by: Liran Rotenberg <lrotenbe@redhat.com>