### PR TITLE
Default empty 'seal' argument to true

### DIFF
--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendVmPoolResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendVmPoolResource.java
@@ -150,7 +150,7 @@ public class BackendVmPoolResource
     }
 
     private void setupSealing(AddVmPoolParameters params) {
-        Boolean seal = ParametersHelper.getBooleanParameter(httpHeaders, uriInfo, SEAL, null, null);
+        Boolean seal = ParametersHelper.getBooleanParameter(httpHeaders, uriInfo, SEAL, Boolean.TRUE, null);
         params.setSeal(seal);
     }
 

--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendVmPoolsResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendVmPoolsResource.java
@@ -134,7 +134,7 @@ public class BackendVmPoolsResource
     }
 
     private void setupSealing(AddVmPoolParameters params) {
-        Boolean seal = ParametersHelper.getBooleanParameter(httpHeaders, uriInfo, SEAL, null, null);
+        Boolean seal = ParametersHelper.getBooleanParameter(httpHeaders, uriInfo, SEAL, Boolean.TRUE, null);
         params.setSeal(seal);
     }
 

--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendVmsResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendVmsResource.java
@@ -643,7 +643,7 @@ public class BackendVmsResource extends
     }
 
     private void setupSealing(AddVmParameters params) {
-        Boolean seal = ParametersHelper.getBooleanParameter(httpHeaders, uriInfo, SEAL, null, null);
+        Boolean seal = ParametersHelper.getBooleanParameter(httpHeaders, uriInfo, SEAL, Boolean.TRUE, null);
         params.setSeal(seal);
     }
 


### PR DESCRIPTION
When specifying the 'seal' argument on the API without a value, it will be considered as TRUE