### PR TITLE
[db] fkvalidator fix

### DIFF
--- a/packaging/setup/dbutils/fkvalidator_sp.sql
+++ b/packaging/setup/dbutils/fkvalidator_sp.sql
@@ -20,7 +20,7 @@ DECLARE
         c.relname as table_name,
         substring(substring ((select pg_get_constraintdef(r.oid)) from '[a-zA-Z0-9_, \-][(][a-zA-Z0-9_, \-]+[)]') from 2) as table_col,
         c2.relname AS fk_table_name,
-        substring ((select pg_get_constraintdef(r.oid)) from ' [(][a-zA-Z0-9_, \-]+[)] ') as fk_col
+        substring ((select pg_get_constraintdef(r.oid)) from '((?<=[a-zA-Z0-9])[(][a-zA-Z0-9_, \-]+[)])') as fk_col
     FROM pg_class c, pg_class c2, pg_constraint r, pg_catalog.pg_namespace n
     WHERE c.relname in (select table_name from information_schema.tables
     where table_schema not in ('pg_catalog','information_schema') and table_type = 'BASE TABLE') AND
@@ -42,13 +42,13 @@ BEGIN
         v_record.fk_status := 0;
         IF (v_fix_it) THEN
             v_sql := 'delete from ' || v_record.schema_name || '.'  || v_record.fk_table_name ||
-                      ' where ' || v_record.fk_col || 'IS NOT NULL and '  || v_record.fk_col || ' not in (select ' ||
-                      trim(both '()' from v_record.table_col) || ' from ' || v_record.schema_name || '.'  || v_record.table_name || ');';
+                      ' where ' || v_record.table_col || 'IS NOT NULL and '  || v_record.table_col || ' not in (select ' ||
+                      trim(both '()' from v_record.fk_col) || ' from ' || v_record.schema_name || '.'  || v_record.table_name || ');';
             v_msg := 'Fixing violation/s found in ' ||  v_record.fk_table_name ;
         ELSE
-            v_sql := 'select ' ||  v_record.fk_col || ' from ' || v_record.schema_name || '.'  || v_record.fk_table_name ||
-                      ' where ' || v_record.fk_col || 'IS NOT NULL and ' || v_record.fk_col || ' not in (select ' ||
-                      trim(both '()' from v_record.table_col) || ' from ' || v_record.schema_name || '.'  || v_record.table_name || ');';
+            v_sql := 'select ' ||  v_record.table_col || ' from ' || v_record.schema_name || '.'  || v_record.fk_table_name ||
+                      ' where ' || v_record.table_col || 'IS NOT NULL and ' || v_record.table_col || ' not in (select ' ||
+                      trim(both '()' from v_record.fk_col) || ' from ' || v_record.schema_name || '.'  || v_record.table_name || ');';
             v_msg := 'Constraint violation found in  ' ||  v_record.fk_table_name || v_record.fk_col;
         END IF;
         EXECUTE v_sql;


### PR DESCRIPTION
This patch fixes an issue with fk validator.
The root cause was the fact that this store procedure incorrectly parsed
foreign key column from the constraint definition. Table column was
always chosen whereas there should a referenced (foreign) column
selected.

In example:
Let's take one fk constraint body:
FOREIGN KEY (group_id) REFERENCES ad_groups(id)

Before that patch 'fk_col' would be always resolved to 'group_id'. After
applying the patch it would be 'id'  (from 'ad_groups' table)

Now the expected fk check sql should take a form of:

select (group_id) from public.tags_user_group_map where (
group_id)IS NOT NULL
and (id) not in (select id from public.ad_groups)

In case non empty results fkvalidator would raise an error (as expected
for such integrity check)
