### PR TITLE
Replace selinux_permissions ansible module with command

### DIFF
--- a/packaging/ansible-runner-service-project/project/roles/ovirt-host-deploy-vdsm/tasks/configure.yml
+++ b/packaging/ansible-runner-service-project/project/roles/ovirt-host-deploy-vdsm/tasks/configure.yml
@@ -41,9 +41,8 @@
 
   # workaround for BZ 2054323
   - name: Change the openvswitch_t to permissive
-    selinux_permissive:
-      name: openvswitch_t
-      permissive: true
+    command: semanage permissive -a openvswitch_t
+    changed_when: True
 
   when: el_ver|int >= 9
 


### PR DESCRIPTION
selinux_permissive ansible module is not in RH supported collections, so
we need to replace it with direct command invocation to be able to
upgrade to ansible-core-2.12

Signed-off-by: Martin Perina <mperina@redhat.com>
