### PR TITLE
Eliminate a race between AddVmTemplate and UpdateVmVersion

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/AddVmTemplateCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/AddVmTemplateCommand.java
@@ -1054,6 +1054,7 @@ public class AddVmTemplateCommand<T extends AddVmTemplateParameters> extends VmT
         restoreCommandState();
 
         vmStaticDao.incrementDbGeneration(getVmTemplateId());
+        freeLock();
         if (reloadVmTemplateFromDB() != null) {
             endDefaultOperations();
         }


### PR DESCRIPTION
We've noticed a race in our **beloved testing framework** (OST) between AddVmTemplate and UpdateVmVersion
This should prevent it by making sure AddVmTemplate releases its locks before calling UpdateVmVersion

In more details, we've noticed the following race:
1. 2022-03-15 11:30:21,740Z INFO  [org.ovirt.engine.core.bll.AddVmTemplateCommand] ...
 Lock Acquired to object 'EngineLock:{exclusiveLocks='[f05484e6-9fb4-446d-904b-56932120c747=TEMPLATE]',
 sharedLocks='[58dd14eb-ba04-4687-98e1-f5aac18df59b=TEMPLATE, 59f5dd98-212f-4324-9081-44c198c6653a=VM]'}'
2. 2022-03-15 11:30:21,756Z INFO  [org.ovirt.engine.core.bll.AddVmTemplateCommand] ...
 Running command: AddVmTemplateCommand
3. 2022-03-15 11:30:24,400Z WARN  [org.ovirt.engine.core.bll.UpdateVmVersionCommand] ...
 Validation of action 'UpdateVmVersion' failed for user admin@internal-authz. Reasons:
 VAR__ACTION__UPDATE_VM_VERSION,VAR__TYPE__VM,ACTION_TYPE_FAILED_TEMPLATE_IS_BEING_CREATED
4. 2022-03-15 11:30:24,401Z INFO  [org.ovirt.engine.core.bll.AddVmTemplateCommand] ...
 Lock freed to object 'EngineLock:{exclusiveLocks='[f05484e6-9fb4-446d-904b-56932120c747=TEMPLATE]',
 sharedLocks='[58dd14eb-ba04-4687-98e1-f5aac18df59b=TEMPLATE, 59f5dd98-212f-4324-9081-44c198c6653a=VM]'}'
5. 2022-03-15 11:30:24,407Z INFO  ...
 Creation of Template cirros_template from VM ovf_vm has been completed.

Which means that UpdateVmVersion that was initiated by AddVmTemplate
failed to acquire the lock on the template that is still held by
AddVmTemplate.

AddVmTemplate will now release its locks before calling UpdateVmVersion.