### PR TITLE
core: fix locks in ConvertDiskCommand

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/ConvertDiskCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/ConvertDiskCommand.java
@@ -170,7 +170,9 @@ public class ConvertDiskCommand<T extends ConvertDiskCommandParameters> extends 
         long requiredSize =  actionReturnValue.getActionReturnValue();
 
         // Create volume in the same disk
-        runInternalAction(ActionType.CreateVolumeContainer, createVolumeCreationParameters(getDiskImage(), requiredSize));
+        runInternalAction(ActionType.CreateVolumeContainer,
+                createVolumeCreationParameters(getDiskImage(), requiredSize),
+                ExecutionHandler.createDefaultContextForTasks(getContext()));
         updatePhase(ConvertDiskCommandParameters.ConvertDiskPhase.CONVERT_VOLUME);
 
         setSucceeded(true);
@@ -199,8 +201,9 @@ public class ConvertDiskCommand<T extends ConvertDiskCommandParameters> extends 
                 setCommandStatus(CommandStatus.FAILED);
                 return true;
             }
-            runInternalAction(ActionType.DestroyImage, createDestroyImageParameters(getDiskImage().getImageId(),
-                    getActionType()));
+            runInternalAction(ActionType.DestroyImage,
+                    createDestroyImageParameters(getDiskImage().getImageId(), getActionType()),
+                    ExecutionHandler.createDefaultContextForTasks(getContext()));
 
             updatePhase(ConvertDiskCommandParameters.ConvertDiskPhase.COMPLETE);
 


### PR DESCRIPTION
Currently child commands like DestroyImage and CreateVolumeContainer will unlock the exclusive lock acquired by ConvertDisk as the lock is implicitly passed down to them.
This PR changes the execution context to one that does pass the locks down to prevent the premature unlock.

Bug-Url: https://bugzilla.redhat.com/2069670
Depends on: https://github.com/oVirt/ovirt-engine/pull/203