### PR TITLE
Consider numa memory to dedicated scheduling

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/SchedulingManager.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/SchedulingManager.java
@@ -423,6 +423,8 @@ public class SchedulingManager implements BackendService {
                 }
 
                 VDS host = hostsMap.get(bestHostId);
+                // For dedicate VMs we are going to miss adding up the pending resources for NUMA.
+                // TODO move the NUMA sets into scheduling phase and add the pending NUMA resources.
                 Map<Guid, Map<Integer, NumaNodeMemoryConsumption>> numaConsumptionPerVm = vmNumaRequirements(vmGroup, host);
                 Map<Integer, NumaNodeMemoryConsumption> numaConsumption = numaConsumptionPerVm.values().stream()
                         .flatMap(m -> m.entrySet().stream())

--- a/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/scheduling/utils/VdsCpuUnitPinningHelperTest.java
+++ b/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/scheduling/utils/VdsCpuUnitPinningHelperTest.java
@@ -23,6 +23,7 @@ import org.ovirt.engine.core.common.businessentities.VDS;
 import org.ovirt.engine.core.common.businessentities.VM;
 import org.ovirt.engine.core.common.businessentities.VdsCpuUnit;
 import org.ovirt.engine.core.compat.Guid;
+import org.ovirt.engine.core.dao.VdsNumaNodeDao;
 import org.ovirt.engine.core.vdsbroker.ResourceManager;
 import org.ovirt.engine.core.vdsbroker.VdsManager;
 
@@ -33,6 +34,8 @@ public class VdsCpuUnitPinningHelperTest {
     private VdsManager vdsManager;
     @Mock
     private ResourceManager resourceManager;
+    @Mock
+    private VdsNumaNodeDao vdsNumaNodeDao;
     @InjectMocks
     @Spy
     private VdsCpuUnitPinningHelper vdsCpuUnitPinningHelper;

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/utils/NumaPinningHelper.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/utils/NumaPinningHelper.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import org.ovirt.engine.core.common.businessentities.CpuPinningPolicy;
 import org.ovirt.engine.core.common.businessentities.HugePage;
 import org.ovirt.engine.core.common.businessentities.NumaNode;
 import org.ovirt.engine.core.common.businessentities.NumaTuneMode;
@@ -274,7 +275,8 @@ public class NumaPinningHelper {
                     HugePageUtils.getHugePageSize(vm.getStaticData()),
                     vm.getCurrentNumOfCpus(),
                     NumaTuneMode.STRICT,
-                    vm.getCurrentThreadsPerCore());
+                    vm.getCurrentThreadsPerCore(),
+                    vm.getCpuPinningPolicy() == CpuPinningPolicy.DEDICATED);
         }
         vm.setvNumaNodeList(vmNumaNodes);
     }

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/utils/NumaUtils.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/utils/NumaUtils.java
@@ -12,7 +12,7 @@ import org.ovirt.engine.core.common.businessentities.VmNumaNode;
 public class NumaUtils {
 
     public static void setNumaListConfiguration(List<VmNumaNode> nodeList, long memTotal, Optional<Integer> hugepages,
-            int cpuCount, int threadsPerCore) {
+            int cpuCount, int threadsPerCore, boolean dedicated) {
         // Sorting is needed, otherwise the list will be ordered by nodeId,
         // as it was returned by DB. It can assign wrong CPU IDs to nodes.
         nodeList.sort(Comparator.comparing(NumaNode::getIndex));
@@ -39,7 +39,7 @@ public class NumaUtils {
             }
 
             // Update Memory
-            if (hasRemainderMemBlocks) {
+            if (hasRemainderMemBlocks || dedicated) {
                 // splitting memory to the nodes equally
                 long nodeBlocks = memBlocksPerNode + (remainingBlocks > 0 ? 1 : 0);
                 --remainingBlocks;
@@ -58,9 +58,9 @@ public class NumaUtils {
     }
 
     public static void setNumaListConfiguration(List<VmNumaNode> nodeList, long memTotal, Optional<Integer> hugepages,
-            int cpuCount, NumaTuneMode numaTuneMode, int threadsPerCore) {
+            int cpuCount, NumaTuneMode numaTuneMode, int threadsPerCore, boolean dedicated) {
 
-        setNumaListConfiguration(nodeList, memTotal, hugepages, cpuCount, threadsPerCore);
+        setNumaListConfiguration(nodeList, memTotal, hugepages, cpuCount, threadsPerCore, dedicated);
         for (VmNumaNode vmNumaNode : nodeList) {
             // Update tune mode
             vmNumaNode.setNumaTuneMode(numaTuneMode);

--- a/backend/manager/modules/common/src/test/java/org/ovirt/engine/core/common/utils/NumaUtilsTest.java
+++ b/backend/manager/modules/common/src/test/java/org/ovirt/engine/core/common/utils/NumaUtilsTest.java
@@ -28,7 +28,7 @@ public class NumaUtilsTest {
 
     @Test
     public void testNumaConfigurationSingle() {
-        NumaUtils.setNumaListConfiguration(nodeList, 1024, Optional.empty(), 2, NumaTuneMode.STRICT, 1);
+        NumaUtils.setNumaListConfiguration(nodeList, 1024, Optional.empty(), 2, NumaTuneMode.STRICT, 1, false);
 
         assertThat(nodeList.get(0).getCpuIds().size(), is(1));
         assertThat(nodeList.get(0).getMemTotal(), is((long)512));
@@ -37,7 +37,7 @@ public class NumaUtilsTest {
 
     @Test
     public void testNumaConfigurationDual() {
-        NumaUtils.setNumaListConfiguration(nodeList, 1024, Optional.empty(), 4, NumaTuneMode.STRICT, 1);
+        NumaUtils.setNumaListConfiguration(nodeList, 1024, Optional.empty(), 4, NumaTuneMode.STRICT, 1, false);
 
         assertThat(nodeList.get(0).getCpuIds().size(), is(2));
         assertThat(nodeList.get(0).getMemTotal(), is((long)512));
@@ -46,7 +46,7 @@ public class NumaUtilsTest {
 
     @Test
     public void testNumaConfigurationHugePages() {
-        NumaUtils.setNumaListConfiguration(nodeList, 1024, Optional.of(1048576), 2, NumaTuneMode.STRICT, 1);
+        NumaUtils.setNumaListConfiguration(nodeList, 1024, Optional.of(1048576), 2, NumaTuneMode.STRICT, 1, false);
 
         assertThat(nodeList.get(0).getCpuIds().size(), is(1));
         assertThat(nodeList.get(0).getMemTotal(), is((long)1024));
@@ -55,7 +55,7 @@ public class NumaUtilsTest {
 
     @Test
     public void testNumaConfigurationHugePagesBigMemory() {
-        NumaUtils.setNumaListConfiguration(nodeList, 8192, Optional.of(1048576), 2, NumaTuneMode.STRICT, 1);
+        NumaUtils.setNumaListConfiguration(nodeList, 8192, Optional.of(1048576), 2, NumaTuneMode.STRICT, 1, false);
 
         assertThat(nodeList.get(0).getCpuIds().size(), is(1));
         assertThat(nodeList.get(0).getMemTotal(), is((long)4096));
@@ -71,7 +71,7 @@ public class NumaUtilsTest {
         VmNumaNode vmNumaNode1 = new VmNumaNode();
         vmNumaNode1.setIndex(3);
         nodes.add(vmNumaNode1);
-        NumaUtils.setNumaListConfiguration(nodes, 1024, Optional.empty(), 46, NumaTuneMode.STRICT, 2);
+        NumaUtils.setNumaListConfiguration(nodes, 1024, Optional.empty(), 46, NumaTuneMode.STRICT, 2, false);
 
         assertThat(nodes.get(0).getCpuIds().size(), is(12));
         assertThat(nodes.get(1).getCpuIds().size(), is(12));
@@ -90,7 +90,7 @@ public class NumaUtilsTest {
         VmNumaNode vmNumaNode1 = new VmNumaNode();
         vmNumaNode1.setIndex(3);
         nodes.add(vmNumaNode1);
-        NumaUtils.setNumaListConfiguration(nodes, 46 * 32, Optional.empty(), 46, NumaTuneMode.STRICT, 2);
+        NumaUtils.setNumaListConfiguration(nodes, 46 * 32, Optional.empty(), 46, NumaTuneMode.STRICT, 2, false);
 
         assertThat(nodes.get(0).getCpuIds().size(), is(12));
         assertThat(nodes.get(1).getCpuIds().size(), is(12));

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/NumaSettingFactory.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/NumaSettingFactory.java
@@ -53,10 +53,9 @@ public class NumaSettingFactory {
     }
 
     public static Map<String, Object> buildVmNumatuneSetting(VM vm, List<VmNumaNode> vmNumaNodes) {
-
         Map<Integer, Collection<Integer>> currentNumaPinning = NumaPinningHelper.parseNumaMapping(vm.getCurrentNumaPinning());
-
         List<Map<String, String>> memNodeList = new ArrayList<>();
+
         for (VmNumaNode node : vmNumaNodes) {
             if (currentNumaPinning != null) {
                 if (currentNumaPinning.containsKey(node.getIndex())) {
@@ -68,7 +67,6 @@ public class NumaSettingFactory {
                 memNodeList.add(createMemNode(node.getIndex(), node.getVdsNumaNodeList(), node.getNumaTuneMode()));
             }
         }
-
         // If no node is pinned, leave pinning implicit
         if (memNodeList.isEmpty()) {
             return Collections.emptyMap();

--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/builders/vm/NumaUnitToVmBaseBuilder.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/builders/vm/NumaUnitToVmBaseBuilder.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import org.ovirt.engine.core.common.businessentities.CpuPinningPolicy;
 import org.ovirt.engine.core.common.businessentities.VmBase;
 import org.ovirt.engine.core.common.businessentities.VmNumaNode;
 import org.ovirt.engine.core.common.utils.NumaUtils;
@@ -38,7 +39,8 @@ public class NumaUnitToVmBaseBuilder<T extends VmBase> extends BaseSyncBuilder<U
                 model.getMemSize().getEntity(),
                 getHugePageSize(model),
                 Integer.parseInt(model.getTotalCPUCores().getEntity()),
-                model.getThreadsPerCore().getSelectedItem());
+                model.getThreadsPerCore().getSelectedItem(),
+                vm.getCpuPinningPolicy() == CpuPinningPolicy.DEDICATED);
         vm.setvNumaNodeList(nodeList);
     }
 


### PR DESCRIPTION
When we have virtual NUMA provided with a dedicated VM, we wish to pin
that virtual NUMA to a physical NUMA. But we have a memory constraint.
The future physical resources we are going to use needs to provide
enough memory in order to use it.
This needed to be considered when scheduling such VM and selecting the
physical resources to use.
For now the NUMA will use the tune `interleave`, that would let the
memory pages to be used from multiple physical NUMA nodes.

Change-Id: I9d3a79296391cd77f7d53cc75eb152383dba9137
Signed-off-by: Liran Rotenberg <lrotenbe@redhat.com>