### PR TITLE
ansible: Sync OVN SB DB chassis after upgrade

### DIFF
--- a/packaging/ansible-runner-service-project/project/ovirt-host-reconfigure-ovn.yml
+++ b/packaging/ansible-runner-service-project/project/ovirt-host-reconfigure-ovn.yml
@@ -14,9 +14,25 @@
   when:
     - ansible_facts.packages['rhv-openvswitch'] is defined
 
-- name: Reconfigure OVN for oVirt
-  command: >
-    vdsm-tool ovn-config {{ ovn_central }} {{ ovn_tunneling_interface }} {{ ovn_host_fqdn }}
+- block:
+  - name: Get OVS chassis id
+    command: ovs-vsctl --no-wait get open . external_ids:system-id
+    register: chassis_id
+
+  - name: Reconfigure OVN for oVirt
+    command: vdsm-tool ovn-config {{ ovn_central }} {{ ovn_tunneling_interface }} {{ ovn_host_fqdn }}
+
+  - name: Sync chassis in OVN SB DB
+    command: >
+        ovn-sbctl
+        --if-exists
+        --db=ssl:{{ ovn_central }}:6642
+        --ca-cert={{ ovirt_vdsm_trust_store }}/{{ ovirt_ovn_ca_file }}
+        --certificate={{ ovirt_vdsm_trust_store }}/{{ ovirt_ovn_cert_file }}
+        --private-key={{ ovirt_vdsm_trust_store }}/{{ ovirt_ovn_key_file }}
+        chassis-del
+        {{ chassis_id.stdout }}
+
   when:
     - ovirt_openvswitch_pre.version is version('2.11', '==')
     - ovirt_openvswitch_post.version is version('2.15', '>=')

--- a/packaging/ansible-runner-service-project/project/ovirt_host_upgrade_vars.yml
+++ b/packaging/ansible-runner-service-project/project/ovirt_host_upgrade_vars.yml
@@ -40,6 +40,9 @@ ovirt_vdsm_key_size: 2048
 ovirt_vdsm_key_type: rsa
 
 # OVN
+ovirt_ovn_ca_file: 'ovn/ca-cert.pem'
+ovirt_ovn_cert_file: 'ovn/ovn-cert.pem'
+ovirt_ovn_key_file: 'ovn/ovn-key.pem'
 ovn_central: "{{ host_deploy_ovn_central | default(omit) }}"
 ovn_tunneling_interface: "{{ host_deploy_ovn_tunneling_interface | default('ovirtmgmt') }}"
 ovn_host_fqdn: "{{ ovirt_vds_hostname | default('') }}"


### PR DESCRIPTION
The upgrade lefts chassis in strange state causes
ovn-controller to lose tunnel connection. To fix that
remove the old chassis after upgrade, which gives
ovn-controller chance to introduce the host again
with proper configuration.

Signed-off-by: Ales Musil <amusil@redhat.com>
Bug-Url: https://bugzilla.redhat.com/1940824