### PR TITLE
core: mark command as failed if no hosts are found

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/ConvertDiskCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/ConvertDiskCommand.java
@@ -134,6 +134,7 @@ public class ConvertDiskCommand<T extends ConvertDiskCommandParameters> extends 
                 FeatureSupported::isConvertDiskSupported);
         if (Guid.isNullOrEmpty(hostForExecution)) {
             log.error("Could not find a host to perform conversion");
+            setCommandStatus(CommandStatus.FAILED);
             return;
         }
 


### PR DESCRIPTION
If no hosts are found ConvertDiskCommand will exit, having execution status failed, but since it is an async command, it will execute endSuccessfully because no child commands failed.

By setting CommandStatus to FAILED, this patch will force the command to go endWithFailure.

Bug: https://bugzilla.redhat.com/2063802