### PR TITLE
[WIP] packaging: spec: %add_maven_depmap removal

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,7 @@ jobs:
       run: |
         # Install oVirt repositories
         dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-8
+        dnf install -y ovirt-release-master
 
         # Requried for python3-ansible-lint and python3-isort
         dnf copr enable -y sbonazzo/EL8_collection

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
         include:
           - name: centos-stream-8
             shortcut: cs8
-            container-name: stream8
+            container-name: el8stream
           # Try to enable CS9 after switch to xmaven is finished
           # - name: centos-stream-9
           #  shortcut: cs9
@@ -27,59 +27,9 @@ jobs:
       ARTIFACTS_DIR: exported-artifacts
 
     container:
-      image: quay.io/centos/centos:${{ matrix.container-name }}
+      image: quay.io/ovirt/buildcontainer:${{ matrix.container-name }}
 
     steps:
-    - name: Prepare CentOS Stream 8 environment
-      if: ${{ matrix.shortcut == 'cs8' }}
-      run: |
-        # Install oVirt repositories
-        dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-8
-        dnf install -y ovirt-release-master
-
-        # Requried for python3-ansible-lint and python3-isort
-        dnf copr enable -y sbonazzo/EL8_collection
-
-        # Configure CS8 repositories
-        dnf config-manager --enable powertools
-        dnf module enable -y pki-deps javapackages-tools maven:3.6
-
-    - name: Prepare CentOS Stream 9 environment
-      if: ${{ matrix.shortcut == 'cs9' }}
-      run: |
-        # DNF core plugins are installed in the official CS9 container image
-        dnf install -y dnf-plugins-core
-
-        # Install oVirt repositories
-        dnf copr enable -y ovirt/ovirt-master-snapshot
-
-        # Requried for python3-ansible-lint and python3-isort
-        dnf copr enable -y sbonazzo/EL9_collection
-
-        # Configure CS9 repositories
-        dnf config-manager --enable crb
-
-    - name: Install required packages
-      run: |
-        dnf install -y \
-          createrepo_c \
-          dnf-utils \
-          git \
-          gzip \
-          java-11-openjdk-devel \
-          make \
-          maven \
-          python3-pycodestyle \
-          python3-pytest \
-          python3-devel \
-          python3-isort \
-          python3-pyflakes \
-          python3-pyOpenSSL \
-          python3-dnf-plugin-versionlock \
-          rpm-build \
-          sed \
-          tar
-
     - name: Checkout sources
       uses: actions/checkout@v2
 

--- a/Makefile
+++ b/Makefile
@@ -429,6 +429,8 @@ install_poms:
 	install -m 644 backend/manager/modules/dal/pom.xml "$(DESTDIR)$(MAVENPOM_DIR)/$(PACKAGE_NAME)-dal.pom"
 	install -m 644 backend/manager/modules/extensions-manager/pom.xml "$(DESTDIR)$(MAVENPOM_DIR)/$(PACKAGE_NAME)-extensions-manager.pom"
 	install -m 644 backend/manager/modules/pom.xml "$(DESTDIR)$(MAVENPOM_DIR)/$(PACKAGE_NAME)-manager-modules.pom"
+	install -m 644 backend/manager/modules/restapi/interface/pom.xml "$(DESTDIR)$(MAVENPOM_DIR)/$(PACKAGE_NAME)-interface.pom"
+	install -m 644 backend/manager/modules/restapi/interface/common/pom.xml "$(DESTDIR)$(MAVENPOM_DIR)/$(PACKAGE_NAME)-common-parent.pom"
 	install -m 644 backend/manager/modules/restapi/interface/common/jaxrs/pom.xml "$(DESTDIR)$(MAVENPOM_DIR)/$(PACKAGE_NAME)-interface-common-jaxrs.pom"
 	install -m 644 backend/manager/modules/restapi/interface/definition/pom.xml "$(DESTDIR)$(MAVENPOM_DIR)/$(PACKAGE_NAME)-restapi-definition.pom"
 	install -m 644 backend/manager/modules/restapi/jaxrs/pom.xml "$(DESTDIR)$(MAVENPOM_DIR)/$(PACKAGE_NAME)-restapi-jaxrs.pom"

--- a/ovirt-engine.spec.in
+++ b/ovirt-engine.spec.in
@@ -1137,13 +1137,14 @@ fi
 %dir %{engine_etc}
 %dir %{engine_etc}/ansible
 %dir %{engine_etc}/branding
+%dir %{engine_etc}/cinderlib
 %dir %{engine_etc}/extensions.d
 %dir %{engine_java}
 %license LICENSE
 %{engine_data}/brands/ovirt.brand/
 %{engine_etc}/branding/00-ovirt.brand
 %{engine_etc}/engine.conf.d/
-%{engine_etc}/cinderlib/
+%{engine_etc}/cinderlib/README
 %{engine_etc}/timezones/
 %config %{engine_data}/cinderlib/logger.conf
 %config %attr(0700,%{engine_user},%{engine_group}) %{engine_etc}/cinderlib/ssh_known_hosts
@@ -1161,6 +1162,16 @@ fi
 %if "%{name}" != "%{engine_name}"
 %{_javadir}/%{name}
 %endif
+
+%{_mavenpomdir}/JPP.ovirt-engine-branding.pom
+%{_mavenpomdir}/JPP.ovirt-engine-common.pom
+%{_mavenpomdir}/JPP.ovirt-engine-common-parent.pom
+%{_mavenpomdir}/JPP.ovirt-engine-compat.pom
+%{_mavenpomdir}/JPP.ovirt-engine-extensions-manager.pom
+%{_mavenpomdir}/JPP.ovirt-engine-logutils.pom
+%{_mavenpomdir}/JPP.ovirt-engine-root.pom
+%{_mavenpomdir}/JPP.ovirt-engine-utils.pom
+%{_mavenpomdir}/JPP.ovirt-engine-uutils.pom
 
 %if %{rhv_build}
 %files -n rhvm
@@ -1210,6 +1221,17 @@ fi
 %{engine_ear}/welcome.war/
 %{engine_etc}/osinfo.conf.d/
 %{engine_jboss_modules}/
+
+%{_mavenpomdir}/JPP.ovirt-engine-aaa.pom
+%{_mavenpomdir}/JPP.ovirt-engine-backend.pom
+%{_mavenpomdir}/JPP.ovirt-engine-bll.pom
+%{_mavenpomdir}/JPP.ovirt-engine-builtin.pom
+%{_mavenpomdir}/JPP.ovirt-engine-dal.pom
+%{_mavenpomdir}/JPP.ovirt-engine-manager-modules.pom
+%{_mavenpomdir}/JPP.ovirt-engine-manager.pom
+%{_mavenpomdir}/JPP.ovirt-engine-scheduler.pom
+%{_mavenpomdir}/JPP.ovirt-engine-searchbackend.pom
+%{_mavenpomdir}/JPP.ovirt-engine-vdsbroker.pom
 
 %{engine_data}/services/ovirt-engine
 %{_unitdir}/ovirt-engine.service
@@ -1340,6 +1362,12 @@ fi
 %license LICENSE
 %{engine_restapi_war}/
 %{engine_apidoc_war}/
+%{_mavenpomdir}/JPP.ovirt-engine-interface.pom
+%{_mavenpomdir}/JPP.ovirt-engine-interface-common-jaxrs.pom
+%{_mavenpomdir}/JPP.ovirt-engine-restapi-definition.pom
+%{_mavenpomdir}/JPP.ovirt-engine-restapi-jaxrs.pom
+%{_mavenpomdir}/JPP.ovirt-engine-restapi-parent.pom
+%{_mavenpomdir}/JPP.ovirt-engine-restapi-types.pom
 
 %files webadmin-portal
 %license LICENSE
@@ -1415,7 +1443,9 @@ fi
 %{engine_etc}/engine-config/engine-config.*properties
 %{engine_etc}/notifier/notifier.conf.d/
 %{engine_etc}/ovirt-fence-kdump-listener.conf.d/
-
+%{_mavenpomdir}/JPP.ovirt-engine-extensions-tool.pom
+%{_mavenpomdir}/JPP.ovirt-engine-sso-client-registration-tool.pom
+%{_mavenpomdir}/JPP.ovirt-engine-tools.pom
 
 %{_unitdir}/ovirt-engine-notifier.service
 %{_unitdir}/ovirt-fence-kdump-listener.service

--- a/ovirt-engine.spec.in
+++ b/ovirt-engine.spec.in
@@ -276,6 +276,12 @@ BuildRequires:	unzip
 BuildRequires:	ovirt-jboss-modules-maven-plugin >= 2.0.1
 BuildRequires:	javapackages-local
 
+# common-dependencies
+BuildRequires:	ed25519-java
+BuildRequires:	jackson-jaxrs-json-provider
+BuildRequires:	resteasy
+BuildRequires:	apache-sshd
+
 # backend
 BuildRequires:	%{name}-extensions-api >= 1.0.1
 

--- a/ovirt-engine.spec.in
+++ b/ovirt-engine.spec.in
@@ -296,6 +296,7 @@ BuildRequires:	openstack-java-glance-client >= %{openstack_java_version}
 # backend
 BuildRequires:	%{name}-extensions-api >= 1.0.1
 BuildRequires:	ebay-cors-filter
+BuildRequires:	jboss-modules
 
 # findbugs filter
 BuildRequires:	maven-surefire-plugin
@@ -1102,7 +1103,6 @@ perl -i -pe 's/^SHA1-Digest: [^\n]+\n//g' "%{buildroot}%{engine_ear}/META-INF/MA
 # Exception: Following dependencies were not resolved and requires cannot be generated.
 # Either remove the dependencies from pom.xml or add proper packages to BuildRequires:
 # org.infinispan:infinispan-core:9.4.18.Final required by org.ovirt.engine.core:utils
-# org.jboss.modules:jboss-modules:1.1.1.GA required by org.ovirt.engine.core:extensions-manager
 # org.hibernate.validator:hibernate-validator:6.0.18.Final required by org.ovirt.engine.core:common
 #
 #

--- a/ovirt-engine.spec.in
+++ b/ovirt-engine.spec.in
@@ -276,6 +276,14 @@ BuildRequires:	unzip
 BuildRequires:	ovirt-jboss-modules-maven-plugin >= 2.0.1
 BuildRequires:	javapackages-local
 
+# core
+BuildRequires:  java-client-kubevirt
+BuildRequires:  openstack-java-quantum-client
+BuildRequires:  openstack-java-resteasy-connector
+BuildRequires:  ovirt-dependencies
+BuildRequires:  vdsm-jsonrpc-java
+BuildRequires:  xmlrpc-client
+
 # common-dependencies
 BuildRequires:	ed25519-java
 BuildRequires:	jackson-jaxrs-json-provider
@@ -291,6 +299,22 @@ BuildRequires:	ebay-cors-filter
 
 # findbugs filter
 BuildRequires:	maven-surefire-plugin
+
+# restapi
+BuildRequires:  bean-validation-api
+BuildRequires:  istack-commons-runtime
+BuildRequires:  ovirt-engine-api-metamodel
+BuildRequires:  snakeyaml
+
+# tools
+BuildRequires:  apache-commons-configuration
+BuildRequires:  apache-commons-lang
+BuildRequires:  jakarta-mail
+BuildRequires:  snmp4j
+
+# utils
+BuildRequires:  apache-commons-beanutils
+BuildRequires:  apache-commons-collections
 
 Requires(pre):	shadow-utils
 
@@ -1065,11 +1089,22 @@ perl -i -pe 's/^SHA1-Digest: [^\n]+\n//g' "%{buildroot}%{engine_ear}/META-INF/MA
 
 %endif
 
-#FIXME installation fails because:
+# FIXME installation fails because:
 # Exception: Following dependencies were not resolved and requires cannot be generated.
-#   Either remove the dependencies from pom.xml or add proper packages to BuildRequires:
-#   org.hibernate.validator:hibernate-validator:6.0.18.Final required by org.ovirt.engine.core:common
-#   org.infinispan:infinispan-core:9.4.18.Final required by org.ovirt.engine.core:utils
+# Either remove the dependencies from pom.xml or add proper packages to BuildRequires:
+# org.jboss.spec.javax.xml.bind:jboss-jaxb-api_2.3_spec:2.0.0.Final required by org.ovirt.engine.api:restapi-definition
+# javax.activation:activation:1.1 required by org.ovirt.engine.api:restapi-definition
+#
+# Exception: Following dependencies were not resolved and requires cannot be generated.
+# Either remove the dependencies from pom.xml or add proper packages to BuildRequires:
+# org.jboss.spec.javax.interceptor:jboss-interceptors-api_1.1_spec:1.0.0.Final required by org.ovirt.engine.core:bll
+#
+# Exception: Following dependencies were not resolved and requires cannot be generated.
+# Either remove the dependencies from pom.xml or add proper packages to BuildRequires:
+# org.infinispan:infinispan-core:9.4.18.Final required by org.ovirt.engine.core:utils
+# org.jboss.modules:jboss-modules:1.1.1.GA required by org.ovirt.engine.core:extensions-manager
+# org.hibernate.validator:hibernate-validator:6.0.18.Final required by org.ovirt.engine.core:common
+#
 #
 #   asocha:
 #   Unfortunately, we cannot mark these 2 dependencies as 'provided' because they are required at 'compile' time

--- a/ovirt-engine.spec.in
+++ b/ovirt-engine.spec.in
@@ -281,9 +281,13 @@ BuildRequires:	ed25519-java
 BuildRequires:	jackson-jaxrs-json-provider
 BuildRequires:	resteasy
 BuildRequires:	apache-sshd
+BuildRequires:	openstack-java-cinder-client >= %{openstack_java_version}
+BuildRequires:	openstack-java-keystone-client >= %{openstack_java_version}
+BuildRequires:	openstack-java-glance-client >= %{openstack_java_version}
 
 # backend
 BuildRequires:	%{name}-extensions-api >= 1.0.1
+BuildRequires:	ebay-cors-filter
 
 # findbugs filter
 BuildRequires:	maven-surefire-plugin
@@ -888,6 +892,10 @@ ln -s "%{engine_name}" "%{buildroot}%{engine_java}/../%{name}"
 #
 # Register poms
 #
+# All poms including intermediate ones are required.
+# Order of the sequence of %mvn_package & %mvn_artifact matters
+# Registration should start with the most top level pom and go down
+#
 while read package pom; do
 	pomdir="$(dirname "%{_mavenpomdir}/${pom}")"
 	pom="$(basename "${pom}")"
@@ -895,18 +903,21 @@ while read package pom; do
 	mv "%{buildroot}${pomdir}/${pom}" "%{buildroot}${pomdir}/${jpppom}"
 	artifact_id="$(echo "${pom}" | sed -e 's/^%{name}-//' -e 's/\.pom//')"
 	if [ -f "%{buildroot}%{engine_java}/${artifact_id}.jar" ]; then
-		%add_maven_depmap -f "${package}" "${jpppom}" "%{name}/${artifact_id}.jar"
+		%mvn_package ":${artifact_id}*" "${package}"
+		%mvn_artifact "%{buildroot}${pomdir}/${jpppom}" "%{buildroot}%{engine_java}/${artifact_id}.jar"
 	else
-		%add_maven_depmap -f "${package}" "${jpppom}"
+		%mvn_package ":${artifact_id}*" "${package}"
+		%mvn_artifact "%{buildroot}${pomdir}/${jpppom}"
 	fi
 done << __EOF__
-backend %{name}-aaa.pom
+base %{name}-root.pom
 backend %{name}-backend.pom
+backend %{name}-manager.pom
+backend %{name}-manager-modules.pom
+backend %{name}-aaa.pom
 backend %{name}-bll.pom
 backend %{name}-builtin.pom
 backend %{name}-dal.pom
-backend %{name}-manager-modules.pom
-backend %{name}-manager.pom
 backend %{name}-scheduler.pom
 backend %{name}-searchbackend.pom
 backend %{name}-vdsbroker.pom
@@ -915,13 +926,14 @@ base %{name}-common.pom
 base %{name}-compat.pom
 base %{name}-extensions-manager.pom
 base %{name}-logutils.pom
-base %{name}-root.pom
 base %{name}-utils.pom
 base %{name}-uutils.pom
+restapi %{name}-restapi-parent.pom
+restapi %{name}-interface.pom
+restapi %{name}-common-parent.pom
 restapi %{name}-interface-common-jaxrs.pom
 restapi %{name}-restapi-definition.pom
 restapi %{name}-restapi-jaxrs.pom
-restapi %{name}-restapi-parent.pom
 restapi %{name}-restapi-types.pom
 tools %{name}-extensions-tool.pom
 tools %{name}-sso-client-registration-tool.pom
@@ -1052,6 +1064,32 @@ perl -i -pe 'BEGIN{undef $/;} s/Name: [^\n]+\n( [^\n]+\n)*([^\s]+-Digest: [^\n]+
 perl -i -pe 's/^SHA1-Digest: [^\n]+\n//g' "%{buildroot}%{engine_ear}/META-INF/MANIFEST.MF"
 
 %endif
+
+#FIXME installation fails because:
+# Exception: Following dependencies were not resolved and requires cannot be generated.
+#   Either remove the dependencies from pom.xml or add proper packages to BuildRequires:
+#   org.hibernate.validator:hibernate-validator:6.0.18.Final required by org.ovirt.engine.core:common
+#   org.infinispan:infinispan-core:9.4.18.Final required by org.ovirt.engine.core:utils
+#
+#   asocha:
+#   Unfortunately, we cannot mark these 2 dependencies as 'provided' because they are required at 'compile' time
+#
+#   Right now I can only think about 2 options:
+#   1) install it (preferably via ovirt-dependencies) and
+#        'BuildRequires:  <packages>'
+#   2) register earlier using 'mvn_artifact' & 'mvn_package' (plus any transitive dependencies)
+#      and then here in 'install' section use:
+#        '%mvn_package ":hibernate-validator*"  __noinstall'
+#        '%mvn_package ":infinispan-core*"  __noinstall'
+#        '%mvn_package ":jboss-modules*"  __noinstall'
+#      to skip installation
+# Not sure if there is a better way, but I cannot exclude it.
+
+%mvn_install
+
+echo "Install complete"
+
+
 
 %preun
 if [ "$1" -eq 0 ]; then

--- a/pom.xml
+++ b/pom.xml
@@ -228,6 +228,7 @@
         <groupId>org.springframework</groupId>
         <artifactId>spring-core</artifactId>
         <version>${spring.version}</version>
+        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>


### PR DESCRIPTION
migrated %add_maven_depmap macro calls to %mvn_artifact and %mvn_package
macro calls.

%add_maven_depmap macro was provided by javapackage-local and deprecated
long time ago and then removed. It is not available anymore in recent
javapackage-local releases, including the one shipped with CentOS Stream 9.

Change-Id: [If97ab9c94f8c68ee207203008ad28e35df3b5af5](https://gerrit.ovirt.org/q/If97ab9c94f8c68ee207203008ad28e35df3b5af5)
Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=2005978
Signed-off-by: Sandro Bonazzola <[sbonazzo@redhat.com](mailto:sbonazzo@redhat.com)>

Imported from https://gerrit.ovirt.org/c/ovirt-engine/+/116811
Requires: https://github.com/oVirt/ovirt-engine/pull/224