### PR TITLE
Fix readRate/writeRate (long instead of int)

### DIFF
--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/storage/DiskImage.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/storage/DiskImage.java
@@ -22,9 +22,9 @@ public class DiskImage extends DiskImageBase {
     private long actualSizeInBytes;
     private long apparentSizeInBytes;
     private Long initialSizeInBytes;
-    private int readRateFromDiskImageDynamic;
+    private long readRateFromDiskImageDynamic;
     private long readOpsFromDiskImageDynamic;
-    private int writeRateFromDiskImageDynamic;
+    private long writeRateFromDiskImageDynamic;
     private long writeOpsFromDiskImageDynamic;
 
     // Latency fields from DiskImageDynamic which are measured in seconds.
@@ -226,11 +226,11 @@ public class DiskImage extends DiskImageBase {
         this.apparentSizeInBytes = apparentSizeInBytes;
     }
 
-    public int getReadRate() {
+    public long getReadRate() {
         return readRateFromDiskImageDynamic;
     }
 
-    public void setReadRate(int readRateFromDiskImageDynamic) {
+    public void setReadRate(long readRateFromDiskImageDynamic) {
         this.readRateFromDiskImageDynamic = readRateFromDiskImageDynamic;
     }
 
@@ -242,11 +242,11 @@ public class DiskImage extends DiskImageBase {
         this.readOpsFromDiskImageDynamic = readOpsFromDiskImageDynamic;
     }
 
-    public int getWriteRate() {
+    public long getWriteRate() {
         return writeRateFromDiskImageDynamic;
     }
 
-    public void setWriteRate(int writeRateFromDiskImageDynamic) {
+    public void setWriteRate(long writeRateFromDiskImageDynamic) {
         this.writeRateFromDiskImageDynamic = writeRateFromDiskImageDynamic;
     }
 

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/storage/DiskImageDynamic.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/storage/DiskImageDynamic.java
@@ -10,11 +10,11 @@ public class DiskImageDynamic implements BusinessEntity<Guid>, Comparable<DiskIm
     private static final long serialVersionUID = 6357763045419255853L;
     private Guid id;
 
-    private Integer readRate;
+    private Long readRate;
 
     private Long readOps;
 
-    private Integer writeRate;
+    private Long writeRate;
 
     private Long writeOps;
 
@@ -30,11 +30,11 @@ public class DiskImageDynamic implements BusinessEntity<Guid>, Comparable<DiskIm
     public DiskImageDynamic() {
     }
 
-    public Integer getReadRate() {
+    public Long getReadRate() {
         return readRate;
     }
 
-    public void setReadRate(Integer rate) {
+    public void setReadRate(Long rate) {
         readRate = rate;
     }
 
@@ -46,11 +46,11 @@ public class DiskImageDynamic implements BusinessEntity<Guid>, Comparable<DiskIm
         readOps = ops;
     }
 
-    public Integer getWriteRate() {
+    public Long getWriteRate() {
         return writeRate;
     }
 
-    public void setWriteRate(Integer rate) {
+    public void setWriteRate(Long rate) {
         writeRate = rate;
     }
 

--- a/backend/manager/modules/dal/src/main/java/org/ovirt/engine/core/dao/DiskImageDaoImpl.java
+++ b/backend/manager/modules/dal/src/main/java/org/ovirt/engine/core/dao/DiskImageDaoImpl.java
@@ -246,9 +246,9 @@ public class DiskImageDaoImpl extends BaseDao implements DiskImageDao {
             }
             entity.setId(getGuidDefaultEmpty(rs, "image_group_id"));
             entity.setStoragePoolId(getGuid(rs, "storage_pool_id"));
-            entity.setReadRate(rs.getInt("read_rate"));
+            entity.setReadRate(rs.getLong("read_rate"));
             entity.setReadOps(rs.getLong("read_ops"));
-            entity.setWriteRate(rs.getInt("write_rate"));
+            entity.setWriteRate(rs.getLong("write_rate"));
             entity.setWriteOps(rs.getLong("write_ops"));
             entity.setImageTransferPhase(rs.getObject("image_transfer_phase") != null
                     ? ImageTransferPhase.forValue(rs.getInt("image_transfer_phase")) : null);

--- a/backend/manager/modules/dal/src/main/java/org/ovirt/engine/core/dao/DiskImageDynamicDaoImpl.java
+++ b/backend/manager/modules/dal/src/main/java/org/ovirt/engine/core/dao/DiskImageDynamicDaoImpl.java
@@ -53,9 +53,9 @@ public class DiskImageDynamicDaoImpl extends MassOperationsGenericDao<DiskImageD
         return (rs, rowNum) -> {
             DiskImageDynamic entity = new DiskImageDynamic();
             entity.setId(getGuidDefaultEmpty(rs, "image_id"));
-            entity.setReadRate((Integer) rs.getObject("read_rate"));
+            entity.setReadRate((Long) rs.getObject("read_rate"));
             entity.setReadOps((Long) rs.getObject("read_ops"));
-            entity.setWriteRate((Integer) rs.getObject("write_rate"));
+            entity.setWriteRate((Long) rs.getObject("write_rate"));
             entity.setWriteOps((Long) rs.getObject("write_ops"));
             entity.setActualSize(rs.getLong("actual_size"));
             entity.setReadLatency(rs.getObject("read_latency_seconds") != null ? rs.getDouble("read_latency_seconds")

--- a/backend/manager/modules/dal/src/test/java/org/ovirt/engine/core/dao/DiskImageDynamicDaoTest.java
+++ b/backend/manager/modules/dal/src/test/java/org/ovirt/engine/core/dao/DiskImageDynamicDaoTest.java
@@ -46,9 +46,9 @@ public class DiskImageDynamicDaoTest extends BaseGenericDaoTestCase<Guid, DiskIm
 
     public DiskImageDynamic createDiskImageDynamic(Guid id) {
         DiskImageDynamic dynamic = new DiskImageDynamic();
-        dynamic.setReadRate(5);
+        dynamic.setReadRate(5L);
         dynamic.setReadOps(6L);
-        dynamic.setWriteRate(7);
+        dynamic.setWriteRate(7L);
         dynamic.setWriteOps(8L);
         dynamic.setReadLatency(0d);
         dynamic.setFlushLatency(0.0202020d);
@@ -61,7 +61,7 @@ public class DiskImageDynamicDaoTest extends BaseGenericDaoTestCase<Guid, DiskIm
     public void testUpdateAll() {
         DiskImageDynamic existingEntity2 = dao.get(new Guid("42058975-3d5e-484a-80c1-01c31207f579"));
         existingEntity.setActualSize(100);
-        existingEntity2.setReadRate(120);
+        existingEntity2.setReadRate(120L);
         existingEntity.setReadLatency(100d);
         existingEntity2.setReadLatency(0.00001d);
 
@@ -77,10 +77,10 @@ public class DiskImageDynamicDaoTest extends BaseGenericDaoTestCase<Guid, DiskIm
         Guid imageGroupId = FixturesTool.IMAGE_GROUP_ID_2;
 
         DiskImageDynamic existingEntity2 = dao.get(imageId);
-        assertNotEquals(120, (int) existingEntity2.getReadRate());
+        assertNotEquals(120, existingEntity2.getReadRate());
 
         existingEntity2.setId(imageGroupId);
-        Integer readRate = 120;
+        Long readRate = 120L;
         existingEntity2.setReadRate(readRate);
 
         // test that the record is updated when the active disk is attached to the vm
@@ -90,7 +90,7 @@ public class DiskImageDynamicDaoTest extends BaseGenericDaoTestCase<Guid, DiskIm
         existingEntity2.setId(imageId);
         assertEquals(existingEntity2, dao.get(imageId));
 
-        existingEntity2.setReadRate(150);
+        existingEntity2.setReadRate(150L);
         dao.updateAllDiskImageDynamicWithDiskIdByVmId(Collections.singleton(new Pair<>(FixturesTool.VM_RHEL5_POOL_57,
                 existingEntity2)));
         assertEquals(readRate, dao.get(imageId).getReadRate());

--- a/backend/manager/modules/restapi/jaxrs/src/test/java/org/ovirt/engine/api/restapi/resource/BackendDiskResourceTest.java
+++ b/backend/manager/modules/restapi/jaxrs/src/test/java/org/ovirt/engine/api/restapi/resource/BackendDiskResourceTest.java
@@ -151,9 +151,9 @@ public class BackendDiskResourceTest
     }
 
     static org.ovirt.engine.core.common.businessentities.storage.Disk setUpStatisticalEntityExpectations(DiskImage entity) {
-        entity.setReadRate(1);
+        entity.setReadRate(1L);
         entity.setReadOps(2L);
-        entity.setWriteRate(3);
+        entity.setWriteRate(3L);
         entity.setWriteOps(4L);
         entity.setReadLatency(5.0);
         entity.setWriteLatency(6.0);

--- a/backend/manager/modules/restapi/jaxrs/src/test/java/org/ovirt/engine/api/restapi/resource/BackendDisksResourceTest.java
+++ b/backend/manager/modules/restapi/jaxrs/src/test/java/org/ovirt/engine/api/restapi/resource/BackendDisksResourceTest.java
@@ -65,9 +65,9 @@ public class BackendDisksResourceTest extends AbstractBackendCollectionResourceT
         return setUpStatisticalEntityExpectations(entity);    }
 
     static org.ovirt.engine.core.common.businessentities.storage.Disk setUpStatisticalEntityExpectations(DiskImage entity) {
-        entity.setReadRate(1);
+        entity.setReadRate(1L);
         entity.setReadOps(2L);
-        entity.setWriteRate(3);
+        entity.setWriteRate(3L);
         entity.setWriteOps(4L);
         entity.setReadLatency(5.0);
         entity.setWriteLatency(6.0);

--- a/backend/manager/modules/restapi/jaxrs/src/test/java/org/ovirt/engine/api/restapi/resource/BackendExportDomainDisksResourceTest.java
+++ b/backend/manager/modules/restapi/jaxrs/src/test/java/org/ovirt/engine/api/restapi/resource/BackendExportDomainDisksResourceTest.java
@@ -94,9 +94,9 @@ public class BackendExportDomainDisksResourceTest
         return setUpStatisticalEntityExpectations(entity);    }
 
     static org.ovirt.engine.core.common.businessentities.storage.Disk setUpStatisticalEntityExpectations(DiskImage entity) {
-        entity.setReadRate(1);
+        entity.setReadRate(1L);
         entity.setReadOps(2L);
-        entity.setWriteRate(3);
+        entity.setWriteRate(3L);
         entity.setWriteOps(4L);
         entity.setReadLatency(5.0);
         entity.setWriteLatency(6.0);

--- a/backend/manager/modules/restapi/jaxrs/src/test/java/org/ovirt/engine/api/restapi/resource/BackendStorageDomainDiskResourceTest.java
+++ b/backend/manager/modules/restapi/jaxrs/src/test/java/org/ovirt/engine/api/restapi/resource/BackendStorageDomainDiskResourceTest.java
@@ -133,9 +133,9 @@ public class BackendStorageDomainDiskResourceTest
         return setUpStatisticalEntityExpectations(entity);
     }
     static org.ovirt.engine.core.common.businessentities.storage.Disk setUpStatisticalEntityExpectations(DiskImage entity) {
-        entity.setReadRate(1);
+        entity.setReadRate(1L);
         entity.setReadOps(2L);
-        entity.setWriteRate(3);
+        entity.setWriteRate(3L);
         entity.setWriteOps(4L);
         entity.setReadLatency(5.0);
         entity.setWriteLatency(6.0);

--- a/backend/manager/modules/restapi/jaxrs/src/test/java/org/ovirt/engine/api/restapi/resource/BackendStorageDomainDisksResourceTest.java
+++ b/backend/manager/modules/restapi/jaxrs/src/test/java/org/ovirt/engine/api/restapi/resource/BackendStorageDomainDisksResourceTest.java
@@ -64,9 +64,9 @@ public class BackendStorageDomainDisksResourceTest extends AbstractBackendCollec
         return setUpStatisticalEntityExpectations(entity);    }
 
     static org.ovirt.engine.core.common.businessentities.storage.Disk setUpStatisticalEntityExpectations(DiskImage entity) {
-        entity.setReadRate(1);
+        entity.setReadRate(1L);
         entity.setReadOps(2L);
-        entity.setWriteRate(3);
+        entity.setWriteRate(3L);
         entity.setWriteOps(4L);
         entity.setReadLatency(5.0);
         entity.setWriteLatency(6.0);

--- a/backend/manager/modules/restapi/jaxrs/src/test/java/org/ovirt/engine/api/restapi/resource/BackendTemplateDiskResourceTest.java
+++ b/backend/manager/modules/restapi/jaxrs/src/test/java/org/ovirt/engine/api/restapi/resource/BackendTemplateDiskResourceTest.java
@@ -349,9 +349,9 @@ public class BackendTemplateDiskResourceTest
     }
 
     private org.ovirt.engine.core.common.businessentities.storage.Disk setUpStatisticalEntityExpectations(DiskImage entity) {
-        when(entity.getReadRate()).thenReturn(1);
+        when(entity.getReadRate()).thenReturn(1L);
         when(entity.getReadOps()).thenReturn(2L);
-        when(entity.getWriteRate()).thenReturn(3);
+        when(entity.getWriteRate()).thenReturn(3L);
         when(entity.getWriteOps()).thenReturn(4L);
         when(entity.getReadLatency()).thenReturn(5.0);
         when(entity.getWriteLatency()).thenReturn(6.0);

--- a/backend/manager/modules/restapi/jaxrs/src/test/java/org/ovirt/engine/api/restapi/resource/BackendTemplateDisksResourceTest.java
+++ b/backend/manager/modules/restapi/jaxrs/src/test/java/org/ovirt/engine/api/restapi/resource/BackendTemplateDisksResourceTest.java
@@ -104,9 +104,9 @@ public class BackendTemplateDisksResourceTest
     }
 
     static org.ovirt.engine.core.common.businessentities.storage.Disk setUpStatisticalEntityExpectations(DiskImage entity) {
-        when(entity.getReadRate()).thenReturn(1);
+        when(entity.getReadRate()).thenReturn(1L);
         when(entity.getReadOps()).thenReturn(2L);
-        when(entity.getWriteRate()).thenReturn(3);
+        when(entity.getWriteRate()).thenReturn(3L);
         when(entity.getWriteOps()).thenReturn(4L);
         when(entity.getReadLatency()).thenReturn(5.0);
         when(entity.getWriteLatency()).thenReturn(6.0);

--- a/backend/manager/modules/restapi/jaxrs/src/test/java/org/ovirt/engine/api/restapi/resource/BackendVmDiskResourceTest.java
+++ b/backend/manager/modules/restapi/jaxrs/src/test/java/org/ovirt/engine/api/restapi/resource/BackendVmDiskResourceTest.java
@@ -287,9 +287,9 @@ public class BackendVmDiskResourceTest
     protected DiskImage setUpStatisticalExpectations() {
         DiskImage entity = mock(DiskImage.class);
         when(entity.getId()).thenReturn(DISK_ID);
-        when(entity.getReadRate()).thenReturn(10);
+        when(entity.getReadRate()).thenReturn(10L);
         when(entity.getReadOps()).thenReturn(15L);
-        when(entity.getWriteRate()).thenReturn(20);
+        when(entity.getWriteRate()).thenReturn(20L);
         when(entity.getWriteOps()).thenReturn(25L);
         when(entity.getReadLatency()).thenReturn(30.0);
         when(entity.getWriteLatency()).thenReturn(40.0);
@@ -526,9 +526,9 @@ public class BackendVmDiskResourceTest
     }
 
     private org.ovirt.engine.core.common.businessentities.storage.Disk setUpStatisticalEntityExpectations(DiskImage entity) {
-        when(entity.getReadRate()).thenReturn(1);
+        when(entity.getReadRate()).thenReturn(1L);
         when(entity.getReadOps()).thenReturn(2L);
-        when(entity.getWriteRate()).thenReturn(3);
+        when(entity.getWriteRate()).thenReturn(3L);
         when(entity.getWriteOps()).thenReturn(4L);
         when(entity.getReadLatency()).thenReturn(5.0);
         when(entity.getWriteLatency()).thenReturn(6.0);

--- a/backend/manager/modules/restapi/jaxrs/src/test/java/org/ovirt/engine/api/restapi/resource/BackendVmDisksResourceTest.java
+++ b/backend/manager/modules/restapi/jaxrs/src/test/java/org/ovirt/engine/api/restapi/resource/BackendVmDisksResourceTest.java
@@ -122,9 +122,9 @@ public class BackendVmDisksResourceTest
     }
 
     static org.ovirt.engine.core.common.businessentities.storage.Disk setUpStatisticalEntityExpectations(DiskImage entity) {
-        when(entity.getReadRate()).thenReturn(1);
+        when(entity.getReadRate()).thenReturn(1L);
         when(entity.getReadOps()).thenReturn(2L);
-        when(entity.getWriteRate()).thenReturn(3);
+        when(entity.getWriteRate()).thenReturn(3L);
         when(entity.getWriteOps()).thenReturn(4L);
         when(entity.getReadLatency()).thenReturn(5.0);
         when(entity.getWriteLatency()).thenReturn(6.0);

--- a/backend/manager/modules/restapi/jaxrs/src/test/java/org/ovirt/engine/api/restapi/resource/DiskStatisticalQueryTest.java
+++ b/backend/manager/modules/restapi/jaxrs/src/test/java/org/ovirt/engine/api/restapi/resource/DiskStatisticalQueryTest.java
@@ -16,9 +16,9 @@ public class DiskStatisticalQueryTest {
     private static final double READ_LATENCY = 1.1;
     private static final double WRITE_LATENCY = 2.2;
     private static final double FLUSH_LATENCY = 3.3;
-    private static final int READ_RATE = 4;
+    private static final long READ_RATE = 4L;
     private static final long READ_OPS = 5L;
-    private static final int WRITE_RATE = 6;
+    private static final long WRITE_RATE = 6L;
     private static final long WRITE_OPS = 7L;
 
     private DiskStatisticalQuery query = new DiskStatisticalQuery(getParent());
@@ -52,13 +52,13 @@ public class DiskStatisticalQueryTest {
 
     private void verifyStatistic(Statistic statistic) {
         if (statistic.getName().equals(DiskStatisticalQuery.DATA_READ.getName())) {
-            assertEquals(READ_RATE, statistic.getValues().getValues().get(0).getDatum().intValue());
+            assertEquals(READ_RATE, statistic.getValues().getValues().get(0).getDatum().longValue());
         }
         if (statistic.getName().equals(DiskStatisticalQuery.DATA_READ_OPS.getName())) {
             assertEquals(READ_OPS, statistic.getValues().getValues().get(0).getDatum().longValue());
         }
         if (statistic.getName().equals(DiskStatisticalQuery.DATA_WRITE.getName())) {
-            assertEquals(WRITE_RATE, statistic.getValues().getValues().get(0).getDatum().intValue());
+            assertEquals(WRITE_RATE, statistic.getValues().getValues().get(0).getDatum().longValue());
         }
         if (statistic.getName().equals(DiskStatisticalQuery.DATA_WRITE_OPS.getName())) {
             assertEquals(WRITE_OPS, statistic.getValues().getValues().get(0).getDatum().longValue());

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/VdsBrokerObjectsBuilder.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/VdsBrokerObjectsBuilder.java
@@ -1795,9 +1795,9 @@ public class VdsBrokerObjectsBuilder {
             if (!StringUtils.isEmpty(imageGroupIdString)) {
                 Guid imageGroupIdGuid = new Guid(imageGroupIdString);
                 diskData.setId(imageGroupIdGuid);
-                diskData.setReadRate(assignIntValue(disk, VdsProperties.vm_disk_read_rate));
+                diskData.setReadRate(assignLongValue(disk, VdsProperties.vm_disk_read_rate));
                 diskData.setReadOps(assignLongValue(disk, VdsProperties.vm_disk_read_ops));
-                diskData.setWriteRate(assignIntValue(disk, VdsProperties.vm_disk_write_rate));
+                diskData.setWriteRate(assignLongValue(disk, VdsProperties.vm_disk_write_rate));
                 diskData.setWriteOps(assignLongValue(disk, VdsProperties.vm_disk_write_ops));
 
                 if (disk.containsKey(VdsProperties.disk_true_size)) {

--- a/backend/manager/modules/vdsbroker/src/test/java/org/ovirt/engine/core/vdsbroker/vdsbroker/VdsBrokerObjectsBuilderTest.java
+++ b/backend/manager/modules/vdsbroker/src/test/java/org/ovirt/engine/core/vdsbroker/vdsbroker/VdsBrokerObjectsBuilderTest.java
@@ -435,6 +435,16 @@ public class VdsBrokerObjectsBuilderTest {
                 new VdsCpuUnit(0, 1, 2), new VdsCpuUnit(1, 0, 3)));
     }
 
+    @Test
+    public void testSetDiskReadRateAsLong() {
+        String longValue = "2";
+        Map<String, Object> diskData = setDiskData();
+        diskData.put(VdsProperties.vm_disk_read_rate, longValue);
+        Map<String, Object> xml = setMockForTesting(diskData);
+        List<DiskImageDynamic> disks = vdsBrokerObjectsBuilder.buildVmDiskStatistics(xml);
+        assertEquals(Long.valueOf(2), disks.get(0).getReadRate());
+    }
+
     private Map<String, Object> createCpuTopologyStruct() {
         Map<String, Integer> cpuCapability1 = new HashMap<>();
         cpuCapability1.put(VdsProperties.cpu_id, 0);

--- a/packaging/dbscripts/disk_image_dynamic_sp.sql
+++ b/packaging/dbscripts/disk_image_dynamic_sp.sql
@@ -5,9 +5,9 @@
 --
 CREATE OR REPLACE FUNCTION Insertdisk_image_dynamic (
     v_image_id UUID,
-    v_read_rate INT,
+    v_read_rate BIGINT,
     v_read_ops BIGINT,
-    v_write_rate INT,
+    v_write_rate BIGINT,
     v_write_ops BIGINT,
     v_actual_size BIGINT,
     v_read_latency_seconds NUMERIC(18, 9),
@@ -43,9 +43,9 @@ LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Updatedisk_image_dynamic (
     v_image_id UUID,
-    v_read_rate INT,
+    v_read_rate BIGINT,
     v_read_ops BIGINT,
-    v_write_rate INT,
+    v_write_rate BIGINT,
     v_write_ops BIGINT,
     v_actual_size BIGINT,
     v_read_latency_seconds NUMERIC(18, 9),
@@ -73,9 +73,9 @@ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION Updatedisk_image_dynamic_by_disk_id_and_vm_id (
     v_image_group_id UUID,
     v_vm_id UUID,
-    v_read_rate INT,
+    v_read_rate BIGINT,
     v_read_ops BIGINT,
-    v_write_rate INT,
+    v_write_rate BIGINT,
     v_write_ops BIGINT,
     v_actual_size BIGINT,
     v_read_latency_seconds NUMERIC(18, 9),

--- a/packaging/dbscripts/upgrade/04_05_0230_change_disk_rate.sql
+++ b/packaging/dbscripts/upgrade/04_05_0230_change_disk_rate.sql
@@ -1,0 +1,2 @@
+SELECT fn_db_change_column_type('disk_image_dynamic', 'read_rate', 'INTEGER', 'BIGINT');
+SELECT fn_db_change_column_type('disk_image_dynamic', 'write_rate', 'INTEGER', 'BIGINT');


### PR DESCRIPTION
The readRate and writeRate stats from VDSM are gathered via libvirt.
Libvirt returns a long long (64bit long)
So we need to use Long in the engine to store this values
instead of int.

Bug-Url: https://bugzilla.redhat.com/2007384
Signed-off-by: Shani Leviim <sleviim@redhat.com>