### PR TITLE
core: fix resize and pin scheduling

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/policyunits/CpuPinningPolicyUnit.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/policyunits/CpuPinningPolicyUnit.java
@@ -75,6 +75,12 @@ public class CpuPinningPolicyUnit extends PolicyUnitImpl {
         switch (vm.getCpuPinningPolicy()) {
             case MANUAL:
             case RESIZE_AND_PIN_NUMA:
+                if (StringUtils.isEmpty(cpuPinning)) {
+                    // The logic below applies to MigrateVm in which we get here with CPU pinning that was set on the
+                    // source host. On RunVm, we get here before determining the CPU pinning for the VM so the dynamic
+                    // CPU pinning is not set and hosts should not be filtered by the logic below.
+                    return hosts;
+                }
                 // collect all pinned host cpus and merge them into one set
                 final Set<Integer> pinnedCpus = CpuPinningHelper.getAllPinnedPCpus(cpuPinning);
                 for (final VDS host : hosts) {


### PR DESCRIPTION
When running a Resize and Pin NUMA VM, the validation thinks the CPU
pinning already set. But that is incorrect for this flow. It is set only
in the last phase on running the VM. The validation results in an NPE in
such case.

Change-Id: I83cf61d8b5f82187222ca0f2ee5085dde97452c6
Signed-off-by: Liran Rotenberg <lrotenbe@redhat.com>