### PR TITLE
Fix NPE in AnsibleRunnerHttpClient.getTotalEvents

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleRunnerHttpClient.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleRunnerHttpClient.java
@@ -298,7 +298,8 @@ public class AnsibleRunnerHttpClient {
 
     public int getTotalEvents(String playUuid) {
         String[] events = getEvents(playUuid);
-        return events.length;
+        // if playbook artifacts directory is not yet populated, return 0
+        return events == null ? 0 : events.length;
     }
 
     private JsonNode getEvent(String eventPath) {


### PR DESCRIPTION
If playbook artifacts directory is not yet populated (it may happen
when we use async mode to run playbooks), return 0 as total number
of events to prevent NPE.

Bug-Url: https://bugzilla.redhat.com/2052690
Signed-off-by: Martin Perina <mperina@redhat.com>
