### PR TITLE
core: move resize and pin CPUs settings

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/RunVmCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/RunVmCommand.java
@@ -957,7 +957,7 @@ public class RunVmCommand<T extends RunVmParams> extends RunVmCommandBase<T>
             getVm().setUseHostCpuFlags(true);
         }
 
-        addCpuAndNumaPinning();
+        addNumaPinning();
         setDedicatedCpus();
 
         return true;
@@ -1161,10 +1161,10 @@ public class RunVmCommand<T extends RunVmParams> extends RunVmCommandBase<T>
         return true;
     }
 
-    private void addCpuAndNumaPinning() {
+    private void addNumaPinning() {
+        // The CPU topology and CPU Pinning change happens under schedule(), when allocating CPUs
+        // - VdsCpuUnitPinningHelper::updatePhysicalCpuAllocations.
         if (getVm().getCpuPinningPolicy() == CpuPinningPolicy.RESIZE_AND_PIN_NUMA) {
-            vmHandler.updateCpuAndNumaPinning(getVm(), getVdsId());
-
             List<VmNumaNode> newVmNumaList = getVm().getvNumaNodeList();
             VmNumaNodeOperationParameters params =
                     new VmNumaNodeOperationParameters(getVm(), new ArrayList<>(newVmNumaList));

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/VmHandler.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/VmHandler.java
@@ -55,6 +55,7 @@ import org.ovirt.engine.core.common.businessentities.BiosType;
 import org.ovirt.engine.core.common.businessentities.ChipsetType;
 import org.ovirt.engine.core.common.businessentities.Cluster;
 import org.ovirt.engine.core.common.businessentities.CopyOnNewVersion;
+import org.ovirt.engine.core.common.businessentities.CpuPinningPolicy;
 import org.ovirt.engine.core.common.businessentities.DisplayType;
 import org.ovirt.engine.core.common.businessentities.EditableDeviceOnVmStatusField;
 import org.ovirt.engine.core.common.businessentities.EditableVmField;
@@ -1302,8 +1303,10 @@ public class VmHandler implements BackendService {
     }
 
     public void updateCpuAndNumaPinning(VM vm, Guid vdsId) {
-        VdsDynamic host = vdsDynamicDao.get(vdsId);
-        NumaPinningHelper.applyAutoPinningPolicy(vm, host, vdsNumaNodeDao.getAllVdsNumaNodeByVdsId(host.getId()));
+        if (vm.getCpuPinningPolicy() == CpuPinningPolicy.RESIZE_AND_PIN_NUMA && vm.getCurrentCpuPinning() == null) {
+            VdsDynamic host = vdsDynamicDao.get(vdsId);
+            NumaPinningHelper.applyAutoPinningPolicy(vm, host, vdsNumaNodeDao.getAllVdsNumaNodeByVdsId(host.getId()));
+        }
     }
 
     public void autoSelectResumeBehavior(VmBase vmBase) {

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/SchedulingManager.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/SchedulingManager.java
@@ -431,7 +431,8 @@ public class SchedulingManager implements BackendService {
 
 
                 for (VM vm : vmsNotOnHost) {
-                    List<VdsCpuUnit> dedicatedCpuPinning = vdsCpuUnitPinningHelper.allocateDedicatedCpus(vm,
+                    vmHandler.updateCpuAndNumaPinning(vm, host.getId());
+                    List<VdsCpuUnit> dedicatedCpuPinning = vdsCpuUnitPinningHelper.updatePhysicalCpuAllocations(vm,
                             PendingCpuPinning.collectForHost(getPendingResourceManager(), host.getId()), host.getId());
                     addPendingResources(vm, host, numaConsumptionPerVm.getOrDefault(vm.getId(), Collections.emptyMap()), dedicatedCpuPinning);
                     hostsToNotifyPending.add(bestHostId);

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/utils/VdsCpuUnitPinningHelper.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/utils/VdsCpuUnitPinningHelper.java
@@ -31,7 +31,7 @@ public class VdsCpuUnitPinningHelper {
      *
      * @param vmToPendingPinnings Map of VDS GUID keys to list of VdsCpuUnits pending to be taken.
      * @param vm VM object.
-     * @param hostId GUID of the VDS object..
+     * @param hostId GUID of the VDS object.
      * @return boolean. True if possible to dedicate the VM on the host. Otherwise false.
      */
     public boolean isDedicatedCpuPinningPossibleAtHost(Map<Guid, List<VdsCpuUnit>> vmToPendingPinnings,
@@ -67,7 +67,7 @@ public class VdsCpuUnitPinningHelper {
     }
 
     /**
-     * This function will tell if the host is capable to run a given dedicated CPU policy VM.
+     * This function will allocate the host CPUs to the given CPU pinning policy.
      *
      * The function apply the pending CPU pinning on the host topology, then:
      * The function will select the most available socket (most free CPUs). It will allocate the CPUs and check if we
@@ -77,9 +77,9 @@ public class VdsCpuUnitPinningHelper {
      * @param vm VM object.
      * @param vmToPendingPinnings Map of VDS GUID keys to list of VdsCpuUnits pending to be taken.
      * @param hostId GUID of the VDS object.
-     * @return List<{@link VdsCpuUnit}>. The list of VdsCpuUnit we are going to use. If not possible, return an empty List.
+     * @return List<{@link VdsCpuUnit}>. The list of VdsCpuUnit we are going to use. If not possible, return null.
      */
-    public List<VdsCpuUnit> allocateDedicatedCpus(VM vm, Map<Guid, List<VdsCpuUnit>> vmToPendingPinnings, Guid hostId) {
+    public List<VdsCpuUnit> updatePhysicalCpuAllocations(VM vm, Map<Guid, List<VdsCpuUnit>> vmToPendingPinnings, Guid hostId) {
         if (vm.getCpuPinningPolicy() == CpuPinningPolicy.NONE) {
             return new ArrayList<>();
         }

--- a/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/scheduling/utils/VdsCpuUnitPinningHelperTest.java
+++ b/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/scheduling/utils/VdsCpuUnitPinningHelperTest.java
@@ -185,7 +185,7 @@ public class VdsCpuUnitPinningHelperTest {
         vm.setCpuPerSocket(1);
         vm.setThreadsPerCpu(1);
         vm.setCpuPinningPolicy(CpuPinningPolicy.DEDICATED);
-        List<VdsCpuUnit> cpus = vdsCpuUnitPinningHelper.allocateDedicatedCpus(vm, new HashMap<>(), host.getId());
+        List<VdsCpuUnit> cpus = vdsCpuUnitPinningHelper.updatePhysicalCpuAllocations(vm, new HashMap<>(), host.getId());
         assertEquals(1, cpus.size());
         assertEquals(0, cpus.get(0).getSocket());
         assertEquals(0, cpus.get(0).getCore());
@@ -200,7 +200,7 @@ public class VdsCpuUnitPinningHelperTest {
         vm.setCpuPerSocket(2);
         vm.setThreadsPerCpu(1);
         vm.setCpuPinningPolicy(CpuPinningPolicy.DEDICATED);
-        List<VdsCpuUnit> cpus = vdsCpuUnitPinningHelper.allocateDedicatedCpus(vm, new HashMap<>(), host.getId());
+        List<VdsCpuUnit> cpus = vdsCpuUnitPinningHelper.updatePhysicalCpuAllocations(vm, new HashMap<>(), host.getId());
         assertEquals(2, cpus.size());
         assertEquals(0, cpus.get(0).getSocket());
         assertEquals(0, cpus.get(0).getCore());
@@ -219,7 +219,7 @@ public class VdsCpuUnitPinningHelperTest {
         vm.setCpuPerSocket(1);
         vm.setThreadsPerCpu(1);
         vm.setCpuPinningPolicy(CpuPinningPolicy.DEDICATED);
-        List<VdsCpuUnit> cpus = vdsCpuUnitPinningHelper.allocateDedicatedCpus(vm, new HashMap<>(), host.getId());
+        List<VdsCpuUnit> cpus = vdsCpuUnitPinningHelper.updatePhysicalCpuAllocations(vm, new HashMap<>(), host.getId());
         assertEquals(2, cpus.size());
         assertEquals(0, cpus.get(0).getSocket());
         assertEquals(0, cpus.get(0).getCore());
@@ -238,7 +238,7 @@ public class VdsCpuUnitPinningHelperTest {
         vm.setCpuPerSocket(1);
         vm.setThreadsPerCpu(2);
         vm.setCpuPinningPolicy(CpuPinningPolicy.DEDICATED);
-        List<VdsCpuUnit> cpus = vdsCpuUnitPinningHelper.allocateDedicatedCpus(vm, new HashMap<>(), host.getId());
+        List<VdsCpuUnit> cpus = vdsCpuUnitPinningHelper.updatePhysicalCpuAllocations(vm, new HashMap<>(), host.getId());
         assertEquals(4, cpus.size());
 
         assertEquals(0, cpus.get(0).getSocket());
@@ -266,7 +266,7 @@ public class VdsCpuUnitPinningHelperTest {
         vm.setCpuPerSocket(5);
         vm.setThreadsPerCpu(1);
         vm.setCpuPinningPolicy(CpuPinningPolicy.DEDICATED);
-        List<VdsCpuUnit> cpus = vdsCpuUnitPinningHelper.allocateDedicatedCpus(vm, new HashMap<>(), host.getId());
+        List<VdsCpuUnit> cpus = vdsCpuUnitPinningHelper.updatePhysicalCpuAllocations(vm, new HashMap<>(), host.getId());
         assertNull(cpus);
     }
 
@@ -278,7 +278,7 @@ public class VdsCpuUnitPinningHelperTest {
         vm.setCpuPerSocket(3);
         vm.setThreadsPerCpu(1);
         vm.setCpuPinningPolicy(CpuPinningPolicy.DEDICATED);
-        List<VdsCpuUnit> cpus = vdsCpuUnitPinningHelper.allocateDedicatedCpus(vm, new HashMap<>(), host.getId());
+        List<VdsCpuUnit> cpus = vdsCpuUnitPinningHelper.updatePhysicalCpuAllocations(vm, new HashMap<>(), host.getId());
         assertEquals(3, cpus.size());
 
         assertEquals(0, cpus.get(0).getSocket());
@@ -312,7 +312,7 @@ public class VdsCpuUnitPinningHelperTest {
         cpuTopology.add(new VdsCpuUnit(1, 0, 0));
         when(vdsManager.getCpuTopology()).thenReturn(cpuTopology);
 
-        List<VdsCpuUnit> cpus = vdsCpuUnitPinningHelper.allocateDedicatedCpus(vm, new HashMap<>(), host.getId());
+        List<VdsCpuUnit> cpus = vdsCpuUnitPinningHelper.updatePhysicalCpuAllocations(vm, new HashMap<>(), host.getId());
         assertEquals(2, cpus.size());
 
         assertEquals(0, cpus.get(0).getSocket());
@@ -348,7 +348,7 @@ public class VdsCpuUnitPinningHelperTest {
         cpuTopology.add(vdsCpuUnit);
         when(vdsManager.getCpuTopology()).thenReturn(cpuTopology);
 
-        List<VdsCpuUnit> cpus = vdsCpuUnitPinningHelper.allocateDedicatedCpus(vm, new HashMap<>(), host.getId());
+        List<VdsCpuUnit> cpus = vdsCpuUnitPinningHelper.updatePhysicalCpuAllocations(vm, new HashMap<>(), host.getId());
         assertEquals(2, cpus.size());
 
         assertEquals(0, cpus.get(0).getSocket());
@@ -373,7 +373,7 @@ public class VdsCpuUnitPinningHelperTest {
         cpuTopology.add(new VdsCpuUnit(1, 0, 1));
         cpuTopology.add(new VdsCpuUnit(2, 1, 0));
         when(vdsManager.getCpuTopology()).thenReturn(cpuTopology);
-        List<VdsCpuUnit> cpus = vdsCpuUnitPinningHelper.allocateDedicatedCpus(vm, new HashMap<>(), host.getId());
+        List<VdsCpuUnit> cpus = vdsCpuUnitPinningHelper.updatePhysicalCpuAllocations(vm, new HashMap<>(), host.getId());
         assertNull(cpus);
     }
 

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/VdsCpuUnit.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/VdsCpuUnit.java
@@ -139,6 +139,9 @@ public class VdsCpuUnit implements Comparable<VdsCpuUnit>, Serializable, Cloneab
         if (!this.vmIds.contains(vmId)) {
             this.vmIds.add(vmId);
         }
+        if (cpuPinningPolicy == CpuPinningPolicy.RESIZE_AND_PIN_NUMA) {
+            cpuPinningPolicy = CpuPinningPolicy.MANUAL;
+        }
         this.cpuPinningPolicy = cpuPinningPolicy;
         return true;
     }


### PR DESCRIPTION
Since we introduced `dedicated` policy, we need to allocate the physical
resources even for other policies such: `manual` and `resize and pin
NUMA`. Until now the CPU topology and CPU pinning for `resize and pin
NUMA` happened after host selection by the scheduler. But in that phase
we allocate the physical resources, which result us in NPE and
potential to wrong data for the host resources.
Now, the CPU settings such as topology and CPU pinning will be generated
after host selection, when allocating the physical CPUs.

Change-Id: Iff425646825cd258a9c35c88f36cd4b66618eac5
Signed-off-by: Liran Rotenberg <lrotenbe@redhat.com>