### PR TITLE
Respect deprecated custom property mdev_type on add/update VM

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/AddVmCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/AddVmCommand.java
@@ -119,6 +119,7 @@ import org.ovirt.engine.core.common.locks.LockingGroup;
 import org.ovirt.engine.core.common.osinfo.OsRepository;
 import org.ovirt.engine.core.common.queries.VmIconIdSizePair;
 import org.ovirt.engine.core.common.scheduling.AffinityGroup;
+import org.ovirt.engine.core.common.utils.MDevTypesUtils;
 import org.ovirt.engine.core.common.utils.Pair;
 import org.ovirt.engine.core.common.utils.VmCpuCountHelper;
 import org.ovirt.engine.core.common.utils.VmDeviceType;
@@ -129,7 +130,6 @@ import org.ovirt.engine.core.compat.Version;
 import org.ovirt.engine.core.dal.dbbroker.auditloghandling.AuditLogDirector;
 import org.ovirt.engine.core.dal.dbbroker.auditloghandling.AuditLogable;
 import org.ovirt.engine.core.dao.ClusterDao;
-import org.ovirt.engine.core.dao.DiskImageDao;
 import org.ovirt.engine.core.dao.DiskVmElementDao;
 import org.ovirt.engine.core.dao.LabelDao;
 import org.ovirt.engine.core.dao.PermissionDao;
@@ -192,6 +192,7 @@ public class AddVmCommand<T extends AddVmParameters> extends VmManagementCommand
     private VmTemplate vmDisksSource;
     private VmBase vmDevicesSource;
     private List<StorageDomain> poolDomains;
+    private String mdevType; // the value of the deprecated custom property mdev_type, if specified
 
     private Map<Guid, Guid> srcVmNicIdToTargetVmNicIdMapping = new HashMap<>();
 
@@ -227,8 +228,6 @@ public class AddVmCommand<T extends AddVmParameters> extends VmManagementCommand
     private AffinityGroupDao affinityGroupDao;
     @Inject
     private LabelDao labelDao;
-    @Inject
-    private DiskImageDao diskImageDao;
 
     @Inject
     private VmInitDao vmInitDao;
@@ -305,6 +304,14 @@ public class AddVmCommand<T extends AddVmParameters> extends VmManagementCommand
             imageTypeId = parameters.getVmStaticData().getImageTypeId();
             vmInterfacesSourceId = parameters.getVmStaticData().getVmtGuid();
             vmDisksSource = getVmTemplate();
+
+            var givenVm = getParameters().getVmStaticData();
+            var vmPropertiesUtils = VmPropertiesUtils.getInstance();
+            var customProperties = vmPropertiesUtils.convertProperties(givenVm.getCustomProperties());
+            mdevType = customProperties.remove(MDevTypesUtils.DEPRECATED_CUSTOM_PROPERTY_NAME);
+            if (mdevType != null) {
+                givenVm.setCustomProperties(vmPropertiesUtils.convertProperties(customProperties));
+            }
         }
 
         parameters.setEntityInfo(new EntityInfo(VdcObjectType.VM, getVmId()));
@@ -1072,6 +1079,7 @@ public class AddVmCommand<T extends AddVmParameters> extends VmManagementCommand
             updateSmartCardDevices();
             addVmWatchdog();
             addGraphicsDevice();
+            addMdevDevices();
             getVmDeviceUtils().updateVirtioScsiController(getVm().getStaticData(),
                     getParameters().isVirtioScsiEnabled());
             updateVmDevicesOnChipsetChange();
@@ -1115,6 +1123,13 @@ public class AddVmCommand<T extends AddVmParameters> extends VmManagementCommand
 
             graphicsDevice.setVmId(getVmId());
             backend.runInternalAction(ActionType.AddGraphicsDevice, new GraphicsParameters(graphicsDevice));
+        }
+    }
+
+    private void addMdevDevices() {
+        if (mdevType != null) {
+            var convertedMdevDevices = MDevTypesUtils.convertDeprecatedCustomPropertyToVmDevices(mdevType, getVmId());
+            vmDeviceDao.saveAll(convertedMdevDevices);
         }
     }
 

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/UpdateVmCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/UpdateVmCommand.java
@@ -95,6 +95,7 @@ import org.ovirt.engine.core.common.queries.QueryReturnValue;
 import org.ovirt.engine.core.common.queries.QueryType;
 import org.ovirt.engine.core.common.scheduling.AffinityGroup;
 import org.ovirt.engine.core.common.utils.HugePageUtils;
+import org.ovirt.engine.core.common.utils.MDevTypesUtils;
 import org.ovirt.engine.core.common.utils.Pair;
 import org.ovirt.engine.core.common.utils.VmCommonUtils;
 import org.ovirt.engine.core.common.utils.VmCpuCountHelper;
@@ -194,6 +195,7 @@ public class UpdateVmCommand<T extends VmManagementParametersBase> extends VmMan
     private VmStatic newVmStatic;
     private List<GraphicsDevice> cachedGraphics;
     private boolean isUpdateVmTemplateVersion = false;
+    private String mdevType; // the value of the deprecated custom property mdev_type, if specified
 
     private BiConsumer<AuditLogable, AuditLogDirector> affinityGroupLoggingMethod = (a, b) -> {};
 
@@ -210,6 +212,13 @@ public class UpdateVmCommand<T extends VmManagementParametersBase> extends VmMan
         }
 
         if (isVmExist() && isCompatibilityVersionSupportedByCluster(getEffectiveCompatibilityVersion())) {
+            var givenVm = getParameters().getVmStaticData();
+            var customProperties = getVmPropertiesUtils().convertProperties(givenVm.getCustomProperties());
+            mdevType = customProperties.remove(MDevTypesUtils.DEPRECATED_CUSTOM_PROPERTY_NAME);
+            if (mdevType != null) {
+                givenVm.setCustomProperties(getVmPropertiesUtils().convertProperties(customProperties));
+            }
+
             Version compatibilityVersion = getEffectiveCompatibilityVersion();
             getVmPropertiesUtils().separateCustomPropertiesToUserAndPredefined(
                     compatibilityVersion, getParameters().getVmStaticData());
@@ -329,6 +338,7 @@ public class UpdateVmCommand<T extends VmManagementParametersBase> extends VmMan
             VmStatic oldStatic = oldVm.getStaticData();
             getCompensationContext().snapshotEntityUpdated(oldStatic);
         }
+
         resourceManager.getVmManager(getVmId()).update(newVmStatic);
 
         // Hosted Engine and kubevirt doesn't use next-run snapshots. Instead it requires the configuration
@@ -342,6 +352,7 @@ public class UpdateVmCommand<T extends VmManagementParametersBase> extends VmMan
             updateVmHostDevices();
             updateVmDevicesOnEmulatedMachineChange();
             updateVmDevicesOnChipsetChange();
+            updateMdevDevices();
         }
         iconUtils.removeUnusedIcons(oldIconIds, getCompensationContextIfEnabledByCaller());
         vmHandler.updateVmInitToDB(getParameters().getVmStaticData(), getCompensationContextIfEnabledByCaller());
@@ -445,6 +456,14 @@ public class UpdateVmCommand<T extends VmManagementParametersBase> extends VmMan
 
             log.info("Pinned host changed for VM: {}. Dropping configured host devices.", getVm().getName());
             vmDeviceDao.removeVmDevicesByVmIdAndType(getVmId(), VmDeviceGeneralType.HOSTDEV);
+        }
+    }
+
+    private void updateMdevDevices() {
+        if (mdevType != null) {
+            var convertedMdevDevices = MDevTypesUtils.convertDeprecatedCustomPropertyToVmDevices(mdevType, getVmId());
+            vmDeviceDao.removeVmDevicesByVmIdAndType(getVmId(), VmDeviceGeneralType.MDEV);
+            vmDeviceDao.saveAll(convertedMdevDevices);
         }
     }
 

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/utils/MDevTypesUtils.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/utils/MDevTypesUtils.java
@@ -9,6 +9,7 @@ import org.ovirt.engine.core.compat.Version;
 
 public class MDevTypesUtils {
 
+    public static final String DEPRECATED_CUSTOM_PROPERTY_NAME = "mdev_type";
     public static final String MDEV_TYPE = "mdevType";
     public static final String DRIVER_PARAMETERS = "driverParams";
     public static final String NODISPLAY = "nodisplay";

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/utils/customprop/CustomPropertiesUtils.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/utils/customprop/CustomPropertiesUtils.java
@@ -290,9 +290,7 @@ public class CustomPropertiesUtils {
         }
 
         if (regExMap != null) {
-            for (ValidationError error : validateProperties(regExMap, map)) {
-                map.remove(error.getKeyName());
-            }
+            validateProperties(regExMap, map).stream().map(ValidationError::getKeyName).forEach(map::remove);
         }
 
         return map;

--- a/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfReader.java
+++ b/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfReader.java
@@ -901,9 +901,9 @@ public abstract class OvfReader implements IOvfBuilder {
 
     private void addPredefinedProperties(String properties) {
         if (properties != null) {
-            final SimpleCustomPropertiesUtil util = SimpleCustomPropertiesUtil.getInstance();
-            final Map<String, String> customProperties = util.convertProperties(properties);
-            final String mdevTypes = customProperties.get(MDevTypesUtils.DEPRECATED_CUSTOM_PROPERTY_NAME);
+            var simpleCustomPropertiesUtil = SimpleCustomPropertiesUtil.getInstance();
+            var customProperties = simpleCustomPropertiesUtil.convertProperties(properties);
+            String mdevTypes = customProperties.remove(MDevTypesUtils.DEPRECATED_CUSTOM_PROPERTY_NAME);
             if (mdevTypes != null && !mdevTypes.trim().isEmpty()) {
                 Boolean nodisplay = Boolean.FALSE;
                 for (String type : mdevTypes.split(",")) {
@@ -924,8 +924,7 @@ public abstract class OvfReader implements IOvfBuilder {
                         addManagedVmDevice(device);
                     }
                 }
-                customProperties.remove(MDevTypesUtils.DEPRECATED_CUSTOM_PROPERTY_NAME);
-                properties = util.convertProperties(customProperties);
+                properties = simpleCustomPropertiesUtil.convertProperties(customProperties);
             }
         }
         vmBase.setPredefinedProperties(properties);

--- a/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfReader.java
+++ b/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfReader.java
@@ -903,8 +903,7 @@ public abstract class OvfReader implements IOvfBuilder {
         if (properties != null) {
             final SimpleCustomPropertiesUtil util = SimpleCustomPropertiesUtil.getInstance();
             final Map<String, String> customProperties = util.convertProperties(properties);
-            String mdev_type = "mdev_type";
-            final String mdevTypes = customProperties.get(mdev_type);
+            final String mdevTypes = customProperties.get(MDevTypesUtils.DEPRECATED_CUSTOM_PROPERTY_NAME);
             if (mdevTypes != null && !mdevTypes.trim().isEmpty()) {
                 Boolean nodisplay = Boolean.FALSE;
                 for (String type : mdevTypes.split(",")) {
@@ -925,7 +924,7 @@ public abstract class OvfReader implements IOvfBuilder {
                         addManagedVmDevice(device);
                     }
                 }
-                customProperties.remove(mdev_type);
+                customProperties.remove(MDevTypesUtils.DEPRECATED_CUSTOM_PROPERTY_NAME);
                 properties = util.convertProperties(customProperties);
             }
         }

--- a/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfReader.java
+++ b/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfReader.java
@@ -905,25 +905,8 @@ public abstract class OvfReader implements IOvfBuilder {
             var customProperties = simpleCustomPropertiesUtil.convertProperties(properties);
             String mdevTypes = customProperties.remove(MDevTypesUtils.DEPRECATED_CUSTOM_PROPERTY_NAME);
             if (mdevTypes != null && !mdevTypes.trim().isEmpty()) {
-                Boolean nodisplay = Boolean.FALSE;
-                for (String type : mdevTypes.split(",")) {
-                    if (type.equals("nodisplay")) {
-                        nodisplay = Boolean.TRUE;
-                    } else {
-                        VmDevice device = new VmDevice();
-                        device.setId(new VmDeviceId(Guid.newGuid(), vmBase.getId()));
-                        device.setType(VmDeviceGeneralType.MDEV);
-                        device.setDevice(VmDeviceType.VGPU.getName());
-                        device.setAddress("");
-                        device.setManaged(true);
-                        device.setPlugged(true);
-                        Map<String, Object> specParams = new HashMap<>();
-                        specParams.put(MDevTypesUtils.MDEV_TYPE, type);
-                        specParams.put(MDevTypesUtils.NODISPLAY, nodisplay);
-                        device.setSpecParams(specParams);
-                        addManagedVmDevice(device);
-                    }
-                }
+                var mdevDevices = MDevTypesUtils.convertDeprecatedCustomPropertyToVmDevices(mdevTypes, vmBase.getId());
+                mdevDevices.forEach(this::addManagedVmDevice);
                 properties = simpleCustomPropertiesUtil.convertProperties(customProperties);
             }
         }

--- a/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfWriter.java
+++ b/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfWriter.java
@@ -364,7 +364,7 @@ public abstract class OvfWriter implements IOvfBuilder {
                 if (predefinedProperties == null || predefinedProperties.isEmpty()) {
                     predefinedProperties = vgpuProperties;
                 } else {
-                    predefinedProperties = predefinedProperties + ";" + vgpuProperties;
+                    predefinedProperties += ";" + vgpuProperties;
                 }
             }
         }

--- a/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfWriter.java
+++ b/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfWriter.java
@@ -360,7 +360,7 @@ public abstract class OvfWriter implements IOvfBuilder {
                         .equals((Boolean) device.getSpecParams().get(MDevTypesUtils.NODISPLAY)))) {
                     vgpuProperties = "nodisplay," + vgpuProperties;
                 }
-                vgpuProperties = "mdev_type=" + vgpuProperties;
+                vgpuProperties = String.format("%s=%s", MDevTypesUtils.DEPRECATED_CUSTOM_PROPERTY_NAME, vgpuProperties);
                 if (predefinedProperties == null || predefinedProperties.isEmpty()) {
                     predefinedProperties = vgpuProperties;
                 } else {


### PR DESCRIPTION
We dropped the custom property mdev_type from the predefined properties 
in favor of (fake) VM devices. However, this breaks backward compatibility
with clients that specify the vGPU settings using this custom property.

Therefore PR changes add-VM and update-VM to respect the mdev_type 
custom property when specified. Note that the custom property was already 
converted to VM devices when reading an OVF and that covered most of the 
cases, like snapshots that were taken while mdev_type existed - that
code is now being reused in the aforementioned flows.