### PR TITLE
Add migration support for dedicated policy

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/MigrateVmCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/MigrateVmCommand.java
@@ -618,12 +618,11 @@ public class MigrateVmCommand<T extends MigrateVmParameters> extends RunVmComman
     public void runningSucceded() {
         try {
             queryDowntime();
-            vmDynamicDao.clearMigratingToVds(getVmId());
+            setDedicatedCpus(getDestinationVdsManager());
+            vmDynamicDao.clearMigratingToVdsAndSetDynamicCpuPinning(getVmId(), getVm().getCurrentCpuPinning());
             updateVmAfterMigrationToDifferentCluster();
             plugPassthroughNics();
             initParametersForExternalNetworks(destinationVds, true);
-            setDedicatedCpus(getDestinationVdsManager());
-            vmDynamicDao.update(getVm().getDynamicData());
         } finally {
             super.runningSucceded();
         }

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/StopVmCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/StopVmCommand.java
@@ -32,6 +32,7 @@ public class StopVmCommand<T extends StopVmParameters> extends StopVmCommandBase
             return;
         }
         destroyVm();
+        getVdsManager(getVdsId()).unpinVmCpus(getVm().getId());
         setSucceeded(true);
     }
 

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/VmCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/VmCommand.java
@@ -67,6 +67,7 @@ import org.ovirt.engine.core.dao.network.VmNicDao;
 import org.ovirt.engine.core.utils.transaction.TransactionSuccessListener;
 import org.ovirt.engine.core.utils.transaction.TransactionSupport;
 import org.ovirt.engine.core.vdsbroker.ResourceManager;
+import org.ovirt.engine.core.vdsbroker.VdsManager;
 import org.ovirt.engine.core.vdsbroker.VmManager;
 import org.ovirt.engine.core.vdsbroker.builder.vminfo.VmInfoBuildUtils;
 
@@ -646,5 +647,9 @@ public abstract class VmCommand<T extends VmOperationParameterBase> extends Comm
 
     private boolean shouldBlockDuringBackup() {
         return getParentParameters() == null || getParentParameters().getCommandType() != ActionType.HybridBackup;
+    }
+
+    protected VdsManager getVdsManager(Guid vdsId) {
+        return resourceManager.getVdsManager(vdsId);
     }
 }

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/vdscommands/MigrateVDSCommandParameters.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/vdscommands/MigrateVDSCommandParameters.java
@@ -1,5 +1,6 @@
 package org.ovirt.engine.core.common.vdscommands;
 
+import java.util.List;
 import java.util.Map;
 
 import org.ovirt.engine.core.common.businessentities.MigrationMethod;
@@ -25,6 +26,7 @@ public class MigrateVDSCommandParameters extends VdsAndVmIDVDSParametersBase {
     private Boolean enableGuestEvents;
     private Integer maxIncomingMigrations;
     private Integer maxOutgoingMigrations;
+    private List<String> cpuSets;
 
     private Map<String, Object> convergenceSchedule;
 
@@ -33,7 +35,7 @@ public class MigrateVDSCommandParameters extends VdsAndVmIDVDSParametersBase {
             int migrationDowntime, Boolean autoConverge, Boolean migrateCompressed, Boolean migrateEncrypted,
             String consoleAddress, Integer maxBandwidth, Integer parallelMigrations,
             Map<String, Object> convergenceSchedule, Boolean enableGuestEvents, Integer maxIncomingMigrations,
-            Integer maxOutgoingMigrations) {
+            Integer maxOutgoingMigrations, List<String> cpuSets) {
         super(vdsId, vmId);
         this.srcHost = srcHost;
         this.dstVdsId = dstVdsId;
@@ -53,6 +55,7 @@ public class MigrateVDSCommandParameters extends VdsAndVmIDVDSParametersBase {
         this.enableGuestEvents = enableGuestEvents;
         this.maxIncomingMigrations = maxIncomingMigrations;
         this.maxOutgoingMigrations = maxOutgoingMigrations;
+        this.cpuSets = cpuSets;
     }
 
     public String getSrcHost() {
@@ -175,6 +178,14 @@ public class MigrateVDSCommandParameters extends VdsAndVmIDVDSParametersBase {
         this.maxOutgoingMigrations = maxOutgoingMigrations;
     }
 
+    public List<String> getCpuSets() {
+        return cpuSets;
+    }
+
+    public void setCpuSets(List<String> cpuSets) {
+        this.cpuSets = cpuSets;
+    }
+
     @Override
     protected ToStringBuilder appendAttributes(ToStringBuilder tsb) {
         return super.appendAttributes(tsb)
@@ -194,6 +205,7 @@ public class MigrateVDSCommandParameters extends VdsAndVmIDVDSParametersBase {
                 .append("maxIncomingMigrations", getMaxIncomingMigrations())
                 .append("maxOutgoingMigrations", getMaxOutgoingMigrations())
                 .append("convergenceSchedule", getConvergenceSchedule())
-                .append("dstQemu", getDstQemu());
+                .append("dstQemu", getDstQemu())
+                .append("cpusets", getCpuSets());
     }
 }

--- a/backend/manager/modules/dal/src/main/java/org/ovirt/engine/core/dao/VmDynamicDao.java
+++ b/backend/manager/modules/dal/src/main/java/org/ovirt/engine/core/dao/VmDynamicDao.java
@@ -79,6 +79,8 @@ public interface VmDynamicDao extends GenericDao<VmDynamic, Guid>, StatusAwareDa
 
     void clearMigratingToVds(Guid id);
 
+    void clearMigratingToVdsAndSetDynamicCpuPinning(Guid id, String cpuPinning);
+
 
     /**
      * Update vm dynamics ovirt_guest_agent_status field

--- a/backend/manager/modules/dal/src/main/java/org/ovirt/engine/core/dao/VmDynamicDaoImpl.java
+++ b/backend/manager/modules/dal/src/main/java/org/ovirt/engine/core/dao/VmDynamicDaoImpl.java
@@ -82,6 +82,15 @@ public class VmDynamicDaoImpl extends MassOperationsGenericDao<VmDynamic, Guid>
     }
 
     @Override
+    public void clearMigratingToVdsAndSetDynamicCpuPinning(Guid id, String currentCpuPinning) {
+        MapSqlParameterSource parameterSource = getCustomMapSqlParameterSource()
+                .addValue("vm_guid", id)
+                .addValue("current_cpu_pinning", currentCpuPinning);
+
+        getCallsHandler().executeModification("ClearMigratingToVdsAndSetDynamicCpuPinning", parameterSource);
+    }
+
+    @Override
     public boolean updateConsoleUserWithOptimisticLocking(VmDynamic vm) {
         MapSqlParameterSource parameterSource = getCustomMapSqlParameterSource()
                 .addValue("vm_guid", vm.getId())

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/monitoring/VmAnalyzer.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/monitoring/VmAnalyzer.java
@@ -288,6 +288,7 @@ public class VmAnalyzer {
             }
         }
         destroyVm();
+        vdsManager.unpinVmCpus(getVmId());
 
         // VM is running on another host - must be during migration
         if (!isVmRunningInDatabaseOnMonitoredHost()) {

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/MigrateBrokerVDSCommand.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/MigrateBrokerVDSCommand.java
@@ -77,6 +77,10 @@ public class MigrateBrokerVDSCommand<P extends MigrateVDSCommandParameters> exte
             migrationInfo.put(VdsProperties.MIGRATION_OUTGOING_LIMIT, parameters.getMaxOutgoingMigrations());
         }
 
+        if (parameters.getCpuSets() != null) {
+            migrationInfo.put(VdsProperties.MIGRATION_CPUSETS, parameters.getCpuSets());
+        }
+
         return migrationInfo;
     }
 }

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/VdsProperties.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/VdsProperties.java
@@ -448,6 +448,7 @@ public final class VdsProperties {
     public static final String MIGRATION_DESTINATION = "Migration Destination";
     public static final String MIGRATION_OUTGOING_LIMIT = "outgoingLimit";
     public static final String MIGRATION_INCOMING_LIMIT = "incomingLimit";
+    public static final String MIGRATION_CPUSETS = "cpusets";
 
     // multipath health
     public static final String MULTIPATH_HEALTH = "multipathHealth";

--- a/packaging/dbscripts/vms_sp.sql
+++ b/packaging/dbscripts/vms_sp.sql
@@ -614,6 +614,16 @@ BEGIN
 END;$PROCEDURE$
 LANGUAGE plpgsql;
 
+CREATE OR REPLACE FUNCTION ClearMigratingToVdsAndSetDynamicCpuPinning (v_vm_guid UUID, v_current_cpu_pinning VARCHAR(4000))
+RETURNS VOID AS $PROCEDURE$
+BEGIN
+    UPDATE vm_dynamic
+    SET migrating_to_vds = NULL,
+        current_cpu_pinning = v_current_cpu_pinning
+    WHERE vm_guid = v_vm_guid;
+END;$PROCEDURE$
+LANGUAGE plpgsql;
+
 CREATE OR REPLACE FUNCTION DeleteVmDynamic (v_vm_guid UUID)
 RETURNS VOID AS $PROCEDURE$
 BEGIN


### PR DESCRIPTION
This patch lets dedicated VM to be migrated. It will keep to maintain
the cpuTopology for manual and dedicated pinnings. The `cpusets` sent to
the VM.Migrate verb in VDSM. Where VDSM modify the domxml of `cputune`
to the new pinning.

Change-Id: Ib31de1d26459a3712d0d113418f9fd848a411e3c
Bug-Url: https://bugzilla.redhat.com/1782077
Signed-off-by: Liran Rotenberg <lrotenbe@redhat.com>