### PR TITLE
core: Fix wrong IP comparison in NetworkConfigurator

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/network/NetworkConfigurator.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/network/NetworkConfigurator.java
@@ -38,6 +38,7 @@ import org.ovirt.engine.core.utils.NetworkUtils;
 import org.ovirt.engine.core.utils.network.function.NicToIpv4AddressFunction;
 import org.ovirt.engine.core.utils.network.function.NicToIpv6AddressFunction;
 import org.ovirt.engine.core.utils.network.predicate.InterfaceByNetworkNamePredicate;
+import org.ovirt.engine.core.utils.network.predicate.IpAddressPredicate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,13 +69,13 @@ public class NetworkConfigurator {
             return;
         }
 
-        final String hostIp = NetworkUtils.getHostIp(host);
+        final var hostIpPredicate = new IpAddressPredicate(NetworkUtils.getHostIp(host));
         final String managementNetworkName = managementNetwork.getName();
 
         final String hostManagementNetworkIpv4Address = getIpv4AddressOfNetwork(managementNetworkName);
         final String hostManagementNetworkIpv6Address = getIpv6AddressOfNetwork(managementNetworkName);
-        if (hostManagementNetworkIpv4Address != null && hostManagementNetworkIpv4Address.equals(hostIp) ||
-                hostManagementNetworkIpv6Address != null && hostManagementNetworkIpv6Address.equals(hostIp)) {
+        if (hostManagementNetworkIpv4Address != null && hostIpPredicate.test(hostManagementNetworkIpv4Address) ||
+                hostManagementNetworkIpv6Address != null && hostIpPredicate.test(hostManagementNetworkIpv6Address)) {
             log.info("The management network '{}' is already configured on host '{}'",
                     managementNetworkName,
                     host.getName());


### PR DESCRIPTION
The network configurator was comparing only string
representation of IP addresses which could lead to
trying to setup management network even when there was
already one on the host.

The problem is most obvious for the IPv6, the InetAddress
returns expanded form of address e.g. "fbc::10" becomes
"fbc:0:0:0:0:0:0:10" which compared to the original
unexpanded form fails.

To prevent this use IPAddressPredicate to compare the values,
as the predicate is capable of comparing expanded and
unexpanded form.

Signed-off-by: Ales Musil <amusil@redhat.com>
Bug-Url: https://bugzilla.redhat.com/2061904