### PR TITLE
core: measure volume before starting conversion

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/ConvertDiskCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/ConvertDiskCommand.java
@@ -280,6 +280,7 @@ public class ConvertDiskCommand<T extends ConvertDiskCommandParameters> extends 
 
         DiskImage newImage = DiskImage.copyOf(getDiskImage());
         newImage.setImageId(getParameters().getNewVolGuid());
+        newImage.setSize(info.getSize());
 
         if (getParameters().getVolumeFormat() != null) {
             if (info.getVolumeFormat() != getParameters().getVolumeFormat()) {


### PR DESCRIPTION
When converting a disk on block storage to qcow2, we might not have enough space for the qcow metadata on the created volume if it is converted from RAW format.

* Measure the required size before creating the skeleton volume, and if the required size is smaller than required, the returned size will be used
* Set the size returned by getVolumeInfo to fix the size of the new volume in case it changed after conversion

Bug-Url: https://bugzilla.redhat.com/2069670