### PR TITLE
Change handling of negative scenarios in TransferDiskImage

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/TransferDiskImageCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/TransferDiskImageCommand.java
@@ -1034,6 +1034,12 @@ public class TransferDiskImageCommand<T extends TransferDiskImageParameters> ext
         }
 
         Guid imagedTicketId = Guid.newGuid();
+        ImageTransfer updates = new ImageTransfer();
+        updates.setImagedTicketId(imagedTicketId);
+        updates.setVdsId(getVdsId());
+        updates.setProxyUri(getProxyUri() + IMAGES_PATH);
+        updates.setDaemonUri(getImageDaemonUri(getVds().getHostName()) + IMAGES_PATH);
+        updateEntity(updates);
 
         if (!addImageTicketToDaemon(imagedTicketId, imagePath)) {
             log.error("Failed to add host image ticket for image transfer '{}'", getCommandId());
@@ -1056,13 +1062,6 @@ public class TransferDiskImageCommand<T extends TransferDiskImageParameters> ext
         }
 
         log.info("Started image transfer '{}', timeout {} seconds", getCommandId(), getClientTicketLifetime());
-
-        ImageTransfer updates = new ImageTransfer();
-        updates.setVdsId(getVdsId());
-        updates.setImagedTicketId(imagedTicketId);
-        updates.setProxyUri(getProxyUri() + IMAGES_PATH);
-        updates.setDaemonUri(getImageDaemonUri(getVds().getHostName()) + IMAGES_PATH);
-        updateEntity(updates);
 
         setNewSessionExpiration(getClientTicketLifetime());
         updateEntityPhase(ImageTransferPhase.TRANSFERRING);

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/TransferDiskImageCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/TransferDiskImageCommand.java
@@ -1319,10 +1319,13 @@ public class TransferDiskImageCommand<T extends TransferDiskImageParameters> ext
     }
 
     private boolean stopImageTransferSession(ImageTransfer entity) {
-        if (entity.getImagedTicketId() == null) {
-            log.warn("Failed to stop image transfer '{}'. Ticket does not exist for image '{}'",
+        if (Guid.isNullOrEmpty(entity.getImagedTicketId())) {
+            log.warn("Image transfer '{}'. Ticket does not exist for image '{}'",
                     getCommandId(), entity.getDiskId());
-            return false;
+
+            // Shouldn't happen, but if the image ticket id is missing in the
+            // database it is very likely that it wasn't created
+            return true;
         }
 
         // If we failed to remove the ticket from the daemon, we must fail and

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/TransferImageCommandCallback.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/TransferImageCommandCallback.java
@@ -38,4 +38,8 @@ public class TransferImageCommandCallback implements CommandCallback {
         return commandCoordinatorUtil.retrieveCommand(cmdId);
     }
 
+    @Override
+    public boolean pollOnExecutionFailed() {
+        return true;
+    }
 }

--- a/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/storage/disk/image/TransferDiskImageCommandTest.java
+++ b/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/storage/disk/image/TransferDiskImageCommandTest.java
@@ -95,7 +95,7 @@ public class TransferDiskImageCommandTest extends BaseCommandTest {
         doNothing().when(transferImageCommand).createImage();
         doNothing().when(transferImageCommand).persistCommand(any(), anyBoolean());
         doNothing().when(transferImageCommand).lockImage();
-        doNothing().when(transferImageCommand).startImageTransferSession();
+        doReturn(true).when(transferImageCommand).startImageTransferSession();
     }
 
     private void initializeSuppliedImage() {
@@ -251,7 +251,7 @@ public class TransferDiskImageCommandTest extends BaseCommandTest {
     @Test
     public void testNotCreatingImageIfSupplied() {
         initializeSuppliedImage();
-        doNothing().when(transferImageCommand).handleImageIsReadyForTransfer();
+        doReturn(true).when(transferImageCommand).handleImageIsReadyForTransfer();
         transferImageCommand.executeCommand();
 
         // Make sure no image is created if an image Guid is supplied.

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/VDSDomainsData.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/VDSDomainsData.java
@@ -11,6 +11,7 @@ public class VDSDomainsData implements Serializable {
     private double delay;
     private boolean actual;
     private boolean acquired;
+    private boolean valid;
 
     public Guid getDomainId() {
         return privateDomainId;
@@ -64,5 +65,13 @@ public class VDSDomainsData implements Serializable {
 
     public void setAcquired(boolean acquired) {
         this.acquired = acquired;
+    }
+
+    public boolean isValid() {
+        return valid;
+    }
+
+    public void setValid(boolean valid) {
+        this.valid = valid;
     }
 }

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/VdsBrokerObjectsBuilder.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/VdsBrokerObjectsBuilder.java
@@ -1602,6 +1602,12 @@ public class VdsBrokerObjectsBuilder {
                         acquired = (Boolean)internalValue.get(VdsProperties.acquired);
                     }
                     data.setAcquired(acquired);
+
+                    Boolean valid = Boolean.FALSE;
+                    if (internalValue.containsKey(VdsProperties.valid)) {
+                        valid = (Boolean)internalValue.get(VdsProperties.valid);
+                    }
+                    data.setValid(valid);
                     domainsData.add(data);
                 } catch (Exception e) {
                     log.error("failed building domains: {}", e.getMessage());

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/VdsProperties.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/VdsProperties.java
@@ -461,6 +461,7 @@ public final class VdsProperties {
     public static final String delay = "delay";
     public static final String actual = "actual";
     public static final String acquired = "acquired";
+    public static final String valid = "valid";
 
     public static final String DISK_STATS = "diskStats";
     public static final String DISK_STATS_FREE = "free";


### PR DESCRIPTION
Improve the handling of some negative scenarios in TransferDiskImage:
* Failure during executeCommand() will lead to a stuck transfer, because polling will not continue and the command is not marked as failed
* Filter out hosts the have the target domains not reported as "valid: True", to avoid using hosts that might not be ready to service requests and failing
* Check if actually managed to initiate the transfer before continuing
* Set ImageTicketId before adding it in imageio to avoid looping trying to stop a transfer for a ticket that does not exist