### PR TITLE
engine: keep original cpuProfile in UpdateVmVersionCommand

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/UpdateVmVersionCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/UpdateVmVersionCommand.java
@@ -76,6 +76,8 @@ public class UpdateVmVersionCommand<T extends UpdateVmVersionParameters> extends
     @Inject
     private DiskProfileDao diskProfileDao;
 
+    private Guid originalCpuProfileId;
+
     /**
      * Constructor for command creation when compensation is applied on startup
      */
@@ -143,6 +145,7 @@ public class UpdateVmVersionCommand<T extends UpdateVmVersionParameters> extends
     protected void executeVmCommand() {
         // load vm init from db
         vmHandler.updateVmInitFromDB(getVmTemplate(), false);
+        originalCpuProfileId = getVm().getCpuProfileId();
         if (!VmHandler.copyData(getVmTemplate(), getVm().getStaticData())) {
             return;
         }
@@ -252,6 +255,11 @@ public class UpdateVmVersionCommand<T extends UpdateVmVersionParameters> extends
         // reset vm to not initialized
         addVmParams.getVmStaticData().setInitialized(false);
 
+        // the validation during add vm would failed because the template's cpu profile
+        // is not on the vm's cluster, lets keep the original cpu profile
+        if (!addVmParams.getVmStaticData().getClusterId().equals(getVmTemplate().getClusterId())) {
+            addVmParams.getVmStaticData().setCpuProfileId(originalCpuProfileId);
+        }
         return addVmParams;
     }
 

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/UpdateVmVersionCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/UpdateVmVersionCommand.java
@@ -255,9 +255,9 @@ public class UpdateVmVersionCommand<T extends UpdateVmVersionParameters> extends
         // reset vm to not initialized
         addVmParams.getVmStaticData().setInitialized(false);
 
-        // the validation during add vm would failed because the template's cpu profile
-        // is not on the vm's cluster, lets keep the original cpu profile
         if (!addVmParams.getVmStaticData().getClusterId().equals(getVmTemplate().getClusterId())) {
+            // the validation during add vm would fail because the template's cpu profile
+            // is not at the same cluster as the vm, lets keep the original cpu profile
             addVmParams.getVmStaticData().setCpuProfileId(originalCpuProfileId);
         }
         return addVmParams;


### PR DESCRIPTION
If the vm and the template are not on the same cluster, adding of the newly created vm fails because of the validation
of the cpu profile (it requires the cpu profile to be from the vm's cluster, but it is actually copied from the template on a different cluster).

This patch keeps the original cpuProfile in vm's configuration if the template is on a different cluster.