### PR TITLE
fapolicy: add allow rule for vdsm-mom

### DIFF
--- a/packaging/ansible-runner-service-project/project/roles/ovirt-host-deploy-vdsm/tasks/configure.yml
+++ b/packaging/ansible-runner-service-project/project/roles/ovirt-host-deploy-vdsm/tasks/configure.yml
@@ -64,3 +64,18 @@
 - name: Configure host for vdsm
   command: vdsm-tool configure --force
   changed_when: True
+
+- name: add vdsm-mom allow rule to fapolicy
+  copy:
+   dest: /etc/fapolicyd/rules.d/32-allow-vdsm-mom.rules
+   group: fapolicyd
+   mode: '0644'
+   remote_src: yes
+   content: |
+     allow perm=any trust=1 : dir=/etc/vdsm/mom.d/ ftype=text/x-lisp
+  when: ansible_distribution == 'RedHat'
+
+- name: restart fapolicy service
+  systemd:
+   state: restarted
+   name: fapolicyd


### PR DESCRIPTION
currently, vdsm-mom service is blocked by one of the fapolciy rules,
adding an exception rule for the service.

Bug-Url: https://bugzilla.redhat.com/2015802