### PR TITLE
restapi: Add 'seal' parameter for created VMs

### DIFF
--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendVmPoolResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendVmPoolResource.java
@@ -13,6 +13,7 @@ import org.ovirt.engine.api.resource.CreationResource;
 import org.ovirt.engine.api.resource.VmPoolResource;
 import org.ovirt.engine.api.restapi.types.VmMapper;
 import org.ovirt.engine.api.restapi.util.LinkHelper;
+import org.ovirt.engine.api.restapi.util.ParametersHelper;
 import org.ovirt.engine.core.common.VdcObjectType;
 import org.ovirt.engine.core.common.action.ActionParametersBase;
 import org.ovirt.engine.core.common.action.ActionType;
@@ -33,6 +34,8 @@ import org.ovirt.engine.core.compat.Guid;
 public class BackendVmPoolResource
         extends AbstractBackendActionableResource<VmPool, org.ovirt.engine.core.common.businessentities.VmPool>
     implements VmPoolResource {
+
+    public static final String SEAL = "seal";
 
     private BackendVmPoolsResource parent;
 
@@ -141,8 +144,14 @@ public class BackendVmPoolResource
 
             final AddVmPoolParameters parameters = new AddVmPoolParameters(entity, vm, size);
             parameters.setStorageDomainId(getStorageDomainId(vm.getVmtGuid()));
+            setupSealing(parameters);
             return parameters;
         }
+    }
+
+    private void setupSealing(AddVmPoolParameters params) {
+        Boolean seal = ParametersHelper.getBooleanParameter(httpHeaders, uriInfo, SEAL, null, null);
+        params.setSeal(seal);
     }
 
     private Guid getTempalteId(Template template) {

--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendVmPoolsResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendVmPoolsResource.java
@@ -40,6 +40,8 @@ public class BackendVmPoolsResource
         extends AbstractBackendCollectionResource<VmPool, org.ovirt.engine.core.common.businessentities.VmPool>
     implements VmPoolsResource {
 
+    public static final String SEAL = "seal";
+
     public BackendVmPoolsResource() {
         super(VmPool.class, org.ovirt.engine.core.common.businessentities.VmPool.class);
     }
@@ -123,11 +125,17 @@ public class BackendVmPoolsResource
         params.getVmStaticData().setCustomProperties(pool.isSetVm() && pool.getVm().isSetCustomProperties() ?
                 CustomPropertiesParser.parse(pool.getVm().getCustomProperties().getCustomProperties()) : params.getVmStaticData().getCustomProperties());
         params.setTpmEnabled(pool.isSetTpmEnabled() ? pool.isTpmEnabled() : null);
+        setupSealing(params);
 
         return performCreate(ActionType.AddVmPool,
                                params,
                                new QueryIdResolver<Guid>(QueryType.GetVmPoolById,
                                                    IdQueryParameters.class));
+    }
+
+    private void setupSealing(AddVmPoolParameters params) {
+        Boolean seal = ParametersHelper.getBooleanParameter(httpHeaders, uriInfo, SEAL, null, null);
+        params.setSeal(seal);
     }
 
     @Override

--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendVmsResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendVmsResource.java
@@ -103,6 +103,7 @@ public class BackendVmsResource extends
 
     public static final String CLONE = "clone";
     public static final String CLONE_PERMISSIONS = "clone_permissions";
+    public static final String SEAL = "seal";
     public static final String OVF_AS_OVA = "ovf_as_ova";
     public static final String AUTO_PINNING_POLICY = "auto_pinning_policy";
     private static final String LEGAL_CLUSTER_COMPATIBILITY_VERSIONS =
@@ -625,6 +626,7 @@ public class BackendVmsResource extends
         addDevicesToParams(params, vm, template, instanceType, staticVm, cluster);
         IconHelper.setIconToParams(vm, params);
         DisplayHelper.setGraphicsToParams(vm.getDisplay(), params);
+        setupSealing(params);
 
         return performCreate(ActionType.AddVm,
                                params,
@@ -638,6 +640,11 @@ public class BackendVmsResource extends
         }
     }
 
+    private void setupSealing(AddVmParameters params) {
+        Boolean seal = ParametersHelper.getBooleanParameter(httpHeaders, uriInfo, SEAL, null, null);
+        params.setSeal(seal);
+    }
+
     protected Response addVmFromScratch(VmStatic staticVm, Vm vm, InstanceType instanceType, Cluster cluster) {
         AddVmParameters params = new AddVmParameters(staticVm);
         params.setVmPayload(getPayload(vm));
@@ -646,6 +653,7 @@ public class BackendVmsResource extends
         addDevicesToParams(params, vm, null, instanceType, staticVm, cluster);
         IconHelper.setIconToParams(vm, params);
         DisplayHelper.setGraphicsToParams(vm.getDisplay(), params);
+        setupSealing(params);
 
         return performCreate(ActionType.AddVmFromScratch,
                                params,

--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendVmsResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendVmsResource.java
@@ -465,6 +465,7 @@ public class BackendVmsResource extends
         }
 
         DisplayHelper.setGraphicsToParams(vm.getDisplay(), params);
+        setupSealing(params);
 
         return performCreate(ActionType.AddVmFromSnapshot,
                                 params,
@@ -483,6 +484,7 @@ public class BackendVmsResource extends
         addAutoPinningPolicy(vm, params);
         setupCloneTemplatePermissions(params);
         DisplayHelper.setGraphicsToParams(vm.getDisplay(), params);
+        setupSealing(params);
 
         return performCreate(ActionType.AddVmFromTemplate,
                 params,


### PR DESCRIPTION
The 'seal' parameter is added to VM creation and to VM Pool creation and
update, when VMs may be created for the pool.

Change-Id: Ibc053f1e581142d81c3e60cfe251da5187dfa8f4
Bug-Url: https://bugzilla.redhat.com/2054681
Signed-off-by: Shmuel Melamud <smelamud@redhat.com>