### PR TITLE
restapi: stub HostCpuUnitsResource

### DIFF
--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendHostCpuUnitsResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendHostCpuUnitsResource.java
@@ -1,0 +1,15 @@
+package org.ovirt.engine.api.restapi.resource;
+
+import org.ovirt.engine.api.model.HostCpuUnit;
+import org.ovirt.engine.api.resource.HostCpuUnitsResource;
+import org.ovirt.engine.core.compat.Guid;
+
+public class BackendHostCpuUnitsResource extends AbstractBackendCollectionResource<HostCpuUnit, Object> implements HostCpuUnitsResource {
+
+    private Guid hostId;
+
+    public BackendHostCpuUnitsResource(Guid hostId) {
+        super(HostCpuUnit.class, Object.class);
+        this.hostId = hostId;
+    }
+}

--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendHostResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendHostResource.java
@@ -26,6 +26,7 @@ import org.ovirt.engine.api.resource.AssignedPermissionsResource;
 import org.ovirt.engine.api.resource.AssignedTagsResource;
 import org.ovirt.engine.api.resource.ExternalNetworkProviderConfigurationsResource;
 import org.ovirt.engine.api.resource.FenceAgentsResource;
+import org.ovirt.engine.api.resource.HostCpuUnitsResource;
 import org.ovirt.engine.api.resource.HostDevicesResource;
 import org.ovirt.engine.api.resource.HostNicsResource;
 import org.ovirt.engine.api.resource.HostNumaNodesResource;
@@ -833,5 +834,10 @@ public class BackendHostResource extends AbstractBackendActionableResource<Host,
     @Override
     public ExternalNetworkProviderConfigurationsResource getExternalNetworkProviderConfigurationsResource() {
         return inject(new BackendHostExternalNetworkProviderConfigurationsResource(guid));
+    }
+
+    @Override
+    public HostCpuUnitsResource getCpuUnitsResource() {
+        return inject(new BackendHostCpuUnitsResource(guid));
     }
 }


### PR DESCRIPTION
In order to let the unit tests pass, we need to stub the
HostCpuUnitsResource.

Change-Id: I130ae6c14d1d51cf58f3d835639628c5a9db56a8
Signed-off-by: Liran Rotenberg <lrotenbe@redhat.com>