### PR TITLE
Add console disconnect action delay to OVF

### DIFF
--- a/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfProperties.java
+++ b/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfProperties.java
@@ -77,6 +77,7 @@ public interface OvfProperties {
     String IS_SPICE_COPY_PASTE_ENABLED = "IsSpiceCopyPasteEnabled";
     String ALLOW_CONSOLE_RECONNECT = "AllowConsoleReconnect";
     String CONSOLE_DISCONNECT_ACTION = "ConsoleDisconnectAction";
+    String CONSOLE_DISCONNECT_ACTION_DELAY = "ConsoleDisconnectActionDelay";
     String COMMENT = "Comment";
     String IS_AUTO_CONVERGE = "IsAutoConverge";
     String IS_MIGRATE_COMPRESSED = "IsMigrateCompressed";

--- a/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfReader.java
+++ b/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfReader.java
@@ -624,6 +624,9 @@ public abstract class OvfReader implements IOvfBuilder {
         consumeReadProperty(content,
                 CONSOLE_DISCONNECT_ACTION,
                 val -> vmBase.setConsoleDisconnectAction(ConsoleDisconnectAction.fromString(val)));
+        consumeReadProperty(content,
+                CONSOLE_DISCONNECT_ACTION_DELAY,
+                val -> vmBase.setConsoleDisconnectActionDelay(Integer.parseInt(val)));
         consumeReadProperty(content, IS_AUTO_CONVERGE, val -> vmBase.setAutoConverge(Boolean.parseBoolean(val)));
         consumeReadProperty(content,
                 IS_MIGRATE_COMPRESSED,

--- a/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfWriter.java
+++ b/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfWriter.java
@@ -296,6 +296,7 @@ public abstract class OvfWriter implements IOvfBuilder {
         _writer.writeElement(IS_SPICE_COPY_PASTE_ENABLED, String.valueOf(vmBase.isSpiceCopyPasteEnabled()));
         _writer.writeElement(ALLOW_CONSOLE_RECONNECT, String.valueOf(vmBase.isAllowConsoleReconnect()));
         _writer.writeElement(CONSOLE_DISCONNECT_ACTION, String.valueOf(vmBase.getConsoleDisconnectAction()));
+        _writer.writeElement(CONSOLE_DISCONNECT_ACTION_DELAY, String.valueOf(vmBase.getConsoleDisconnectActionDelay()));
 
         if (vmBase.getAutoConverge() != null) {
             _writer.writeElement(IS_AUTO_CONVERGE, String.valueOf(vmBase.getAutoConverge()));


### PR DESCRIPTION
We need to have not only for export-import but also for keeping it when next-run configuration is created and when restoring snapshots