### PR TITLE
Revert: Update read/write ops dwh columns names

### DIFF
--- a/packaging/dbscripts/create_dwh_views.sql
+++ b/packaging/dbscripts/create_dwh_views.sql
@@ -485,10 +485,10 @@ SELECT d.disk_id AS vm_disk_id,
     cast(images.imageStatus AS SMALLINT) AS vm_disk_status,
     vm_disk_actual_size.vm_disk_actual_size_mb AS vm_disk_actual_size_mb,
     disk_image_dynamic.read_rate AS read_rate_bytes_per_second,
-    disk_image_dynamic.read_ops AS read_ops_total_count,
+    disk_image_dynamic.read_ops AS read_ops_per_second,
     disk_image_dynamic.read_latency_seconds AS read_latency_seconds,
     disk_image_dynamic.write_rate AS write_rate_bytes_per_second,
-    disk_image_dynamic.write_ops AS write_ops_total_count,
+    disk_image_dynamic.write_ops AS write_ops_per_second,
     disk_image_dynamic.write_latency_seconds AS write_latency_seconds,
     disk_image_dynamic.flush_latency_seconds AS flush_latency_seconds
 FROM images


### PR DESCRIPTION
This reverts changes introduced by commit
5584aaf58b13ab9ed8cae17c9aad3cd66d126644 in PR:
https://github.com/oVirt/ovirt-engine/pull/133

Bug-Url: https://bugzilla.redhat.com/2010903
Signed-off-by: Martin Perina <mperina@redhat.com>
