### PR TITLE
webadmin: Cluster grid upgrade status column as progress bar

### DIFF
--- a/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/widget/table/column/ClusterUpgradeStatusColumn.java
+++ b/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/widget/table/column/ClusterUpgradeStatusColumn.java
@@ -50,16 +50,29 @@ public class ClusterUpgradeStatusColumn extends AbstractColumn<Cluster, Cluster>
         }
     }
 
-    private static class UpgradeProgressColumn extends AbstractTextColumn<Cluster> {
+    private static class UpgradeProgressColumn extends AbstractOneColorPercentColumn<Cluster> {
+        public UpgradeProgressColumn() {
+            super(AbstractOneColorPercentColumn.ProgressBarColors.GREEN);
+        }
+
         @Override
-        public String getValue(Cluster object) {
+        public SafeHtml getValue(Cluster object) {
           if (!object.isUpgradeRunning()) {
               return null;
           }
 
-          return constants.clusterUpgradeInProgress();
+          return super.getValue(object);
+        }
+
+        @Override
+        public Integer getProgressValue(Cluster object) {
+            return object.getUpgradePercentComplete();
+        }
+
+        @Override
+        protected String getStyle() {
+            return "engine-progress-box-migration";//$NON-NLS-1$
         }
     }
-
 
 }


### PR DESCRIPTION
Given REST changes in [1] and [2], when a cluster is marked as upgrade in progress, show the progress value as a progress bar on the cluster grid.

[1] - https://github.com/oVirt/ovirt-engine-api-model/pull/32
[2] - https://github.com/oVirt/ovirt-engine/pull/170
Bug-Url: https://bugzilla.redhat.com/2040474

~~_Note: This PR is dependent on #170 so it currently includes those commits as well.  Only the last commit belongs to this PR.  I will rebase as needed and as merges happen._~~
