### PR TITLE
Default custom parallel migrations to 2

### DIFF
--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/clusters/ClusterModel.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/clusters/ClusterModel.java
@@ -1477,7 +1477,7 @@ public class ClusterModel extends EntityModel<Cluster> implements HasValidatedTa
         if (ParallelMigrationsType.CUSTOM.equals(getParallelMigrationsType().getSelectedItem())) {
             getCustomParallelMigrations().setIsChangeable(true);
             if (getCustomParallelMigrations().getEntity() == null) {
-                getCustomParallelMigrations().setEntity(0);
+                getCustomParallelMigrations().setEntity(2);
             }
         } else {
             getCustomParallelMigrations().setIsChangeable(false, constants.customParallelMigrationsDisabledReason());

--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/UnitVmModel.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/UnitVmModel.java
@@ -3985,7 +3985,7 @@ public class UnitVmModel extends Model implements HasValidatedTabs, ModelWithMig
         if (ParallelMigrationsType.CUSTOM.equals(parallelMigrationsType.getSelectedItem())) {
             getCustomParallelMigrations().setIsChangeable(true);
             if (getCustomParallelMigrations().getEntity() == null) {
-                getCustomParallelMigrations().setEntity(0);
+                getCustomParallelMigrations().setEntity(2);
             }
         } else {
             getCustomParallelMigrations().setIsChangeable(false, constants.customParallelMigrationsDisabledReason());


### PR DESCRIPTION
The valid values for custom parallel migrations are between 2 to 255 so it doesn't make sense to default it to 0.
Let's default it to the lowest level allowed (2) instead.