### PR TITLE
webadmin: display toast notifications via Frontend

### DIFF
--- a/frontend/webadmin/modules/frontend/src/main/java/org/ovirt/engine/ui/frontend/Frontend.java
+++ b/frontend/webadmin/modules/frontend/src/main/java/org/ovirt/engine/ui/frontend/Frontend.java
@@ -58,6 +58,8 @@ import com.google.inject.Inject;
  */
 public class Frontend implements HasHandlers {
 
+    private NotificationHandler notificationHandler;
+
     /**
      * Provides static access to {@code Frontend} singleton instance.
      */
@@ -1109,4 +1111,20 @@ public class Frontend implements HasHandlers {
         }
         return webAdminSettings;
     }
+
+    public void setNotificationHandler(NotificationHandler handler) {
+        this.notificationHandler = handler;
+    }
+
+    /**
+     * Display a toast notification using registered {@linkplain NotificationHandler} (if available).
+     */
+    public void showToast(String text, NotificationStatus status) {
+        // use local reference for async action
+        NotificationHandler handler = notificationHandler;
+        if (handler != null) {
+            Scheduler.get().scheduleDeferred(() -> handler.showToast(text, status));
+        }
+    }
+
 }

--- a/frontend/webadmin/modules/frontend/src/main/java/org/ovirt/engine/ui/frontend/NotificationHandler.java
+++ b/frontend/webadmin/modules/frontend/src/main/java/org/ovirt/engine/ui/frontend/NotificationHandler.java
@@ -1,0 +1,8 @@
+package org.ovirt.engine.ui.frontend;
+
+/**
+ * Generic notification handler that can be used across all modules.
+ */
+public interface NotificationHandler {
+    void showToast(String text, NotificationStatus status);
+}

--- a/frontend/webadmin/modules/frontend/src/main/java/org/ovirt/engine/ui/frontend/NotificationStatus.java
+++ b/frontend/webadmin/modules/frontend/src/main/java/org/ovirt/engine/ui/frontend/NotificationStatus.java
@@ -1,0 +1,11 @@
+package org.ovirt.engine.ui.frontend;
+
+/**
+ * Version without any dependencies to be used across all modules.
+ */
+public enum NotificationStatus {
+    INFO,
+    SUCCESS,
+    WARNING,
+    DANGER;
+}

--- a/frontend/webadmin/modules/gwt-common/src/main/java/org/ovirt/engine/ui/common/widget/uicommon/tasks/ToastNotification.java
+++ b/frontend/webadmin/modules/gwt-common/src/main/java/org/ovirt/engine/ui/common/widget/uicommon/tasks/ToastNotification.java
@@ -31,6 +31,20 @@ public class ToastNotification extends Composite {
             this.iconStyleName = iconStyleName;
         }
 
+        public static NotificationStatus from(org.ovirt.engine.ui.frontend.NotificationStatus status) {
+            switch (status){
+            case DANGER:
+                return DANGER;
+            case SUCCESS:
+                return SUCCESS;
+            case WARNING:
+                return WARNING;
+            case INFO:
+            default:
+                return INFO;
+            }
+        }
+
         public String getStyleName() {
             return styleName;
         }

--- a/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/section/main/presenter/overlay/TasksPresenterWidget.java
+++ b/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/section/main/presenter/overlay/TasksPresenterWidget.java
@@ -14,6 +14,8 @@ import org.ovirt.engine.core.common.action.ActionType;
 import org.ovirt.engine.core.common.job.Job;
 import org.ovirt.engine.core.common.job.JobExecutionStatus;
 import org.ovirt.engine.ui.common.widget.uicommon.tasks.ToastNotification.NotificationStatus;
+import org.ovirt.engine.ui.frontend.Frontend;
+import org.ovirt.engine.ui.frontend.NotificationHandler;
 import org.ovirt.engine.ui.uicommonweb.models.events.TaskListModel;
 import org.ovirt.engine.ui.uicompat.EnumTranslator;
 import org.ovirt.engine.ui.webadmin.section.main.presenter.AbstractOverlayPresenterWidget;
@@ -23,9 +25,15 @@ import org.ovirt.engine.ui.webadmin.uicommon.model.TaskModelProvider;
 import com.google.inject.Inject;
 import com.google.web.bindery.event.shared.EventBus;
 
-public class TasksPresenterWidget extends AbstractOverlayPresenterWidget<TasksPresenterWidget.ViewDef> {
+public class TasksPresenterWidget extends AbstractOverlayPresenterWidget<TasksPresenterWidget.ViewDef>
+        implements NotificationHandler {
 
     protected final Logger log = Logger.getLogger(TasksPresenterWidget.class.getName());
+
+    @Override
+    public void showToast(String text, org.ovirt.engine.ui.frontend.NotificationStatus status) {
+        notificationPresenterWidget.createNotification(text, NotificationStatus.from(status));
+    }
 
     public interface ViewDef extends AbstractOverlayPresenterWidget.ViewDef {
         void updateTaskStatus(TaskListModel taskListModel);
@@ -71,6 +79,8 @@ public class TasksPresenterWidget extends AbstractOverlayPresenterWidget<TasksPr
     @Override
     public void onBind() {
         super.onBind();
+        Frontend.getInstance().setNotificationHandler(this);
+        registerHandler(() -> Frontend.getInstance().setNotificationHandler(null));
         taskModelProvider.getModel().getItemsChangedEvent().addListener((ev, sender, args) -> {
             getView().updateTaskStatus(taskModelProvider.getModel());
             if (lastSpecialTaskEndTime == NOT_INITIALIZED_END_TIME) {


### PR DESCRIPTION
Before, in order to display a toast notification, the component needed
direct access to NotificationPresenterWidget.
With this patch this restriction has been removed. The notification
handler registers itself in the Frontend which allows public access.