### PR TITLE
Consider NUMA pending resources for a dedicated VM

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/VmHandler.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/VmHandler.java
@@ -1358,6 +1358,19 @@ public class VmHandler implements BackendService {
                 cpuUnits);
     }
 
+    public String createNumaPinningForDedicated(VM vm, List<VdsCpuUnit> cpuUnits) {
+        if (vm.getCpuPinningPolicy() != CpuPinningPolicy.DEDICATED
+                || vm.getvNumaNodeList() == null
+                || vm.getvNumaNodeList().isEmpty()
+                || cpuUnits == null) {
+            return null;
+        }
+
+        return NumaPinningHelper.createNumaPinningAccordingToCpuPinning(
+                vm.getvNumaNodeList(),
+                cpuUnits);
+    }
+
     public void autoSelectResumeBehavior(VmBase vmBase) {
         if (vmBase.isAutoStartup() && vmBase.getLeaseStorageDomainId() != null) {
             // since 4.2 the only supported resume behavior for HA vms with lease is kill


### PR DESCRIPTION
When initiating a dedicated VM the NUMA pinning is automatically generated by the engine, based on the physical CPU taken. This patch will take into consideration the memory such VM needs and set it to the NUMA pending resources.

Signed-off-by: Liran Rotenberg <lrotenbe@redhat.com>