### PR TITLE
restapi: do not serialized nullable fields

### DIFF
--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/json/CustomObjectMapperFactory.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/json/CustomObjectMapperFactory.java
@@ -26,7 +26,7 @@ public class CustomObjectMapperFactory {
         return new ObjectMapper()
                 .configure(INDENT_OUTPUT, true)
                 .setAnnotationIntrospector(new JaxbAnnotationIntrospector(TypeFactory.defaultInstance()))
-                .setSerializationInclusion(JsonInclude.Include.USE_DEFAULTS)
+                .setSerializationInclusion(JsonInclude.Include.NON_NULL)
                 .registerModule(new SimpleModule() {
                     @Override
                     public void setupModule(SetupContext context) {


### PR DESCRIPTION
This patch fixes an issue introduced during the migration from codehaus
jackson into fasterxml jackson that resulted in serialization of nulls.
Now such fields are skipped.

Bug-Url: https://bugzilla.redhat.com/2032917
