### PR TITLE
core: only use selected disks for hybrid backup

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/backup/HybridBackupCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/backup/HybridBackupCommand.java
@@ -268,6 +268,10 @@ public class HybridBackupCommand<T extends VmBackupParameters> extends StartVmBa
         parameters.setEntityInfo(getParameters().getEntityInfo());
         parameters.setEndProcedure(ActionParametersBase.EndProcedure.COMMAND_MANAGED);
         parameters.setBitmap(bitmapId);
+        parameters.setDiskIds(getParameters().getVmBackup().getDisks()
+                .stream()
+                .map(DiskImage::getId)
+                .collect(Collectors.toSet()));
         return parameters;
     }
 


### PR DESCRIPTION
Hybrid backup should only backup the disks selected for the backup (i.e.with --disk-uuid <id>).

This change uses the selected disks when creating the snapshot to ensure only the selected disks participate in the snapshot.

Bug-Url: https://bugzilla.redhat.com/2070184
