### PR TITLE
Disable Stateless VM field

### DIFF
--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/ExistingVmModelBehavior.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/ExistingVmModelBehavior.java
@@ -181,6 +181,8 @@ public class ExistingVmModelBehavior extends VmModelBehaviorBase<UnitVmModel> {
 
         // Update model state according to VM properties.
         buildModel(vm.getStaticData(), (source, destination) -> {
+            // General
+            updateStateless();
             // System
             if (isHotSetCpuSupported()) {
                 // cancel related events while fetching data

--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/NewVmModelBehavior.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/NewVmModelBehavior.java
@@ -154,7 +154,11 @@ public class NewVmModelBehavior extends VmModelBehaviorBase<UnitVmModel> {
             // General
             getModel().getIsRunAndPause().setEntity(template.isRunAndPause());
             // update fields special for new VM
-            if (updateStatelessFlag) {
+            // if the selected template is the latest, the VM has to be stateless,
+            // otherwise copy from the template
+            if (isLatestTemplateSelected()) {
+                getModel().getIsStateless().setEntity(true);
+            } else if (updateStatelessFlag) {
                 getModel().getIsStateless().setEntity(template.isStateless());
             }
             updateStatelessFlag = true;

--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/VmModelBehaviorBase.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/VmModelBehaviorBase.java
@@ -256,6 +256,7 @@ public abstract class VmModelBehaviorBase<TModel extends UnitVmModel> {
 
     public void templateWithVersion_SelectedItemChanged() {
         updateSeal();
+        updateStateless();
     }
 
     public void postDataCenterWithClusterSelectedItemChanged() {
@@ -1724,6 +1725,12 @@ public abstract class VmModelBehaviorBase<TModel extends UnitVmModel> {
         getModel().getIsSealed().setEntity(isSealByDefault(template));
     }
 
+    protected void updateStateless() {
+            getModel().getIsStateless()
+                    .setIsChangeable(!isLatestTemplateSelected(),
+                            constants.statelessVmFieldDisabledReason());
+    }
+
     protected boolean isSealByDefault(VmTemplate template) {
         return template.isSealed();
     }
@@ -1834,5 +1841,11 @@ public abstract class VmModelBehaviorBase<TModel extends UnitVmModel> {
 
      protected List<Integer> getOsValues(ArchitectureType architectureType, Version version) {
          return AsyncDataProvider.getInstance().getOsIds(architectureType);
+     }
+
+     protected boolean isLatestTemplateSelected() {
+         return getModel().getTemplateWithVersion() != null
+                 && getModel().getTemplateWithVersion().getSelectedItem() != null
+                 && getModel().getTemplateWithVersion().getSelectedItem().isLatest();
      }
 }

--- a/frontend/webadmin/modules/uicompat/src/main/java/org/ovirt/engine/ui/uicompat/UIConstants.java
+++ b/frontend/webadmin/modules/uicompat/src/main/java/org/ovirt/engine/ui/uicompat/UIConstants.java
@@ -2246,4 +2246,6 @@ public interface UIConstants extends Constants {
     String confirmSuspendingVm();
 
     String homePageCustom();
+
+    String statelessVmFieldDisabledReason();
 }

--- a/frontend/webadmin/modules/uicompat/src/main/resources/org/ovirt/engine/ui/uicompat/UIConstants.properties
+++ b/frontend/webadmin/modules/uicompat/src/main/resources/org/ovirt/engine/ui/uicompat/UIConstants.properties
@@ -1134,4 +1134,4 @@ customParallelMigrationsDisabledReason=Available only when Custom Parallel Migra
 clusterDefaultCustomParallelMigrationsDisabledReason=Cannot change for Cluster default value.
 cpuPinningDedicatedDescription=Exclusively pin virtual CPUs to host physical CPUs. If a VM has NUMA enabled, the NUMA nodes will be pinned automatically.
 cpuPinningDedicatedDisabled=Dedicated CPU Policy is available on cluster version 4.7 or newer. If the VM has NUMA enabled, all nodes have to be unpinned.
-statelessVmFieldDisabledReason=Disabled when the latest version of a template is selected.
+statelessVmFieldDisabledReason=Disabled when using the latest version of a template is selected.

--- a/frontend/webadmin/modules/uicompat/src/main/resources/org/ovirt/engine/ui/uicompat/UIConstants.properties
+++ b/frontend/webadmin/modules/uicompat/src/main/resources/org/ovirt/engine/ui/uicompat/UIConstants.properties
@@ -1134,3 +1134,4 @@ customParallelMigrationsDisabledReason=Available only when Custom Parallel Migra
 clusterDefaultCustomParallelMigrationsDisabledReason=Cannot change for Cluster default value.
 cpuPinningDedicatedDescription=Exclusively pin virtual CPUs to host physical CPUs. If a VM has NUMA enabled, the NUMA nodes will be pinned automatically.
 cpuPinningDedicatedDisabled=Dedicated CPU Policy is available on cluster version 4.7 or newer. If the VM has NUMA enabled, all nodes have to be unpinned.
+statelessVmFieldDisabledReason=Disabled when the latest version of a template is selected.


### PR DESCRIPTION
When the latest version of the template is selected in the new VM dialog, the VM has to remain stateless no matter what is set on the template. To ensure that (and to allow the selection of the latest statefull template), the field is automatically disabled and checked as Stateless.

When creating a VM, the clone provisioning is selected by default. That does not make much sense for the latest template because the purpose of the latest template version is to be able to apply template's latest changes to the vm. This patch changes the selected provisioning to thin if the latest template is selected.