### PR TITLE
webadmin: fix displaying IOMMU placeholder rows

### DIFF
--- a/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/section/main/view/tab/virtualMachine/VmHostDeviceModelTable.java
+++ b/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/section/main/view/tab/virtualMachine/VmHostDeviceModelTable.java
@@ -4,33 +4,25 @@ import org.ovirt.engine.core.common.businessentities.HostDeviceView;
 import org.ovirt.engine.core.common.businessentities.VM;
 import org.ovirt.engine.ui.common.system.ClientStorage;
 import org.ovirt.engine.ui.common.uicommon.model.SearchableTableModelProvider;
-import org.ovirt.engine.ui.common.widget.table.AbstractActionTable;
 import org.ovirt.engine.ui.uicommonweb.models.vms.hostdev.VmHostDeviceListModel;
 import org.ovirt.engine.ui.webadmin.section.main.presenter.tab.virtualMachine.VmHostDeviceActionPanelPresenterWidget;
 import org.ovirt.engine.ui.webadmin.section.main.view.tab.host.HostDeviceModelBaseTable;
 
-import com.google.gwt.dom.client.TableRowElement;
 import com.google.gwt.event.shared.EventBus;
+import com.google.gwt.user.cellview.client.RowStyles;
 
-public class VmHostDeviceModelTable extends HostDeviceModelBaseTable<VM, VmHostDeviceListModel> implements AbstractActionTable.RowVisitor<HostDeviceView> {
+public class VmHostDeviceModelTable extends HostDeviceModelBaseTable<VM, VmHostDeviceListModel> {
 
     public VmHostDeviceModelTable(
             SearchableTableModelProvider<HostDeviceView, VmHostDeviceListModel> modelProvider,
-            EventBus eventBus, VmHostDeviceActionPanelPresenterWidget actionPanel,
+            EventBus eventBus,
+            VmHostDeviceActionPanelPresenterWidget actionPanel,
             ClientStorage clientStorage) {
         super(modelProvider, eventBus, actionPanel, clientStorage);
+        RowStyles<HostDeviceView> rowStyles =
+                (item, rowIndex) -> item.isIommuPlaceholder() ? "cellTableDisabledRow" : null; //$NON-NLS-1$
+
+        getTable().table.setRowStyles(rowStyles);
     }
 
-    @Override
-    public void initTable() {
-        super.initTable();
-        getTable().setRowVisitor(this);
-    }
-
-    @Override
-    public void visit(TableRowElement row, HostDeviceView item) {
-        if (item.isIommuPlaceholder()) {
-            row.addClassName("cellTableDisabledRow"); //$NON-NLS-1$
-        }
-    }
 }


### PR DESCRIPTION
The fix applies to rows in Virtual Machines -> {vm} -> Host Devices
table that have the IOMMU placeholder flag enabled.

Before, such rows were repeatedly switching between "enabled" and
"disabled" CSS styles. The problem was fixed by using an extension
point dedicated to row CSS customization.