### PR TITLE
Add an action panel to vm devices tab

### DIFF
--- a/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/gin/PresenterModule.java
+++ b/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/gin/PresenterModule.java
@@ -95,6 +95,7 @@ import org.ovirt.engine.ui.uicommonweb.models.storage.StorageListModel;
 import org.ovirt.engine.ui.uicommonweb.models.templates.TemplateListModel;
 import org.ovirt.engine.ui.uicommonweb.models.users.UserListModel;
 import org.ovirt.engine.ui.uicommonweb.models.vms.DiskModel;
+import org.ovirt.engine.ui.uicommonweb.models.vms.VmDeviceFeEntity;
 import org.ovirt.engine.ui.uicommonweb.models.vms.VmListModel;
 import org.ovirt.engine.ui.uicommonweb.models.volumes.VolumeListModel;
 import org.ovirt.engine.ui.webadmin.section.main.presenter.AboutPopupPresenterWidget;
@@ -2197,6 +2198,8 @@ public class PresenterModule extends BasePresenterModule {
             new TypeLiteral<DetailActionPanelView<VM, Snapshot>>(){});
         bindActionPanel(new TypeLiteral<DetailActionPanelPresenterWidget.ViewDef<VM, HostDeviceView>>(){},
             new TypeLiteral<DetailActionPanelView<VM, HostDeviceView>>(){});
+        bindActionPanel(new TypeLiteral<DetailActionPanelPresenterWidget.ViewDef<VM, VmDeviceFeEntity>>(){},
+                new TypeLiteral<DetailActionPanelView<VM, VmDeviceFeEntity>>(){});
         bindActionPanel(new TypeLiteral<DetailActionPanelPresenterWidget.ViewDef<VDS, HostInterfaceLineModel>>(){},
             new TypeLiteral<DetailActionPanelView<VDS, HostInterfaceLineModel>>(){});
         bindActionPanel(new TypeLiteral<DetailActionPanelPresenterWidget.ViewDef<VDS, HostDeviceView>>(){},

--- a/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/section/main/presenter/tab/virtualMachine/SubTabVirtualMachineVmDevicePresenter.java
+++ b/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/section/main/presenter/tab/virtualMachine/SubTabVirtualMachineVmDevicePresenter.java
@@ -42,9 +42,9 @@ public class SubTabVirtualMachineVmDevicePresenter
     @Inject
     public SubTabVirtualMachineVmDevicePresenter(EventBus eventBus, ViewDef view, ProxyDef proxy,
             PlaceManager placeManager, SearchableDetailModelProvider<VmDeviceFeEntity, VmListModel<Void>, VmDevicesListModel<VM>> modelProvider,
-            VirtualMachineMainSelectedItems selectedItems) {
+            VirtualMachineMainSelectedItems selectedItems, VmDeviceActionPanelPresenterWidget actionPanel) {
         // View has no action panel, passing null.
-        super(eventBus, view, proxy, placeManager, modelProvider, selectedItems, null,
+        super(eventBus, view, proxy, placeManager, modelProvider, selectedItems, actionPanel,
                 VirtualMachineSubTabPanelPresenter.TYPE_SetTabContent);
     }
 

--- a/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/section/main/presenter/tab/virtualMachine/VmDeviceActionPanelPresenterWidget.java
+++ b/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/section/main/presenter/tab/virtualMachine/VmDeviceActionPanelPresenterWidget.java
@@ -1,0 +1,28 @@
+package org.ovirt.engine.ui.webadmin.section.main.presenter.tab.virtualMachine;
+
+import javax.inject.Inject;
+
+import org.ovirt.engine.core.common.businessentities.VM;
+import org.ovirt.engine.ui.common.presenter.DetailActionPanelPresenterWidget;
+import org.ovirt.engine.ui.common.uicommon.model.SearchableDetailModelProvider;
+import org.ovirt.engine.ui.uicommonweb.models.vms.VmDeviceFeEntity;
+import org.ovirt.engine.ui.uicommonweb.models.vms.VmDevicesListModel;
+import org.ovirt.engine.ui.uicommonweb.models.vms.VmListModel;
+
+import com.google.web.bindery.event.shared.EventBus;
+
+public class VmDeviceActionPanelPresenterWidget extends
+    DetailActionPanelPresenterWidget<VM, VmDeviceFeEntity, VmListModel<Void>, VmDevicesListModel<VM>> {
+
+    @Inject
+    public VmDeviceActionPanelPresenterWidget(EventBus eventBus,
+            DetailActionPanelPresenterWidget.ViewDef<VM, VmDeviceFeEntity> view,
+            SearchableDetailModelProvider<VmDeviceFeEntity, VmListModel<Void>, VmDevicesListModel<VM>> dataProvider) {
+        super(eventBus, view, dataProvider);
+    }
+
+    @Override
+    protected void initializeButtons() {
+        // no GWT action buttons
+    }
+}

--- a/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/section/main/view/tab/virtualMachine/SubTabVirtualMachineVmDevicesView.java
+++ b/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/section/main/view/tab/virtualMachine/SubTabVirtualMachineVmDevicesView.java
@@ -2,6 +2,7 @@ package org.ovirt.engine.ui.webadmin.section.main.view.tab.virtualMachine;
 
 import org.ovirt.engine.core.common.businessentities.VM;
 import org.ovirt.engine.ui.common.idhandler.ElementIdHandler;
+import org.ovirt.engine.ui.common.presenter.AbstractSubTabPresenter;
 import org.ovirt.engine.ui.common.system.ClientStorage;
 import org.ovirt.engine.ui.common.uicommon.model.SearchableDetailModelProvider;
 import org.ovirt.engine.ui.common.view.AbstractSubTabTableWidgetView;
@@ -31,6 +32,7 @@ public class SubTabVirtualMachineVmDevicesView extends AbstractSubTabTableWidget
         ViewIdHandler.idHandler.generateAndSetIds(this);
         initTable();
         initWidget(getModelBoundTableWidget());
+        bindSlot(AbstractSubTabPresenter.TYPE_SetActionPanel, getModelBoundTableWidget().getActionPanelContainer());
     }
 
     @Override


### PR DESCRIPTION
In order for the ui-extensions to be able to add the action button to the vm devices tab, the action panel needs to be created.

This patch creates and injects the action panel presenter to the vm devices tab.