### PR TITLE
engine: move setting of cpu profile to execute

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/UpdateVmVersionCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/UpdateVmVersionCommand.java
@@ -154,6 +154,12 @@ public class UpdateVmVersionCommand<T extends UpdateVmVersionParameters> extends
         getParameters().setPreviousDiskOperatorAuthzPrincipalDbId(getIdOfDiskOperator());
         getParameters().setVmStaticData(getVm().getStaticData());
 
+        if (!Objects.equals(getVm().getClusterId(), getVmTemplate().getClusterId())) {
+            // the validation during add vm would fail because the template's cpu profile
+            // is not at the same cluster as the vm, lets keep the original cpu profile
+            getParameters().getVmStaticData().setCpuProfileId(originalCpuProfileId);
+        }
+
         if (getParameters().getUseLatestVersion() != null) {
             getParameters().getVmStaticData().setUseLatestVersion(getParameters().getUseLatestVersion());
         }
@@ -256,11 +262,6 @@ public class UpdateVmVersionCommand<T extends UpdateVmVersionParameters> extends
         // reset vm to not initialized
         addVmParams.getVmStaticData().setInitialized(false);
 
-        if (!Objects.equals(addVmParams.getVmStaticData().getClusterId(), getVmTemplate().getClusterId())) {
-            // the validation during add vm would fail because the template's cpu profile
-            // is not at the same cluster as the vm, lets keep the original cpu profile
-            addVmParams.getVmStaticData().setCpuProfileId(originalCpuProfileId);
-        }
         return addVmParams;
     }
 

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/UpdateVmVersionCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/UpdateVmVersionCommand.java
@@ -77,8 +77,6 @@ public class UpdateVmVersionCommand<T extends UpdateVmVersionParameters> extends
     @Inject
     private DiskProfileDao diskProfileDao;
 
-    private Guid originalCpuProfileId;
-
     /**
      * Constructor for command creation when compensation is applied on startup
      */
@@ -146,7 +144,7 @@ public class UpdateVmVersionCommand<T extends UpdateVmVersionParameters> extends
     protected void executeVmCommand() {
         // load vm init from db
         vmHandler.updateVmInitFromDB(getVmTemplate(), false);
-        originalCpuProfileId = getVm().getCpuProfileId();
+        Guid originalCpuProfileId = getVm().getCpuProfileId();
         if (!VmHandler.copyData(getVmTemplate(), getVm().getStaticData())) {
             return;
         }


### PR DESCRIPTION
When updating a version of a VM, there might be some asynchronous operations running which could cause the endCommand() to be called with null getVm() and null getVmTemplate(). We should rely solely on the parameters at this point.