### PR TITLE
spec: Add dependency on scap-security-guide

### DIFF
--- a/ovirt-engine.spec.in
+++ b/ovirt-engine.spec.in
@@ -339,6 +339,8 @@ Requires:	fapolicyd >= 1.1
 Requires:	fapolicyd
 %endif
 
+Requires:	scap-security-guide >= 0.1.60-4
+
 # Metrics stuff
 Requires:	collectd
 Requires:	collectd-postgresql


### PR DESCRIPTION
Add dependency on scap-security-guide that contains
all fixes for RHV.

Signed-off-by: Ales Musil <amusil@redhat.com>