### PR TITLE
Handle numa pinning without cpu pinning

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/SchedulingManager.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/SchedulingManager.java
@@ -432,6 +432,7 @@ public class SchedulingManager implements BackendService {
 
                 for (VM vm : vmsNotOnHost) {
                     vmHandler.updateCpuAndNumaPinning(vm, host.getId());
+                    vmHandler.setCpuPinningByNumaPinning(vm, host.getId());
                     List<VdsCpuUnit> dedicatedCpuPinning = vdsCpuUnitPinningHelper.updatePhysicalCpuAllocations(vm,
                             PendingCpuPinning.collectForHost(getPendingResourceManager(), host.getId()), host.getId());
                     addPendingResources(vm, host, numaConsumptionPerVm.getOrDefault(vm.getId(), Collections.emptyMap()), dedicatedCpuPinning);
@@ -558,7 +559,7 @@ public class SchedulingManager implements BackendService {
 
 
         boolean considerCpuPinning = filteredVms.stream()
-                .anyMatch(vm -> !StringUtils.isEmpty(VmCpuCountHelper.isDynamicCpuPinning(vm) ? vm.getCurrentCpuPinning() : vm.getCpuPinning()));
+                .anyMatch(vm -> !StringUtils.isEmpty(vm.getVmPinning()));
 
         Optional<Map<Guid, Integer>> nodeAssignment = Optional.empty();
         if (considerCpuPinning) {

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/policyunits/CpuPinningPolicyUnit.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/policyunits/CpuPinningPolicyUnit.java
@@ -27,7 +27,6 @@ import org.ovirt.engine.core.common.scheduling.PerHostMessages;
 import org.ovirt.engine.core.common.scheduling.PolicyUnit;
 import org.ovirt.engine.core.common.scheduling.PolicyUnitType;
 import org.ovirt.engine.core.common.utils.CpuPinningHelper;
-import org.ovirt.engine.core.common.utils.VmCpuCountHelper;
 import org.ovirt.engine.core.compat.Guid;
 import org.ovirt.engine.core.vdsbroker.ResourceManager;
 import org.slf4j.Logger;
@@ -61,7 +60,7 @@ public class CpuPinningPolicyUnit extends PolicyUnitImpl {
             final List<VDS> hosts,
             final VM vm,
             final PerHostMessages messages) {
-        final String cpuPinning = VmCpuCountHelper.isDynamicCpuPinning(vm) ? vm.getCurrentCpuPinning() : vm.getCpuPinning();
+        final String cpuPinning = vm.getVmPinning();
 
         // return all hosts when no CPU pinning is requested
         if (vm.getCpuPinningPolicy() == CpuPinningPolicy.NONE) {

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/policyunits/HighPerformanceCpuPolicyUnit.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/policyunits/HighPerformanceCpuPolicyUnit.java
@@ -14,7 +14,6 @@ import org.ovirt.engine.core.common.businessentities.VmType;
 import org.ovirt.engine.core.common.scheduling.PolicyUnit;
 import org.ovirt.engine.core.common.scheduling.PolicyUnitType;
 import org.ovirt.engine.core.common.utils.Pair;
-import org.ovirt.engine.core.common.utils.VmCpuCountHelper;
 import org.ovirt.engine.core.compat.Guid;
 
 @SchedulingUnit(
@@ -60,7 +59,7 @@ public class HighPerformanceCpuPolicyUnit extends PolicyUnitImpl {
     private boolean policyUnitEnabled(VM vm) {
         if (vm.getVmType() == VmType.HighPerformance ||
                 vm.isUsingCpuPassthrough() ||
-                StringUtils.isNotEmpty(VmCpuCountHelper.isDynamicCpuPinning(vm) ? vm.getCurrentCpuPinning() : vm.getCpuPinning())) {
+                StringUtils.isNotEmpty(vm.getVmPinning())) {
             return true;
         }
 

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/utils/NumaPinningHelper.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/utils/NumaPinningHelper.java
@@ -20,7 +20,6 @@ import org.ovirt.engine.core.common.businessentities.VmNumaNode;
 import org.ovirt.engine.core.common.utils.CpuPinningHelper;
 import org.ovirt.engine.core.common.utils.HugePageUtils;
 import org.ovirt.engine.core.common.utils.NumaUtils;
-import org.ovirt.engine.core.common.utils.VmCpuCountHelper;
 import org.ovirt.engine.core.compat.Guid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -78,7 +77,7 @@ public class NumaPinningHelper {
         List<VmNumaNodeData> vmNodesData = vms.stream()
                 .flatMap(vm -> {
                     Map<Integer, Collection<Integer>> cpuPinning = considerCpuPinning ?
-                            CpuPinningHelper.parseCpuPinning(VmCpuCountHelper.isDynamicCpuPinning(vm) ? vm.getCurrentCpuPinning() : vm.getCpuPinning()).stream()
+                            CpuPinningHelper.parseCpuPinning(vm.getVmPinning()).stream()
                                     .collect(Collectors.toMap(p -> p.getvCpu(), p -> p.getpCpus())) :
                             null;
                     Optional<Integer> hugePageSize = HugePageUtils.getHugePageSize(vm.getStaticData());

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/utils/VdsCpuUnitPinningHelper.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/utils/VdsCpuUnitPinningHelper.java
@@ -80,9 +80,6 @@ public class VdsCpuUnitPinningHelper {
      * @return List<{@link VdsCpuUnit}>. The list of VdsCpuUnit we are going to use. If not possible, return null.
      */
     public List<VdsCpuUnit> updatePhysicalCpuAllocations(VM vm, Map<Guid, List<VdsCpuUnit>> vmToPendingPinnings, Guid hostId) {
-        if (vm.getCpuPinningPolicy() == CpuPinningPolicy.NONE) {
-            return new ArrayList<>();
-        }
         List<VdsCpuUnit> cpuTopology = resourceManager.getVdsManager(hostId).getCpuTopology();
         if (cpuTopology.isEmpty()) {
             return new ArrayList<>();
@@ -92,7 +89,10 @@ public class VdsCpuUnitPinningHelper {
 
         if (vm.getCpuPinningPolicy() != CpuPinningPolicy.DEDICATED) {
             List<VdsCpuUnit> cpusToBeAllocated = new ArrayList<>();
-            String cpuPinning = vm.getCpuPinningPolicy() == CpuPinningPolicy.MANUAL ? vm.getCpuPinning() : vm.getCurrentCpuPinning();
+            String cpuPinning = vm.getVmPinning();
+            if (cpuPinning == null || cpuPinning.isEmpty()) {
+                return cpusToBeAllocated;
+            }
             Set<Integer> requestedCpus = CpuPinningHelper.getAllPinnedPCpus(cpuPinning);
             for (Integer cpuId : requestedCpus) {
                 VdsCpuUnit vdsCpuUnit = getCpu(cpuTopology, cpuId);

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/validator/InClusterUpgradeValidator.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/validator/InClusterUpgradeValidator.java
@@ -24,7 +24,6 @@ import org.ovirt.engine.core.common.businessentities.VDS;
 import org.ovirt.engine.core.common.businessentities.VM;
 import org.ovirt.engine.core.common.businessentities.VmNumaNode;
 import org.ovirt.engine.core.common.errors.EngineMessage;
-import org.ovirt.engine.core.common.utils.VmCpuCountHelper;
 import org.ovirt.engine.core.utils.OS;
 
 @Singleton
@@ -70,7 +69,7 @@ public class InClusterUpgradeValidator {
         if (vm.getStatus().isSuspended()) {
             errors.addAll(toVmEngineMessage(vm, EngineMessage.CLUSTER_UPGRADE_DETAIL_VM_SUSPENDED));
         }
-        if (!StringUtils.isEmpty(VmCpuCountHelper.isDynamicCpuPinning(vm) ? vm.getCurrentCpuPinning() : vm.getCpuPinning())) {
+        if (!StringUtils.isEmpty(vm.getVmPinning())) {
             errors.addAll(toVmEngineMessage(vm, EngineMessage.CLUSTER_UPGRADE_DETAIL_VM_CPUS_PINNED));
         }
         for (VmNumaNode vmNumaNode : vm.getvNumaNodeList()) {

--- a/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/scheduling/policyunits/CpuAndNumaPinningWeightPolicyUnitTest.java
+++ b/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/scheduling/policyunits/CpuAndNumaPinningWeightPolicyUnitTest.java
@@ -18,6 +18,7 @@ import org.mockito.quality.Strictness;
 import org.ovirt.engine.core.bll.scheduling.SchedulingContext;
 import org.ovirt.engine.core.bll.scheduling.pending.PendingResourceManager;
 import org.ovirt.engine.core.common.businessentities.Cluster;
+import org.ovirt.engine.core.common.businessentities.CpuPinningPolicy;
 import org.ovirt.engine.core.common.businessentities.VDS;
 import org.ovirt.engine.core.common.businessentities.VM;
 import org.ovirt.engine.core.common.config.ConfigValues;
@@ -66,6 +67,7 @@ public class CpuAndNumaPinningWeightPolicyUnitTest extends NumaPolicyTestBase {
     @Test
     public void testNoVmNuma() {
         vm.setCpuPinning("0#0_1#1");
+        vm.setCpuPinningPolicy(CpuPinningPolicy.MANUAL);
         vm.setvNumaNodeList(Collections.emptyList());
 
         assertThat(score()).extracting("first", "second").contains(
@@ -78,6 +80,7 @@ public class CpuAndNumaPinningWeightPolicyUnitTest extends NumaPolicyTestBase {
     @Test
     public void testNoNumaPinning() {
         vm.setCpuPinning("0#0_1#1");
+        vm.setCpuPinningPolicy(CpuPinningPolicy.MANUAL);
         vm.setvNumaNodeList(Arrays.asList(
                 createVmNode(NODE_SIZE, 0, Collections.emptyList(), Arrays.asList(0)),
                 createVmNode(NODE_SIZE, 1, Collections.emptyList(), Arrays.asList(1))
@@ -108,6 +111,7 @@ public class CpuAndNumaPinningWeightPolicyUnitTest extends NumaPolicyTestBase {
     @Test
     public void testCpuAndNumaPinning() {
         vm.setCpuPinning("0#0_1#1");
+        vm.setCpuPinningPolicy(CpuPinningPolicy.MANUAL);
         vm.setvNumaNodeList(Arrays.asList(
                 createVmNode(NODE_SIZE, 0, Arrays.asList(0), Arrays.asList(0)),
                 createVmNode(NODE_SIZE, 1, Arrays.asList(1), Arrays.asList(1))

--- a/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/validator/InClusterUpgradeValidatorTest.java
+++ b/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/validator/InClusterUpgradeValidatorTest.java
@@ -18,6 +18,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.ovirt.engine.core.bll.ValidationResult;
 import org.ovirt.engine.core.bll.hostdev.HostDeviceManager;
+import org.ovirt.engine.core.common.businessentities.CpuPinningPolicy;
 import org.ovirt.engine.core.common.businessentities.VDS;
 import org.ovirt.engine.core.common.businessentities.VM;
 import org.ovirt.engine.core.common.businessentities.VMStatus;
@@ -83,6 +84,7 @@ public class InClusterUpgradeValidatorTest {
     @Test
     public void shouldDetectInvalidVMOnClusterUpgradeCheck() {
         invalidVM.setCpuPinning("i am pinned");
+        invalidVM.setCpuPinningPolicy(CpuPinningPolicy.MANUAL);
         assertThat(validator.isUpgradePossible(Arrays.asList(newHost1, newHost2), Arrays.asList(validVM, invalidVM)))
                 .isNotEqualTo(ValidationResult.VALID);
     }
@@ -97,6 +99,7 @@ public class InClusterUpgradeValidatorTest {
     @Test
     public void shouldDetectCpuPinning() {
         invalidVM.setCpuPinning("i am pinned");
+        invalidVM.setCpuPinningPolicy(CpuPinningPolicy.MANUAL);
         assertThat(validator.checkVmReadyForUpgrade(invalidVM)).contains(
                 EngineMessage.CLUSTER_UPGRADE_DETAIL_VM_CPUS_PINNED.name());
     }
@@ -131,6 +134,7 @@ public class InClusterUpgradeValidatorTest {
     @Test
     public void shouldCreateNiceValidationResult() {
         invalidVM.setCpuPinning("i am pinned");
+        invalidVM.setCpuPinningPolicy(CpuPinningPolicy.MANUAL);
         invalidVM.setDedicatedVmForVdsList(Collections.singletonList(Guid.newGuid()));
         invalidVM.setMigrationSupport(PINNED_TO_HOST);
         invalidVM.setId(Guid.Empty);

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/VM.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/VM.java
@@ -2008,4 +2008,20 @@ public class VM implements Queryable, BusinessEntityWithStatus<Guid, VMStatus>, 
     public void setCpuPinningPolicy(CpuPinningPolicy cpuPinningPolicy) {
         vmStatic.setCpuPinningPolicy(cpuPinningPolicy);
     }
+
+    /**
+     * Get the CPU pinning string for the VM.
+     *
+     * Manual policy is an exception in which the pinning is specified in vm_static, otherwise
+     * we take it from vm_dynamic.
+     * @return the CPU pinning string.
+     */
+    public String getVmPinning() {
+        if (getCpuPinningPolicy() == CpuPinningPolicy.MANUAL) {
+            return getCpuPinning();
+        }
+        // For VMs with NUMA and without CPU pinning set, the engine creates the CPU pinning.
+        // In this case we save it as dynamic pinning.
+        return getCurrentCpuPinning();
+    }
 }

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/VdsCpuUnit.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/VdsCpuUnit.java
@@ -139,7 +139,8 @@ public class VdsCpuUnit implements Comparable<VdsCpuUnit>, Serializable, Cloneab
         if (!this.vmIds.contains(vmId)) {
             this.vmIds.add(vmId);
         }
-        if (cpuPinningPolicy == CpuPinningPolicy.RESIZE_AND_PIN_NUMA) {
+        // CpuPinningPolicy.NONE may happen when the engine generates CPU pinning based on the NUMA pinning.
+        if (cpuPinningPolicy == CpuPinningPolicy.RESIZE_AND_PIN_NUMA || cpuPinningPolicy == CpuPinningPolicy.NONE) {
             cpuPinningPolicy = CpuPinningPolicy.MANUAL;
         }
         this.cpuPinningPolicy = cpuPinningPolicy;

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/utils/CpuPinningHelper.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/utils/CpuPinningHelper.java
@@ -14,7 +14,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import org.ovirt.engine.core.common.businessentities.VM;
 import org.ovirt.engine.core.common.businessentities.VdsCpuUnit;
 
 public class CpuPinningHelper {
@@ -92,18 +91,6 @@ public class CpuPinningHelper {
             return returnList;
         } else {
             return null;
-        }
-    }
-
-    public static String getVmPinning(VM vm) {
-        switch (vm.getCpuPinningPolicy()) {
-            case MANUAL:
-                return vm.getCpuPinning();
-            case RESIZE_AND_PIN_NUMA:
-            case DEDICATED:
-                return vm.getCurrentCpuPinning();
-            default:
-                return null;
         }
     }
 

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/utils/VmCpuCountHelper.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/utils/VmCpuCountHelper.java
@@ -173,10 +173,6 @@ public class VmCpuCountHelper {
         return vm.getCpuPinningPolicy() == CpuPinningPolicy.RESIZE_AND_PIN_NUMA;
     }
 
-    public static boolean isDynamicCpuPinning(VM vm) {
-        return vm.getCpuPinningPolicy() != CpuPinningPolicy.NONE && vm.getCpuPinningPolicy() != CpuPinningPolicy.MANUAL;
-    }
-
     public static int getDynamicNumOfCpu(VM vm) {
         return isResizeAndPinPolicy(vm) && vm.getCurrentNumOfCpus() > 0 ? vm.getCurrentNumOfCpus() : vm.getNumOfCpus();
     }

--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendHostCpuUnitsResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendHostCpuUnitsResource.java
@@ -57,7 +57,7 @@ public class BackendHostCpuUnitsResource extends AbstractBackendCollectionResour
 
     private void addPinnedVms(List<HostCpuUnit> hostCpuUnits, List<VM> vms) {
         for (VM vm : vms) {
-            String vmPinning = CpuPinningHelper.getVmPinning(vm);
+            String vmPinning = vm.getVmPinning();
             if (vmPinning == null) {
                 continue;
             }

--- a/backend/manager/modules/restapi/types/src/main/java/org/ovirt/engine/api/restapi/types/VmMapper.java
+++ b/backend/manager/modules/restapi/types/src/main/java/org/ovirt/engine/api/restapi/types/VmMapper.java
@@ -300,7 +300,7 @@ public class VmMapper extends VmBaseMapper {
                 Boot boot = map(entity.getBootSequence(), null);
                 model.getOs().setBoot(boot);
             }
-            if (VmCpuCountHelper.isDynamicCpuPinning(entity)) {
+            if (entity.getCurrentCpuPinning() != null) {
                 model.setDynamicCpu(new DynamicCpu());
                 model.getDynamicCpu().setCpuTune(stringToCpuTune(entity.getCurrentCpuPinning()));
                 if (VmCpuCountHelper.isResizeAndPinPolicy(entity)) {

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/VdsManager.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/VdsManager.java
@@ -1270,7 +1270,7 @@ public class VdsManager {
      */
     private void recoverCpuPinning(List<VM> vms) {
         for (VM vm : vms) {
-            String pinning = CpuPinningHelper.getVmPinning(vm);
+            String pinning = vm.getVmPinning();
             if (pinning != null) {
                 Set<Integer> pinnedCpus = CpuPinningHelper.getAllPinnedPCpus(pinning);
                 synchronized (this) {

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/builder/vminfo/VmInfoBuildUtils.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/builder/vminfo/VmInfoBuildUtils.java
@@ -1328,15 +1328,13 @@ public class VmInfoBuildUtils {
                 .collect(Collectors.toMap(split -> split[0], split -> split[1]));
     }
 
-    public boolean isNumaEnabled(MemoizingSupplier<List<VdsNumaNode>> hostNumaNodesSupplier,
-            MemoizingSupplier<List<VmNumaNode>> vmNumaNodesSupplier, VM vm) {
-        List<VdsNumaNode> hostNumaNodes = hostNumaNodesSupplier.get();
+    public boolean isNumaEnabled(List<VdsNumaNode> hostNumaNodes,
+            List<VmNumaNode> vmNumaNodes, VM vm) {
         if (hostNumaNodes.isEmpty()) {
             log.warn("No host NUMA nodes found for vm {} ({})", vm.getName(), vm.getId());
             return false;
         }
 
-        List<VmNumaNode> vmNumaNodes = vmNumaNodesSupplier.get();
         if (vmNumaNodes.isEmpty()) {
             return false;
         }


### PR DESCRIPTION
When creating a VM without CPU pinning but with NUMA pinning the engine
generated CPU pinning according to the NUMA pinning of the VM. It was
made to ensure the virtual CPUs are using the right physical CPU in the
desired NUMA. The CPU pinning was not saved to the DB, it was written to
the VM domain XML.

Since the new CPU pinning policies, VDSM requires a policy that is not
`none` to save the CPU pinning of the VM when migrating it to a new
host. Also, for supporting `dedicated` policy, the engine needs to know
what the status of usage of each physical CPU.

Therefore, the generated CPU will happen on scheduling, right after the
host being selected and will be saved to the dynamic CPU.

Change-Id: I9a10e1e6b2e2933cd0f96a20192e9837944d79b7
Bug-Url: https://bugzilla.redhat.com/2065152
Signed-off-by: Liran Rotenberg <lrotenbe@redhat.com>