### PR TITLE
Add VM shared disks to 'OVF STORE' configuration

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ImportVmCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ImportVmCommand.java
@@ -1100,7 +1100,6 @@ public class ImportVmCommand<T extends ImportVmParameters> extends ImportVmComma
                 } else {
                     newDiskIdForDisk.put(disk.getId(), disk);
                 }
-                disk.setCreationDate(new Date());
                 saveImage(disk);
                 ImagesHandler.setDiskAlias(disk, getVm(), ++aliasCounter);
                 saveBaseDisk(disk);

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ImportVmCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ImportVmCommand.java
@@ -475,7 +475,7 @@ public class ImportVmCommand<T extends ImportVmParameters> extends ImportVmComma
 
         // Iterate over all the VM disks (active image and snapshots).
         for (DiskImage image : getImages()) {
-            if (Guid.Empty.equals(image.getVmSnapshotId())) {
+            if (Guid.Empty.equals(image.getVmSnapshotId()) && !image.isShareable()) {
                 return failValidation(EngineMessage.ACTION_TYPE_FAILED_CORRUPTED_VM_SNAPSHOT_ID);
             }
 
@@ -751,7 +751,7 @@ public class ImportVmCommand<T extends ImportVmParameters> extends ImportVmComma
     protected boolean validateNoDuplicateDiskImages(Collection<DiskImage> images) {
         if (!getParameters().isImportAsNewEntity()) {
             DiskImagesValidator diskImagesValidator = new DiskImagesValidator(images);
-            return validate(diskImagesValidator.disksNotExist());
+            return validate(diskImagesValidator.disksNotExistOrShareable());
         }
 
         return true;

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ImportVmCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ImportVmCommand.java
@@ -1102,7 +1102,7 @@ public class ImportVmCommand<T extends ImportVmParameters> extends ImportVmComma
                 saveImage(disk);
                 ImagesHandler.setDiskAlias(disk, getVm(), ++aliasCounter);
                 saveBaseDisk(disk);
-                saveDiskVmElement(disk.getId(), getVmId(), disk.getDiskVmElementForVm(getParameters().getVmId()));
+                saveDiskVmElement(disk);
                 saveDiskImageDynamic(disk);
             }
 
@@ -1128,7 +1128,7 @@ public class ImportVmCommand<T extends ImportVmParameters> extends ImportVmComma
                 ImagesHandler.setDiskAlias(disk, getVm(), ++aliasCounter);
                 updateImage(disk);
                 saveBaseDisk(disk);
-                saveDiskVmElement(disk.getId(), getVmId(), disk.getDiskVmElementForVm(getParameters().getVmId()));
+                saveDiskVmElement(disk);
             }
 
             // Update active snapshot's data, since it was inserted as a regular snapshot.
@@ -1143,40 +1143,44 @@ public class ImportVmCommand<T extends ImportVmParameters> extends ImportVmComma
     }
 
     /**
-     * Saves the base disk object
+     * Saves the base disk object.
      */
     protected void saveBaseDisk(DiskImage disk) {
         baseDiskDao.save(disk);
     }
 
-    protected void saveDiskVmElement(Guid diskId, Guid vmId, DiskVmElement diskVmElement) {
-        diskVmElementDao.save(DiskVmElement.copyOf(diskVmElement, diskId, vmId));
+    /**
+     * Saves the {@code DiskVmElement} object.
+     */
+    protected void saveDiskVmElement(DiskImage disk) {
+        DiskVmElement diskVmElement = disk.getDiskVmElementForVm(getParameters().getVmId());
+        diskVmElementDao.save(DiskVmElement.copyOf(diskVmElement, disk.getId(), getVmId()));
     }
 
     /**
-     * Save the entire image, including it's storage mapping
+     * Save the entire image, including it's storage mapping.
      */
     protected void saveImage(DiskImage disk) {
         imagesHandler.saveImage(disk);
     }
 
     /**
-     * Updates an image of a disk
+     * Updates an image of a disk.
      */
     protected void updateImage(DiskImage disk) {
         imageDao.update(disk.getImage());
     }
 
     /**
-     * Generates and saves a {@link DiskImageDynamic} for the given <code>disk</code>
+     * Generates and saves a {@link DiskImageDynamic} for the given {@code disk}.
      *
-     * @param disk The imported disk
+     * @param disk the disk being imported
      **/
     protected void saveDiskImageDynamic(DiskImage disk) {
-        DiskImageDynamic diskDynamic = new DiskImageDynamic();
-        diskDynamic.setId(disk.getImageId());
-        diskDynamic.setActualSize(disk.getActualSizeInBytes());
-        diskImageDynamicDao.save(diskDynamic);
+        DiskImageDynamic diskImageDynamic = new DiskImageDynamic();
+        diskImageDynamic.setId(disk.getImageId());
+        diskImageDynamic.setActualSize(disk.getActualSizeInBytes());
+        diskImageDynamicDao.save(diskImageDynamic);
     }
 
     /**

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ImportVmFromConfigurationCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ImportVmFromConfigurationCommand.java
@@ -140,7 +140,7 @@ public class ImportVmFromConfigurationCommand<T extends ImportVmFromConfParamete
     private boolean isValidDisks() {
         ImportValidator importValidator = getImportValidator();
         if (isImagesAlreadyOnTarget()) {
-            if (!validate(importValidator.validateDiskImagesNotExist(getImages(),
+            if (!validate(importValidator.validateDiskImagesNotExistOrShareable(getImages(),
                     getParameters().isAllowPartialImport(),
                     imageToDestinationDomainMap,
                     failedDisksToImportForAuditLog))) {

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ImportVmFromConfigurationCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ImportVmFromConfigurationCommand.java
@@ -140,7 +140,7 @@ public class ImportVmFromConfigurationCommand<T extends ImportVmFromConfParamete
     private boolean isValidDisks() {
         ImportValidator importValidator = getImportValidator();
         if (isImagesAlreadyOnTarget()) {
-            if (!validate(importValidator.validateDiskNotAlreadyExistOnDB(getImages(),
+            if (!validate(importValidator.validateDiskImagesNotExist(getImages(),
                     getParameters().isAllowPartialImport(),
                     imageToDestinationDomainMap,
                     failedDisksToImportForAuditLog))) {

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ImportVmTemplateCommandBase.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ImportVmTemplateCommandBase.java
@@ -274,7 +274,7 @@ public abstract class ImportVmTemplateCommandBase<T extends ImportVmTemplatePara
     protected boolean validateNoDuplicateDiskImages(Collection<DiskImage> images) {
         if (!getParameters().isImportAsNewEntity() && !getParameters().isImagesExistOnTargetStorageDomain()) {
             DiskImagesValidator diskImagesValidator = new DiskImagesValidator(images);
-            return validate(diskImagesValidator.diskImagesAlreadyExist());
+            return validate(diskImagesValidator.disksNotExist());
         }
 
         return true;

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ImportVmTemplateCommandBase.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ImportVmTemplateCommandBase.java
@@ -274,7 +274,7 @@ public abstract class ImportVmTemplateCommandBase<T extends ImportVmTemplatePara
     protected boolean validateNoDuplicateDiskImages(Collection<DiskImage> images) {
         if (!getParameters().isImportAsNewEntity() && !getParameters().isImagesExistOnTargetStorageDomain()) {
             DiskImagesValidator diskImagesValidator = new DiskImagesValidator(images);
-            return validate(diskImagesValidator.disksNotExist());
+            return validate(diskImagesValidator.disksNotExistOrShareable());
         }
 
         return true;

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ImportVmTemplateFromConfigurationCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ImportVmTemplateFromConfigurationCommand.java
@@ -201,7 +201,7 @@ public class ImportVmTemplateFromConfigurationCommand<T extends ImportVmTemplate
 
         ImportValidator importValidator = new ImportValidator(getParameters());
 
-        if (!validate(importValidator.validateDiskImagesNotExist(
+        if (!validate(importValidator.validateDiskImagesNotExistOrShareable(
                 getImages(),
                 getParameters().isAllowPartialImport(),
                 imageToDestinationDomainMap,

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ImportVmTemplateFromConfigurationCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ImportVmTemplateFromConfigurationCommand.java
@@ -201,7 +201,7 @@ public class ImportVmTemplateFromConfigurationCommand<T extends ImportVmTemplate
 
         ImportValidator importValidator = new ImportValidator(getParameters());
 
-        if (!validate(importValidator.validateDiskNotAlreadyExistOnDB(
+        if (!validate(importValidator.validateDiskImagesNotExist(
                 getImages(),
                 getParameters().isAllowPartialImport(),
                 imageToDestinationDomainMap,

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/ovfstore/OvfUpdateProcessHelper.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/ovfstore/OvfUpdateProcessHelper.java
@@ -1,7 +1,6 @@
 package org.ovirt.engine.core.bll.storage.ovfstore;
 
 import static org.ovirt.engine.core.bll.storage.disk.image.DisksFilter.ONLY_ACTIVE;
-import static org.ovirt.engine.core.bll.storage.disk.image.DisksFilter.ONLY_SNAPABLE;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -127,7 +126,7 @@ public class OvfUpdateProcessHelper {
 
     public ArrayList<DiskImage> getVmImagesFromDb(VM vm) {
         ArrayList<DiskImage> allVmImages = new ArrayList<>();
-        List<DiskImage> filteredDisks = DisksFilter.filterImageDisks(vm.getDiskList(), ONLY_SNAPABLE, ONLY_ACTIVE);
+        List<DiskImage> filteredDisks = DisksFilter.filterImageDisks(vm.getDiskMap().values(), ONLY_ACTIVE);
 
         for (DiskImage diskImage : filteredDisks) {
             allVmImages.addAll(diskImageDao.getAllSnapshotsForLeaf(diskImage.getImageId()));

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/validator/storage/DiskImagesValidator.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/validator/storage/DiskImagesValidator.java
@@ -39,7 +39,7 @@ import org.ovirt.engine.core.di.Injector;
 import org.ovirt.engine.core.utils.ReplacementUtils;
 
 /**
- * A validator for the {@link DiskImage} class. Since most usecases require validations of multiple {@link DiskImage}s
+ * A validator for the {@link DiskImage} class. Since most use cases require validations of multiple {@link DiskImage}s
  * (e.g., all the disks belonging to a VM/template), this class works on a {@link Collection} of {@link DiskImage}s.
  *
  */
@@ -78,17 +78,17 @@ public class DiskImagesValidator {
     }
 
     /**
-     * Validates that non of the disks exists
+     * Validates that none of the disks exists.
      *
      * @return A {@link ValidationResult} with the validation information.
      */
-    public ValidationResult diskImagesAlreadyExist() {
-
+    public ValidationResult disksNotExist() {
         List<String> existingDisksAliases = new ArrayList<>();
-        for (DiskImage diskImage : diskImages) {
-            Disk existingDisk = getExistingDisk(diskImage.getId());
+        for (Disk newDisk : diskImages) {
+            Disk existingDisk = getExistingDisk(newDisk.getId());
             if (existingDisk != null) {
-                existingDisksAliases.add(diskImage.getDiskAlias().isEmpty() ? existingDisk.getDiskAlias() : diskImage.getDiskAlias());
+                existingDisksAliases.add(
+                        newDisk.getDiskAlias().isEmpty() ? existingDisk.getDiskAlias() : newDisk.getDiskAlias());
             }
         }
 
@@ -101,7 +101,7 @@ public class DiskImagesValidator {
     }
 
     /**
-     * Validates that non of the disk are in the given {@link #status}.
+     * Validates that non of the disk are in the given {@code status}.
      *
      * @param status
      *            The status to check
@@ -109,7 +109,7 @@ public class DiskImagesValidator {
      *            The validation message to return in case of failure.
      * @return A {@link ValidationResult} with the validation information. If none of the disks are in the given status,
      *         {@link ValidationResult#VALID} is returned. If one or more disks are in that status, a
-     *         {@link ValidationResult} with {@link #failMessage} and the names of the disks in that status is returned.
+     *         {@link ValidationResult} with {@code failMessage} and the names of the disks in that status is returned.
      */
     private ValidationResult diskImagesNotInStatus(ImageStatus status, EngineMessage failMessage) {
         List<String> disksInStatus = new ArrayList<>();
@@ -146,7 +146,7 @@ public class DiskImagesValidator {
                     onlyPlugged ? EngineMessage.ACTION_TYPE_FAILED_VM_DISK_SNAPSHOT_IS_PLUGGED_TO_ANOTHER_VM
                             : EngineMessage.ACTION_TYPE_FAILED_VM_DISK_SNAPSHOT_IS_ATTACHED_TO_ANOTHER_VM;
             return new ValidationResult(message,
-                    String.format("$disksInfo %s", String.format(StringUtils.join(pluggedDiskSnapshotInfo, "%n"))));
+                    String.format("$disksInfo %s", StringUtils.join(pluggedDiskSnapshotInfo, "%n")));
         }
 
         return ValidationResult.VALID;
@@ -169,7 +169,7 @@ public class DiskImagesValidator {
         if (!diskSnapshotInfo.isEmpty()) {
             EngineMessage message = EngineMessage.ACTION_TYPE_FAILED_VM_DISK_SNAPSHOT_NOT_ATTACHED_TO_VM;
             return new ValidationResult(message,
-                    String.format("$disksInfo %s", String.format(StringUtils.join(diskSnapshotInfo, "%n"))),
+                    String.format("$disksInfo %s", StringUtils.join(diskSnapshotInfo, "%n")),
                     String.format("$vmName %s", vm.getName()));
         }
 
@@ -197,8 +197,7 @@ public class DiskImagesValidator {
 
         if (!disksInfo.isEmpty()) {
             return new ValidationResult(EngineMessage.ACTION_TYPE_FAILED_DETECTED_DERIVED_DISKS,
-                    String.format("$disksInfo %s",
-                            String.format(StringUtils.join(disksInfo, "%n"))));
+                    String.format("$disksInfo %s", StringUtils.join(disksInfo, "%n")));
         }
 
         return ValidationResult.VALID;

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/validator/storage/DiskImagesValidator.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/validator/storage/DiskImagesValidator.java
@@ -78,15 +78,16 @@ public class DiskImagesValidator {
     }
 
     /**
-     * Validates that none of the disks exists.
+     * Validates that none of the new disks already exists in the database
+     * or that both the existing and the new disks are shareable.
      *
      * @return A {@link ValidationResult} with the validation information.
      */
-    public ValidationResult disksNotExist() {
+    public ValidationResult disksNotExistOrShareable() {
         List<String> existingDisksAliases = new ArrayList<>();
         for (Disk newDisk : diskImages) {
             Disk existingDisk = getExistingDisk(newDisk.getId());
-            if (existingDisk != null) {
+            if (!diskNotExistsOrBothShareable(existingDisk, newDisk)) {
                 existingDisksAliases.add(
                         newDisk.getDiskAlias().isEmpty() ? existingDisk.getDiskAlias() : newDisk.getDiskAlias());
             }
@@ -98,6 +99,11 @@ public class DiskImagesValidator {
         }
 
         return ValidationResult.VALID;
+    }
+
+    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
+    public static boolean diskNotExistsOrBothShareable(Disk existingDisk, Disk newDisk) {
+        return existingDisk == null || existingDisk.isShareable() && newDisk.isShareable();
     }
 
     /**

--- a/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/exportimport/ImportVmCommandTest.java
+++ b/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/exportimport/ImportVmCommandTest.java
@@ -425,7 +425,7 @@ public class ImportVmCommandTest extends BaseCommandTest {
         doNothing().when(cmd).saveImage(collapsedDisk);
         doNothing().when(cmd).saveBaseDisk(collapsedDisk);
         doNothing().when(cmd).saveDiskImageDynamic(collapsedDisk);
-        doNothing().when(cmd).saveDiskVmElement(any(), any(), any());
+        doNothing().when(cmd).saveDiskVmElement(collapsedDisk);
         doReturn(new Snapshot()).when(cmd).addActiveSnapshot(any());
         cmd.addVmImagesAndSnapshots();
         assertEquals("testVm_Disk1", collapsedDisk.getDiskAlias(), "Disk alias not generated.");
@@ -461,7 +461,7 @@ public class ImportVmCommandTest extends BaseCommandTest {
         doNothing().when(cmd).updateImage(activeDisk);
         doNothing().when(cmd).saveBaseDisk(activeDisk);
         doNothing().when(cmd).updateActiveSnapshot(any());
-        doNothing().when(cmd).saveDiskVmElement(any(), any(), any());
+        doNothing().when(cmd).saveDiskVmElement(activeDisk);
 
         cmd.addVmImagesAndSnapshots();
         assertEquals("testVm_Disk1", activeDisk.getDiskAlias(), "Disk alias not generated.");
@@ -480,7 +480,7 @@ public class ImportVmCommandTest extends BaseCommandTest {
         doNothing().when(cmd).saveImage(activeDisk);
         doNothing().when(cmd).saveDiskImageDynamic(activeDisk);
         doNothing().when(cmd).saveBaseDisk(activeDisk);
-        doNothing().when(cmd).saveDiskVmElement(any(), any(), any());
+        doNothing().when(cmd).saveDiskVmElement(activeDisk);
         doReturn(new Snapshot()).when(cmd).addActiveSnapshot(any());
 
         cmd.addVmImagesAndSnapshots();

--- a/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/exportimport/ImportVmCommandTest.java
+++ b/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/exportimport/ImportVmCommandTest.java
@@ -66,7 +66,6 @@ import org.ovirt.engine.core.common.errors.EngineMessage;
 import org.ovirt.engine.core.common.osinfo.OsRepository;
 import org.ovirt.engine.core.common.utils.Pair;
 import org.ovirt.engine.core.common.utils.ValidationUtils;
-import org.ovirt.engine.core.common.utils.VmDeviceType;
 import org.ovirt.engine.core.compat.Guid;
 import org.ovirt.engine.core.compat.Version;
 import org.ovirt.engine.core.utils.MockConfigDescriptor;
@@ -74,7 +73,6 @@ import  org.ovirt.engine.core.utils.MockedConfig;
 import org.ovirt.engine.core.utils.RandomUtils;
 import org.ovirt.engine.core.utils.RandomUtilsSeedingExtension;
 import org.ovirt.engine.core.vdsbroker.vdsbroker.CloudInitHandler;
-import org.ovirt.engine.core.vdsbroker.vdsbroker.VdsProperties;
 
 @ExtendWith(RandomUtilsSeedingExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -186,17 +184,6 @@ public class ImportVmCommandTest extends BaseCommandTest {
                 EngineMessage.ACTION_TYPE_FAILED_DISK_SPACE_LOW_ON_STORAGE_DOMAIN);
     }
 
-    private void addBalloonToVm(VM vm) {
-        Guid deviceId = Guid.newGuid();
-        Map<String, Object> specParams = new HashMap<>();
-        specParams.put(VdsProperties.Model, VdsProperties.Virtio);
-        VmDevice balloon = new VmDevice(new VmDeviceId(deviceId, vm.getId()),
-                VmDeviceGeneralType.BALLOON, VmDeviceType.MEMBALLOON.toString(), null, specParams,
-                true, true, true, null, null, null, null);
-
-        vm.getManagedVmDeviceMap().put(deviceId, balloon);
-    }
-
     private void addSoundDeviceToVm(VM vm) {
         Guid deviceId = Guid.newGuid();
         Map<String, Object> specParams = new HashMap<>();
@@ -227,7 +214,8 @@ public class ImportVmCommandTest extends BaseCommandTest {
         setupCanImportPpcTest();
 
         addSoundDeviceToVm(cmd.getVmFromExportDomain(null));
-        when(osRepository.isSoundDeviceEnabled(cmd.getParameters().getVm().getVmOsId(), cmd.getCluster().getCompatibilityVersion())).thenReturn(false);
+        when(osRepository.isSoundDeviceEnabled(cmd.getParameters().getVm().getVmOsId(), cmd.getCluster().getCompatibilityVersion()))
+                .thenReturn(false);
 
         assertFalse(cmd.validate());
         assertTrue(cmd.getReturnValue()
@@ -272,14 +260,14 @@ public class ImportVmCommandTest extends BaseCommandTest {
     }
 
     protected VM createVmWithSnapshots() {
-        final VM v = new VM();
-        v.setId(Guid.newGuid());
+        final VM vm = new VM();
+        vm.setId(Guid.newGuid());
 
         Snapshot baseSnapshot = new Snapshot();
-        baseSnapshot.setVmId(v.getId());
+        baseSnapshot.setVmId(vm.getId());
 
         Snapshot activeSnapshot = new Snapshot();
-        activeSnapshot.setVmId(v.getId());
+        activeSnapshot.setVmId(vm.getId());
 
         DiskImage baseImage = createDiskImage(Guid.newGuid(), Guid.newGuid(), baseSnapshot.getId(), false);
         DiskImage activeImage =
@@ -288,38 +276,39 @@ public class ImportVmCommandTest extends BaseCommandTest {
         baseSnapshot.setDiskImages(Collections.singletonList(baseImage));
         activeSnapshot.setDiskImages(Collections.singletonList(activeImage));
 
-        v.setDiskMap(Collections.singletonMap(activeImage.getId(), activeImage));
-        v.setImages(new ArrayList<>(Arrays.asList(baseImage, activeImage)));
-        v.setSnapshots(new ArrayList<>(Arrays.asList(baseSnapshot, activeSnapshot)));
-        v.setClusterId(Guid.Empty);
-        v.setBiosType(BiosType.Q35_SEA_BIOS);
+        vm.setDiskMap(Collections.singletonMap(activeImage.getId(), activeImage));
+        vm.setImages(new ArrayList<>(Arrays.asList(baseImage, activeImage)));
+        vm.setSnapshots(new ArrayList<>(Arrays.asList(baseSnapshot, activeSnapshot)));
+        vm.setClusterId(Guid.Empty);
+        vm.setBiosType(BiosType.Q35_SEA_BIOS);
 
-        return v;
+        return vm;
     }
 
     protected VM createVmWithNoSnapshots() {
-        final VM v = new VM();
-        v.setId(Guid.newGuid());
+        final VM vm = new VM();
+        vm.setId(Guid.newGuid());
 
         Snapshot activeSnapshot = new Snapshot();
-        activeSnapshot.setVmId(v.getId());
+        activeSnapshot.setVmId(vm.getId());
         DiskImage activeImage = createDiskImage(Guid.newGuid(), Guid.newGuid(), activeSnapshot.getId(), true);
         activeSnapshot.setDiskImages(Collections.singletonList(activeImage));
 
-        v.setImages(new ArrayList<>(Collections.singletonList(activeImage)));
-        v.setSnapshots(new ArrayList<>(Collections.singletonList(activeSnapshot)));
-        v.setDiskMap(Collections.singletonMap(activeImage.getId(), activeImage));
-        v.setClusterId(Guid.Empty);
-        v.setBiosType(BiosType.Q35_SEA_BIOS);
-        return v;
+        vm.setImages(new ArrayList<>(Collections.singletonList(activeImage)));
+        vm.setSnapshots(new ArrayList<>(Collections.singletonList(activeSnapshot)));
+        vm.setDiskMap(Collections.singletonMap(activeImage.getId(), activeImage));
+        vm.setClusterId(Guid.Empty);
+        vm.setBiosType(BiosType.Q35_SEA_BIOS);
+
+        return vm;
     }
 
-    private DiskImage createDiskImage(Guid imageGroupId, Guid parentImageId, Guid vmSnapshoId, boolean active) {
+    private DiskImage createDiskImage(Guid imageGroupId, Guid parentImageId, Guid vmSnapshotId, boolean active) {
         DiskImage disk = new DiskImage();
         disk.setId(imageGroupId);
         disk.setImageId(Guid.newGuid());
         disk.setSizeInGigabytes(1);
-        disk.setVmSnapshotId(vmSnapshoId);
+        disk.setVmSnapshotId(vmSnapshotId);
         disk.setActive(active);
         disk.setParentId(parentImageId);
 
@@ -365,9 +354,9 @@ public class ImportVmCommandTest extends BaseCommandTest {
         cmd.getParameters().getVm().setName(name);
         cmd.getParameters().setImportAsNewEntity(isImportAsNewEntity);
         cmd.init();
-        Set<ConstraintViolation<ImportVmParameters>> validate =
-                ValidationUtils.getValidator().validate(cmd.getParameters(),
-                        cmd.getValidationGroups().toArray(new Class<?>[0]));
+        Set<ConstraintViolation<ImportVmParameters>> validate = ValidationUtils.getValidator().validate(
+                cmd.getParameters(),
+                cmd.getValidationGroups().toArray(new Class<?>[0]));
         assertFalse(validate.isEmpty());
     }
 
@@ -382,20 +371,21 @@ public class ImportVmCommandTest extends BaseCommandTest {
         cmd.getParameters().getVm().setUserDefinedProperties(tooLongString);
         cmd.getParameters().setImportAsNewEntity(true);
         cmd.init();
-        Set<ConstraintViolation<ImportVmParameters>> validate =
-                ValidationUtils.getValidator().validate(cmd.getParameters(),
-                        cmd.getValidationGroups().toArray(new Class<?>[0]));
+        Set<ConstraintViolation<ImportVmParameters>> validate = ValidationUtils.getValidator().validate(
+                cmd.getParameters(),
+                cmd.getValidationGroups().toArray(new Class<?>[0]));
         assertTrue(validate.isEmpty());
         cmd.getParameters().getVm().setUserDefinedProperties(tooLongString);
         cmd.getParameters().setImportAsNewEntity(false);
         cmd.init();
-        validate = ValidationUtils.getValidator()
-                .validate(cmd.getParameters(), cmd.getValidationGroups().toArray(new Class<?>[0]));
+        validate = ValidationUtils.getValidator().validate(
+                cmd.getParameters(),
+                cmd.getValidationGroups().toArray(new Class<?>[0]));
         assertTrue(validate.isEmpty());
     }
 
     /**
-     * Checking that managed device are sync with the new Guids of disk
+     * Checking that managed device are sync with the new Guids of disk.
      */
     @Test
     @MockedConfig("mockConfiguration")
@@ -418,9 +408,9 @@ public class ImportVmCommandTest extends BaseCommandTest {
         assertEquals(beforeOldDiskId, oldDiskId,
                 "The old disk id should be similar to the value at the newDiskIdForDisk.");
         assertNotNull(managedDevices.get(disk.getId()),
-                "The manged device should return the disk device by the new key");
+                "The managed device should return the disk device by the new key.");
         assertNull(managedDevices.get(beforeOldDiskId),
-                "The manged device should not return the disk device by the old key");
+                "The managed device should not return the disk device by the old key.");
     }
 
     /* Tests for alias generation in addVmImagesAndSnapshots() */
@@ -438,7 +428,7 @@ public class ImportVmCommandTest extends BaseCommandTest {
         doNothing().when(cmd).saveDiskVmElement(any(), any(), any());
         doReturn(new Snapshot()).when(cmd).addActiveSnapshot(any());
         cmd.addVmImagesAndSnapshots();
-        assertEquals("testVm_Disk1", collapsedDisk.getDiskAlias(), "Disk alias not generated");
+        assertEquals("testVm_Disk1", collapsedDisk.getDiskAlias(), "Disk alias not generated.");
     }
 
     /* Test import images with empty Guid is failing */
@@ -474,7 +464,7 @@ public class ImportVmCommandTest extends BaseCommandTest {
         doNothing().when(cmd).saveDiskVmElement(any(), any(), any());
 
         cmd.addVmImagesAndSnapshots();
-        assertEquals("testVm_Disk1", activeDisk.getDiskAlias(), "Disk alias not generated");
+        assertEquals("testVm_Disk1", activeDisk.getDiskAlias(), "Disk alias not generated.");
     }
 
     @Test
@@ -494,6 +484,6 @@ public class ImportVmCommandTest extends BaseCommandTest {
         doReturn(new Snapshot()).when(cmd).addActiveSnapshot(any());
 
         cmd.addVmImagesAndSnapshots();
-        assertEquals("testVm_Disk1", activeDisk.getDiskAlias(), "Disk alias not generated");
+        assertEquals("testVm_Disk1", activeDisk.getDiskAlias(), "Disk alias not generated.");
     }
 }

--- a/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/validator/storage/DiskImagesValidatorTest.java
+++ b/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/validator/storage/DiskImagesValidatorTest.java
@@ -137,9 +137,9 @@ public class DiskImagesValidatorTest {
     }
 
     @Test
-    public void disksNotExistBothExist() {
+    public void disksNotExistOrShareableBothExist() {
         doReturn(new DiskImage()).when(validator).getExistingDisk(any());
-        assertThat(validator.disksNotExist(),
+        assertThat(validator.disksNotExistOrShareable(),
                 both(failsWith(EngineMessage.ACTION_TYPE_FAILED_IMPORT_DISKS_ALREADY_EXIST))
                         .and(replacements(hasItem(createAliasReplacements(disk1, disk2)))));
     }
@@ -149,7 +149,7 @@ public class DiskImagesValidatorTest {
      * the CDA message should be taken from the disks existing on the setup.
      */
     @Test
-    public void disksNotExistDisksWithNullAlias() {
+    public void disksNotExistOrShareableDisksWithNullAlias() {
         disk1.setDiskAlias(null);
         disk2.setDiskAlias(null);
         DiskImage existingImage1 = new DiskImage();
@@ -159,24 +159,24 @@ public class DiskImagesValidatorTest {
 
         doReturn(existingImage1).when(validator).getExistingDisk(disk1.getId());
         doReturn(existingImage2).when(validator).getExistingDisk(disk2.getId());
-        assertThat(validator.disksNotExist(),
+        assertThat(validator.disksNotExistOrShareable(),
                 both(failsWith(EngineMessage.ACTION_TYPE_FAILED_IMPORT_DISKS_ALREADY_EXIST))
                         .and(replacements(hasItem(createAliasReplacements(existingImage1, existingImage2)))));
     }
 
     @Test
-    public void disksNotExistOneExists() {
+    public void disksNotExistOrShareableOneExists() {
         doReturn(new DiskImage()).when(validator).getExistingDisk(disk1.getId());
         doReturn(null).when(validator).getExistingDisk(disk2.getId());
-        assertThat(validator.disksNotExist(),
+        assertThat(validator.disksNotExistOrShareable(),
                 both(failsWith(EngineMessage.ACTION_TYPE_FAILED_IMPORT_DISKS_ALREADY_EXIST))
                         .and(replacements(hasItem(createAliasReplacements(disk1)))));
     }
 
     @Test
-    public void disksNotExistBothNotExist() {
+    public void disksNotExistOrShareableBothNotExist() {
         doReturn(null).when(validator).getExistingDisk(any());
-        assertThat(validator.disksNotExist(), isValid());
+        assertThat(validator.disksNotExistOrShareable(), isValid());
     }
 
     @Test

--- a/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/validator/storage/DiskImagesValidatorTest.java
+++ b/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/validator/storage/DiskImagesValidatorTest.java
@@ -101,7 +101,9 @@ public class DiskImagesValidatorTest {
     }
 
     private static String createAliasReplacements(DiskImage... disks) {
-        return Arrays.stream(disks).map(DiskImage::getDiskAlias).collect(Collectors.joining(", ", "$diskAliases ", ""));
+        return Arrays.stream(disks)
+                .map(DiskImage::getDiskAlias)
+                .collect(Collectors.joining(", ", "$diskAliases ", ""));
     }
 
     @Test
@@ -113,14 +115,16 @@ public class DiskImagesValidatorTest {
     public void diskImagesNotIllegalFirstIllegal() {
         disk1.setImageStatus(ImageStatus.ILLEGAL);
         assertThat(validator.diskImagesNotIllegal(),
-                both(failsWith(EngineMessage.ACTION_TYPE_FAILED_DISKS_ILLEGAL)).and(replacements(hasItem(createAliasReplacements(disk1)))));
+                both(failsWith(EngineMessage.ACTION_TYPE_FAILED_DISKS_ILLEGAL))
+                        .and(replacements(hasItem(createAliasReplacements(disk1)))));
     }
 
     @Test
-    public void diskImagesNotIllegalSecondtIllegal() {
+    public void diskImagesNotIllegalSecondIllegal() {
         disk2.setImageStatus(ImageStatus.ILLEGAL);
         assertThat(validator.diskImagesNotIllegal(),
-                both(failsWith(EngineMessage.ACTION_TYPE_FAILED_DISKS_ILLEGAL)).and(replacements(hasItem(createAliasReplacements(disk2)))));
+                both(failsWith(EngineMessage.ACTION_TYPE_FAILED_DISKS_ILLEGAL))
+                        .and(replacements(hasItem(createAliasReplacements(disk2)))));
     }
 
     @Test
@@ -128,24 +132,24 @@ public class DiskImagesValidatorTest {
         disk1.setImageStatus(ImageStatus.ILLEGAL);
         disk2.setImageStatus(ImageStatus.ILLEGAL);
         assertThat(validator.diskImagesNotIllegal(),
-                both(failsWith(EngineMessage.ACTION_TYPE_FAILED_DISKS_ILLEGAL)).and(replacements
-                        (hasItem(createAliasReplacements(disk1, disk2)))));
+                both(failsWith(EngineMessage.ACTION_TYPE_FAILED_DISKS_ILLEGAL))
+                        .and(replacements(hasItem(createAliasReplacements(disk1, disk2)))));
     }
 
     @Test
     public void diskImagesAlreadyExistBothExist() {
         doReturn(new DiskImage()).when(validator).getExistingDisk(any());
         assertThat(validator.diskImagesAlreadyExist(),
-                both(failsWith(EngineMessage.ACTION_TYPE_FAILED_IMPORT_DISKS_ALREADY_EXIST)).and(replacements
-                        (hasItem(createAliasReplacements(disk1, disk2)))));
+                both(failsWith(EngineMessage.ACTION_TYPE_FAILED_IMPORT_DISKS_ALREADY_EXIST))
+                        .and(replacements(hasItem(createAliasReplacements(disk1, disk2)))));
     }
 
     /**
      * Test a case when the two validated disks exists and have a null disk alias, in that case the disk aliases in
-     * the CDA message should be taken from the disks existing on the setup
+     * the CDA message should be taken from the disks existing on the setup.
      */
     @Test
-    public void diskImagesAlreadyDiskInImportWithNullAlias() {
+    public void diskImagesAlreadyExistDisksWithNullAlias() {
         disk1.setDiskAlias(null);
         disk2.setDiskAlias(null);
         DiskImage existingImage1 = new DiskImage();
@@ -156,18 +160,17 @@ public class DiskImagesValidatorTest {
         doReturn(existingImage1).when(validator).getExistingDisk(disk1.getId());
         doReturn(existingImage2).when(validator).getExistingDisk(disk2.getId());
         assertThat(validator.diskImagesAlreadyExist(),
-                both(failsWith(EngineMessage.ACTION_TYPE_FAILED_IMPORT_DISKS_ALREADY_EXIST)).and(replacements
-                        (hasItem(createAliasReplacements(existingImage1, existingImage2)))));
+                both(failsWith(EngineMessage.ACTION_TYPE_FAILED_IMPORT_DISKS_ALREADY_EXIST))
+                        .and(replacements(hasItem(createAliasReplacements(existingImage1, existingImage2)))));
     }
-
 
     @Test
     public void diskImagesAlreadyExistOneExist() {
         doReturn(new DiskImage()).when(validator).getExistingDisk(disk1.getId());
         doReturn(null).when(validator).getExistingDisk(disk2.getId());
         assertThat(validator.diskImagesAlreadyExist(),
-                both(failsWith(EngineMessage.ACTION_TYPE_FAILED_IMPORT_DISKS_ALREADY_EXIST)).and(replacements
-                        (hasItem(createAliasReplacements(disk1)))));
+                both(failsWith(EngineMessage.ACTION_TYPE_FAILED_IMPORT_DISKS_ALREADY_EXIST))
+                        .and(replacements(hasItem(createAliasReplacements(disk1)))));
     }
 
     @Test
@@ -178,21 +181,23 @@ public class DiskImagesValidatorTest {
 
     @Test
     public void diskImagesNotLockedBothOK() {
-        assertThat("Neither disk is Locked", validator.diskImagesNotLocked(), isValid());
+        assertThat("Neither disk is locked", validator.diskImagesNotLocked(), isValid());
     }
 
     @Test
     public void diskImagesNotLockedFirstLocked() {
         disk1.setImageStatus(ImageStatus.LOCKED);
         assertThat(validator.diskImagesNotLocked(),
-                both(failsWith(EngineMessage.ACTION_TYPE_FAILED_DISKS_LOCKED)).and(replacements(hasItem(createAliasReplacements(disk1)))));
+                both(failsWith(EngineMessage.ACTION_TYPE_FAILED_DISKS_LOCKED))
+                        .and(replacements(hasItem(createAliasReplacements(disk1)))));
     }
 
     @Test
-    public void diskImagesNotLockedSecondtLocked() {
+    public void diskImagesNotLockedSecondLocked() {
         disk2.setImageStatus(ImageStatus.LOCKED);
         assertThat(validator.diskImagesNotLocked(),
-                both(failsWith(EngineMessage.ACTION_TYPE_FAILED_DISKS_LOCKED)).and(replacements(hasItem(createAliasReplacements(disk2)))));
+                both(failsWith(EngineMessage.ACTION_TYPE_FAILED_DISKS_LOCKED))
+                        .and(replacements(hasItem(createAliasReplacements(disk2)))));
     }
 
     @Test
@@ -217,8 +222,7 @@ public class DiskImagesValidatorTest {
     @Test
     public void diskImagesHasDerivedDisksNoStorageDomainSpecifiedSuccess() {
         disk1.setVmEntityType(VmEntityType.TEMPLATE);
-        assertThat(validator.diskImagesHaveNoDerivedDisks(null),
-                isValid());
+        assertThat(validator.diskImagesHaveNoDerivedDisks(null), isValid());
     }
 
     @Test

--- a/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/validator/storage/DiskImagesValidatorTest.java
+++ b/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/validator/storage/DiskImagesValidatorTest.java
@@ -137,9 +137,9 @@ public class DiskImagesValidatorTest {
     }
 
     @Test
-    public void diskImagesAlreadyExistBothExist() {
+    public void disksNotExistBothExist() {
         doReturn(new DiskImage()).when(validator).getExistingDisk(any());
-        assertThat(validator.diskImagesAlreadyExist(),
+        assertThat(validator.disksNotExist(),
                 both(failsWith(EngineMessage.ACTION_TYPE_FAILED_IMPORT_DISKS_ALREADY_EXIST))
                         .and(replacements(hasItem(createAliasReplacements(disk1, disk2)))));
     }
@@ -149,7 +149,7 @@ public class DiskImagesValidatorTest {
      * the CDA message should be taken from the disks existing on the setup.
      */
     @Test
-    public void diskImagesAlreadyExistDisksWithNullAlias() {
+    public void disksNotExistDisksWithNullAlias() {
         disk1.setDiskAlias(null);
         disk2.setDiskAlias(null);
         DiskImage existingImage1 = new DiskImage();
@@ -159,24 +159,24 @@ public class DiskImagesValidatorTest {
 
         doReturn(existingImage1).when(validator).getExistingDisk(disk1.getId());
         doReturn(existingImage2).when(validator).getExistingDisk(disk2.getId());
-        assertThat(validator.diskImagesAlreadyExist(),
+        assertThat(validator.disksNotExist(),
                 both(failsWith(EngineMessage.ACTION_TYPE_FAILED_IMPORT_DISKS_ALREADY_EXIST))
                         .and(replacements(hasItem(createAliasReplacements(existingImage1, existingImage2)))));
     }
 
     @Test
-    public void diskImagesAlreadyExistOneExist() {
+    public void disksNotExistOneExists() {
         doReturn(new DiskImage()).when(validator).getExistingDisk(disk1.getId());
         doReturn(null).when(validator).getExistingDisk(disk2.getId());
-        assertThat(validator.diskImagesAlreadyExist(),
+        assertThat(validator.disksNotExist(),
                 both(failsWith(EngineMessage.ACTION_TYPE_FAILED_IMPORT_DISKS_ALREADY_EXIST))
                         .and(replacements(hasItem(createAliasReplacements(disk1)))));
     }
 
     @Test
-    public void diskImagesAlreadyExistBothDoesntExist() {
+    public void disksNotExistBothNotExist() {
         doReturn(null).when(validator).getExistingDisk(any());
-        assertThat(validator.diskImagesAlreadyExist(), isValid());
+        assertThat(validator.disksNotExist(), isValid());
     }
 
     @Test


### PR DESCRIPTION
Until now the VM shared disks were not part of the 'OVF STORE' configuration.
Adding them to be part of the 'OVF STORE' configuration.
That allows VMs to share disks, move to another environment (`Storage Domain` Detach & Attach) and after being imported still share the same disks without any additional configuration.
Previously those shared disks' configuration was "lost along the way".

Signed-off-by: Pavel Bar <pbar@redhat.com>
Bug-Url: https://bugzilla.redhat.com/1922977