### PR TITLE
core: consider offline cpus

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/utils/VdsCpuUnitPinningHelper.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/utils/VdsCpuUnitPinningHelper.java
@@ -188,6 +188,10 @@ public class VdsCpuUnitPinningHelper {
         int numOfTakenCores = 0;
         for (int socket = 0; socket < host.getCpuSockets(); socket++) {
             for (int core = 0; core < hostCoresPerSocket; core++) {
+                if (getCpusInCore(getCoresInSocket(cpuTopology, socket), core).isEmpty()) {
+                    // TODO change the iterations to consider only online CPUS and remove this.
+                    continue;
+                }
                 if (getNonDedicatedCpusInCore(cpuTopology, socket, core).isEmpty()) {
                     numOfTakenCores++;
                 }


### PR DESCRIPTION
This patch will let the scheduler to deal with mismatch of the host
topology with the online CPUs it has.
It's partially done to not break non-Dedicated flows.

Change-Id: Ib91401c88e0e1e87f3ba1076c8e076f1822549d6
Signed-off-by: Liran Rotenberg <lrotenbe@redhat.com>