### PR TITLE
packaging: bump apache-sshd to 2.8.x

### DIFF
--- a/backend/manager/modules/uutils/src/main/java/org/ovirt/engine/core/uutils/ssh/OpenSSHUtils.java
+++ b/backend/manager/modules/uutils/src/main/java/org/ovirt/engine/core/uutils/ssh/OpenSSHUtils.java
@@ -11,7 +11,7 @@ import org.apache.sshd.common.config.keys.KeyUtils;
 import org.apache.sshd.common.config.keys.PublicKeyEntryResolver;
 import org.apache.sshd.common.config.keys.writer.openssh.OpenSSHKeyPairResourceWriter;
 import org.apache.sshd.common.digest.BuiltinDigests;
-import org.apache.sshd.common.util.io.SecureByteArrayOutputStream;
+import org.apache.sshd.common.util.io.output.SecureByteArrayOutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/ovirt-engine.spec.in
+++ b/ovirt-engine.spec.in
@@ -375,7 +375,7 @@ Requires:	openstack-java-quantum-client >= %{openstack_java_version}
 Requires:	openstack-java-quantum-model >= %{openstack_java_version}
 Requires:	openstack-java-resteasy-connector >= %{openstack_java_version}
 Requires:	python3-dnf-plugin-versionlock
-Requires:	apache-sshd >= 2.6.0
+Requires:	apache-sshd >= 2.8.0
 Requires:	ed25519-java >= 0.3.0
 Requires:	slf4j-jdk14 >= 1.7.0
 Requires:	jcl-over-slf4j >= 1.7.0

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <javax.interceptor.api.version>1.0.0.Final</javax.interceptor.api.version>
     <dozer.version>5.2.0</dozer.version>
     <cxf.version>2.2.7</cxf.version>
-    <sshd-core.version>2.6.0</sshd-core.version>
+    <sshd-core.version>2.8.0</sshd-core.version>
     <eddsa.version>0.3.0</eddsa.version>
     <vdsm-jsonrpc-java.version>1.7.1</vdsm-jsonrpc-java.version>
     <slf4j.version>1.7.22</slf4j.version>


### PR DESCRIPTION
Recently released apache-sshd >= 2.7.0 is incompatible with our
implementation in engine. This patch ensures apache-sshd won't get
automatically upgraded with 'dnf upgrade'
