### PR TITLE
collectd-virt plugin doesn't work with latest libvirt

### DIFF
--- a/ovirt-engine.spec.in
+++ b/ovirt-engine.spec.in
@@ -345,13 +345,13 @@ Requires:	fapolicyd
 Requires:	scap-security-guide >= 0.1.60-4
 
 # Metrics stuff
-Requires:	collectd
-Requires:	collectd-postgresql
-Requires:	collectd-disk
-Requires:	collectd-write_http
+Requires:	collectd >= 5.12.0-7
+Requires:	collectd-postgresql >= 5.12.0-7
+Requires:	collectd-disk >= 5.12.0-7
+Requires:	collectd-write_http >= 5.12.0-7
 %if 0%{?rhel}
 # collectd-write_syslog is available only on EL
-Requires:	collectd-write_syslog
+Requires:	collectd-write_syslog >= 5.12.0-7
 %endif
 
 


### PR DESCRIPTION
Upgrade collectd requirements to >= 5.12.0-7

Bug-Url: https://bugzilla.redhat.com/1868372
Signed-off-by: Aviv Litman <alitman@redhat.com>