### PR TITLE
Fix racing cluster FIPS settings

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/InitVdsOnUpCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/InitVdsOnUpCommand.java
@@ -206,6 +206,8 @@ public class InitVdsOnUpCommand extends StorageHandlingCommandBase<HostStoragePo
             processStoragePoolStatus();
             runUpdateMomPolicy(getCluster(), getVds());
             refreshHostDeviceList();
+            // Check FIPS compatibility
+            resourceManager.getEventListener().handleVdsFips(getVdsId());
         } else {
             Map<String, String> customLogValues = new HashMap<>();
             customLogValues.put("StoragePoolName", getStoragePoolName());

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/VdsManager.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/VdsManager.java
@@ -650,9 +650,6 @@ public class VdsManager {
 
                 // Always check VdsVersion
                 resourceManager.getEventListener().handleVdsVersion(vds.getId());
-
-                // Check FIPS compatibility
-                resourceManager.getEventListener().handleVdsFips(vds.getId());
             }
         }
     }

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/monitoring/HostMonitoring.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/monitoring/HostMonitoring.java
@@ -449,7 +449,6 @@ public class HostMonitoring implements HostMonitoringInterface {
 
             if (refreshedCapabilities) {
                 getVdsEventListener().handleVdsVersion(vds.getId());
-                getVdsEventListener().handleVdsFips(vds.getId());
                 markIsSetNonOperationalExecuted();
             }
 

--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/hosts/HostGeneralModel.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/hosts/HostGeneralModel.java
@@ -1079,7 +1079,6 @@ public class HostGeneralModel extends EntityModel<VDS> {
 
         setKernelFeatures(formatKernelFeatures(vds.getKernelFeatures()));
         setvncEncryptionEnabled(vds.isVncEncryptionEnabled());
-        setFipsEnabled(vds.isFipsEnabled());
         setOvnConfigured(vds.isOvnConfigured());
     }
 
@@ -1251,19 +1250,6 @@ public class HostGeneralModel extends EntityModel<VDS> {
         if (vncEncryptionEnabled != value) {
             vncEncryptionEnabled = value;
             onPropertyChanged(new PropertyChangedEventArgs("vncEncryptionEnabled")); //$NON-NLS-1$
-        }
-    }
-
-    private boolean fipsEnabled;
-
-    public boolean isFipsEnabled() {
-        return fipsEnabled;
-    }
-
-    public void setFipsEnabled(boolean value) {
-        if (fipsEnabled != value) {
-            fipsEnabled = value;
-            onPropertyChanged(new PropertyChangedEventArgs("fipsEnabled")); //$NON-NLS-1$
         }
     }
 

--- a/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/ApplicationConstants.java
+++ b/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/ApplicationConstants.java
@@ -3557,8 +3557,6 @@ public interface ApplicationConstants extends CommonApplicationConstants {
 
     String vncEncryptionLabel();
 
-    String fipsEnabledLabel();
-
     String ovnConfiguredLabel();
 
     String vdsmName();

--- a/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/section/main/view/tab/host/HostGeneralSubTabView.java
+++ b/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/section/main/view/tab/host/HostGeneralSubTabView.java
@@ -85,7 +85,6 @@ public class HostGeneralSubTabView extends AbstractSubTabFormView<VDS, HostListM
     StringValueLabel clusterCompatibilityVersion = new StringValueLabel();
     StringValueLabel hugePages = new StringValueLabel();
     BooleanTextBoxLabel vncEncryptionEnabled = new BooleanTextBoxLabel(constants.enabled(), constants.disabled());
-    BooleanTextBoxLabel fipsEnabled = new BooleanTextBoxLabel(constants.enabled(), constants.disabled());
     BooleanTextBoxLabel ovnConfigured = new BooleanTextBoxLabel(constants.yes(), constants.no());
 
     MemorySizeTextBoxLabel<Integer> physicalMemory = new MemorySizeTextBoxLabel<>();
@@ -212,7 +211,7 @@ public class HostGeneralSubTabView extends AbstractSubTabFormView<VDS, HostListM
         boolean glusterSupported = ApplicationModeHelper.isModeSupported(ApplicationMode.GlusterOnly);
 
         // Build a form using the FormBuilder
-        softwareFormBuilder = new FormBuilder(softwareFormPanel, 1, 15);
+        softwareFormBuilder = new FormBuilder(softwareFormPanel, 1, 14);
         softwareFormBuilder.setRelativeColumnWidth(0, 12);
         softwareFormBuilder.addFormItem(new FormItem(constants.osVersionHostGeneral(), oS, 0).withAutoPlacement(), 2, 10);
         softwareFormBuilder.addFormItem(new FormItem(constants.osPrettyName(), osPrettyName, 0).withAutoPlacement(), 2, 10);
@@ -239,7 +238,6 @@ public class HostGeneralSubTabView extends AbstractSubTabFormView<VDS, HostListM
         softwareFormBuilder.addFormItem(new FormItem(constants.kernelFeatures(), kernelFeatures, 0, true)
                 .withAutoPlacement(), 2, 10);
         softwareFormBuilder.addFormItem(new FormItem(constants.vncEncryptionLabel(), vncEncryptionEnabled, 0).withAutoPlacement(), 2, 10);
-        softwareFormBuilder.addFormItem(new FormItem(constants.fipsEnabledLabel(), fipsEnabled, 0).withAutoPlacement(), 2, 10);
         softwareFormBuilder.addFormItem(new FormItem(constants.ovnConfiguredLabel(), ovnConfigured, 0).withAutoPlacement(), 2, 10);
     }
 

--- a/frontend/webadmin/modules/webadmin/src/main/resources/org/ovirt/engine/ui/webadmin/ApplicationConstants.properties
+++ b/frontend/webadmin/modules/webadmin/src/main/resources/org/ovirt/engine/ui/webadmin/ApplicationConstants.properties
@@ -1777,7 +1777,6 @@ notifDoNotDisturbNextLogin=until Next Log In
 vncEncryptionEnabled=Enable VNC Encryption
 vncEncryptionEnabledHelpMessage=Enabling VNC Encryption will enforce VNC communication over TLS (using X509Vnc VeNCrypt)
 vncEncryptionLabel=VNC Encryption
-fipsEnabledLabel=FIPS mode enabled
 ovnConfiguredLabel=OVN configured
 vdsmName=VDSM Name
 portSecurityEnabledLabel=Network Port Security


### PR DESCRIPTION
When we have a new cluster, the FIPS mode is defined by the first host
being added to that cluster. By default the value of it when unavailable
from the host is `false`. In case of new host deployment to that cluster
and reboot, we may not get the capabilities as expected and even when
the host is with FIPS set, it will still wrongly set the cluster with
`false`, making the host non-operational until the cluster is edited by
the user to be FIPS `true`.

The placement the engine handles the FIPS is moved to a place we can be
certain we already get the capabilities from the host. Therefore, we
will always set it with the right value of the first host in that new
cluster.

Change-Id: I3c21028e3bd0f882340afc13ab05911fb92ec90c
Bug-Url: https://bugzilla.redhat.com/2065543
Signed-off-by: Liran Rotenberg <lrotenbe@redhat.com>