### PR TITLE
core: fix treatment of disks with full backup mode

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/TransferDiskImageCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/TransferDiskImageCommand.java
@@ -44,6 +44,7 @@ import org.ovirt.engine.core.common.businessentities.VDSDomainsData;
 import org.ovirt.engine.core.common.businessentities.VM;
 import org.ovirt.engine.core.common.businessentities.VmBackup;
 import org.ovirt.engine.core.common.businessentities.VmBackupPhase;
+import org.ovirt.engine.core.common.businessentities.storage.DiskBackupMode;
 import org.ovirt.engine.core.common.businessentities.storage.DiskImage;
 import org.ovirt.engine.core.common.businessentities.storage.ImageStatus;
 import org.ovirt.engine.core.common.businessentities.storage.ImageTicket;
@@ -247,14 +248,15 @@ public class TransferDiskImageCommand<T extends TransferDiskImageParameters> ext
     }
 
     private Guid getBitmap() {
-        if (isHybridBackup() && getDiskImage().isQcowFormat()) {
+        if (isHybridBackup() && getDiskImage().getBackupMode() == DiskBackupMode.Incremental) {
             return getBackup().getFromCheckpointId();
         }
 
         if (getParameters().getTransferType() == TransferType.Download
                 && getBackupVm() != null
                 && getBackupVm().isDown()
-                && getDiskImage().isQcowFormat()) {
+                && getDiskImage().isQcowFormat()
+                && getDiskImage().getBackupMode() == DiskBackupMode.Incremental) {
             return getBackup().getFromCheckpointId();
         }
         return null;

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/TransferDiskImageCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/TransferDiskImageCommand.java
@@ -1209,7 +1209,9 @@ public class TransferDiskImageCommand<T extends TransferDiskImageParameters> ext
     }
 
     private boolean isSupportsDirtyExtents() {
-        if (!isBackup() || getParameters().getTransferType() != TransferType.Download) {
+        if (!isBackup() ||
+                getParameters().getTransferType() != TransferType.Download ||
+                getDiskImage().getBackupMode() != DiskBackupMode.Incremental) {
             return false;
         }
         VmBackup backup = getBackup();


### PR DESCRIPTION
RAW disks being backed up in a backup that uses a checkpoint are considered incremental instead of full, if they have qcow overlay. Instead we need to consider the backup mode set for the disk

* Do not use the bitmap if the disk being transfer has the full backup mode
* Do not use dirty extents if the disk being transfer has the full backup mode

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=2068104