### PR TITLE
engine: make host id mandatory for ProcessDownVmParameters

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/ClearNonResponsiveVdsVmsCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/ClearNonResponsiveVdsVmsCommand.java
@@ -67,7 +67,7 @@ public class ClearNonResponsiveVdsVmsCommand<T extends VdsActionParameters> exte
                 logSettingVmToDown(vm);
             }
 
-            runInternalActionWithTasksContext(ActionType.ProcessDownVm, new ProcessDownVmParameters(vm.getId(), true));
+            runInternalActionWithTasksContext(ActionType.ProcessDownVm, new ProcessDownVmParameters(vm.getId(), true, getVdsId()));
         }
 
         runVdsCommand(VDSCommandType.UpdateVdsVMsCleared,

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/ProcessDownVmCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/ProcessDownVmCommand.java
@@ -157,10 +157,13 @@ public class ProcessDownVmCommand<T extends ProcessDownVmParameters> extends Com
             refreshHostIfNeeded(hostId == null ? alternativeHostsList : hostId);
         }
 
-        VdsManager vdsManager = resourceManager.getVdsManager(getParameters().getHostId(), false);
-        if (vdsManager != null) {
-            vdsManager.unpinVmCpus(getVm().getId());
+        if (getParameters().getHostId() != null) {
+            VdsManager vdsManager = resourceManager.getVdsManager(getParameters().getHostId(), false);
+            if (vdsManager != null) {
+                vdsManager.unpinVmCpus(getVm().getId());
+            }
         }
+
         managedBlockStorageCommandUtil.disconnectManagedBlockStorageDisks(getVm(), vmHandler);
         vmNicDao.setVmInterfacesSyncedForVm(getVmId());
     }

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/RestartVdsVmsOperation.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/RestartVdsVmsOperation.java
@@ -116,7 +116,7 @@ public class RestartVdsVmsOperation {
             }
             Injector.get(BackendInternal.class).runInternalAction(
                     ActionType.ProcessDownVm,
-                    new ProcessDownVmParameters(vm.getId(), true),
+                    new ProcessDownVmParameters(vm.getId(), true, vds.getId()),
                     ExecutionHandler.createDefaultContextForTasks(commandContext)
             );
 

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/RunVmCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/RunVmCommand.java
@@ -598,7 +598,7 @@ public class RunVmCommand<T extends RunVmParams> extends RunVmCommandBase<T>
 
     private void removeStatlessSnapshot() {
         runInternalAction(ActionType.ProcessDownVm,
-                new ProcessDownVmParameters(getVm().getId(), true),
+                new ProcessDownVmParameters(getVm().getId(), true, getVdsId()),
                 ExecutionHandler.createDefaultContextForTasks(getContext(), getLock()));
         // setting lock to null in order not to release lock twice
         setLock(null);

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/RunVmCommandBase.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/RunVmCommandBase.java
@@ -216,7 +216,7 @@ public abstract class RunVmCommandBase<T extends VmOperationParameterBase> exten
     protected void processVmOnDown() {
         ThreadPoolUtil.execute(() -> runInternalActionWithTasksContext(
                 ActionType.ProcessDownVm,
-                new ProcessDownVmParameters(getVm().getId())
+                new ProcessDownVmParameters(getVm().getId(), getVdsId())
         ));
     }
 

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/ProcessDownVmParameters.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/ProcessDownVmParameters.java
@@ -13,18 +13,14 @@ public class ProcessDownVmParameters extends IdParameters {
         super();
     }
 
-    public ProcessDownVmParameters(Guid id) {
+    public ProcessDownVmParameters(Guid id, Guid hostId) {
         super(id);
-    }
-
-    public ProcessDownVmParameters(Guid id, boolean skipHostRefresh) {
-        this(id);
-        this.skipHostRefresh = skipHostRefresh;
+        this.hostId = hostId;
     }
 
     public ProcessDownVmParameters(Guid id, boolean skipHostRefresh, Guid hostId) {
-        this(id, skipHostRefresh);
-        this.hostId = hostId;
+        this(id, hostId);
+        this.skipHostRefresh = skipHostRefresh;
     }
 
     public boolean isSkipHostRefresh() {


### PR DESCRIPTION
The ProcessDownVmCommand fails with NPE if the host id is null. This patch makes it mandatory for the caller to provide the host id and fails with IllegalArgumentException if the provided host id is null.