### PR TITLE
core: support backup in convert disk

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/CreateVolumeContainerCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/CreateVolumeContainerCommand.java
@@ -13,6 +13,7 @@ import org.ovirt.engine.core.bll.NonTransactiveCommandAttribute;
 import org.ovirt.engine.core.bll.context.CommandContext;
 import org.ovirt.engine.core.bll.utils.PermissionSubject;
 import org.ovirt.engine.core.common.VdcObjectType;
+import org.ovirt.engine.core.common.action.ActionType;
 import org.ovirt.engine.core.common.action.CreateVolumeContainerCommandParameters;
 import org.ovirt.engine.core.common.asynctasks.AsyncTaskType;
 import org.ovirt.engine.core.common.businessentities.storage.DiskContentType;
@@ -80,6 +81,10 @@ public class CreateVolumeContainerCommand<T extends CreateVolumeContainerCommand
     }
 
     private VolumeType getType() {
+        if (getParentParameters() != null && getParentParameters().getParentCommand() == ActionType.ConvertDisk) {
+            return getParameters().getVolumeType();
+        }
+
         // For raw volume on file-based domain we cannot determine
         // the type according to the format because since 4.3 engine support
         // raw-preallocate file volume on a file-based storage domain

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/ConvertDiskCommandParameters.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/ConvertDiskCommandParameters.java
@@ -1,6 +1,7 @@
 package org.ovirt.engine.core.common.action;
 
 import org.ovirt.engine.core.common.businessentities.LocationInfo;
+import org.ovirt.engine.core.common.businessentities.storage.DiskBackup;
 import org.ovirt.engine.core.common.businessentities.storage.VolumeFormat;
 import org.ovirt.engine.core.common.businessentities.storage.VolumeType;
 import org.ovirt.engine.core.compat.Guid;
@@ -12,6 +13,7 @@ public class ConvertDiskCommandParameters extends ImagesContainterParametersBase
     private VolumeFormat volumeFormat;
     private VolumeType preallocation;
     private Guid newVolGuid;
+    private DiskBackup backup;
 
     private ConvertDiskPhase convertDiskPhase = ConvertDiskPhase.CREATE_TARGET_VOLUME;
 
@@ -57,6 +59,14 @@ public class ConvertDiskCommandParameters extends ImagesContainterParametersBase
 
     public void setConvertDiskPhase(ConvertDiskPhase convertDiskPhase) {
         this.convertDiskPhase = convertDiskPhase;
+    }
+
+    public DiskBackup getBackup() {
+        return backup;
+    }
+
+    public void setBackup(DiskBackup backup) {
+        this.backup = backup;
     }
 
     public enum ConvertDiskPhase {

--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendDiskResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendDiskResource.java
@@ -14,6 +14,7 @@ import org.apache.commons.lang.StringUtils;
 import org.ovirt.engine.api.model.Action;
 import org.ovirt.engine.api.model.BaseResource;
 import org.ovirt.engine.api.model.Disk;
+import org.ovirt.engine.api.model.DiskBackup;
 import org.ovirt.engine.api.model.DiskFormat;
 import org.ovirt.engine.api.model.StorageDomain;
 import org.ovirt.engine.api.model.Vm;
@@ -266,6 +267,12 @@ public class BackendDiskResource
 
         if (action.getDisk().isSetFormat()) {
             parameters.setVolumeFormat(action.getDisk().getFormat() == DiskFormat.RAW ? VolumeFormat.RAW : VolumeFormat.COW);
+        }
+
+        if (action.getDisk().isSetBackup()) {
+            parameters.setBackup(action.getDisk().getBackup() == DiskBackup.INCREMENTAL ?
+                    org.ovirt.engine.core.common.businessentities.storage.DiskBackup.Incremental :
+                    org.ovirt.engine.core.common.businessentities.storage.DiskBackup.None);
         }
 
         return doAction(ActionType.ConvertDisk, parameters, action);


### PR DESCRIPTION
Support sending backup mode when converting disks. This will allow converting a disk to cow-preallocated in one request.