### PR TITLE
core: Fix removal of unmanaged network with long name

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/network/RemoveNetworkParametersBuilder.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/network/RemoveNetworkParametersBuilder.java
@@ -64,10 +64,11 @@ public class RemoveNetworkParametersBuilder extends HostSetupNetworksParametersB
                     setupNetworkParams.getRemovedNetworkAttachments().add(networkAttachment.getId());
                 }
             } else {
-                VdsNetworkInterface nicWithNetwork = nicByNetworkName.get(network.getName());
+                var unmanagedNetworkName = network.getVdsmName();
+                VdsNetworkInterface nicWithNetwork = nicByNetworkName.get(unmanagedNetworkName);
 
                 if (nicWithNetwork != null && NetworkCommonUtils.stripVlan(nicWithNetwork).equals(nic.getName())) {
-                    setupNetworkParams.getRemovedUnmanagedNetworks().add(network.getName());
+                    setupNetworkParams.getRemovedUnmanagedNetworks().add(unmanagedNetworkName);
                 }
             }
             parameters.add(setupNetworkParams);


### PR DESCRIPTION
The long name networks are represented on the host as onUUID.
When the network is unmanaged and the attachment is gone we need
to remove network based on it's vdsm name and not the name
that it had in engine. Use vdsmName for removal of unmanaged
interfaces instead of the engine name.

Signed-off-by: Ales Musil <amusil@redhat.com>