### PR TITLE
Ansible-runner: list artifacts one by one

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleRunnerHttpClient.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleRunnerHttpClient.java
@@ -73,7 +73,7 @@ public class AnsibleRunnerHttpClient {
 
     public AnsibleReturnValue artifactHandler(UUID uuid, int lastEventID, int timeout, BiConsumer<String, String> fn)
             throws Exception {
-        int iteration = 0;
+        int executionTime = 0;
         setArtifactsDir(uuid);
         setReturnValue(uuid);
         while (!playHasEnded(uuid)) {
@@ -81,8 +81,8 @@ public class AnsibleRunnerHttpClient {
             if (lastEventID == -1) {
                 return returnValue;
             }
-            iteration += POLL_INTERVAL / 1000;
-            if (iteration > timeout * 60) {
+            executionTime += POLL_INTERVAL / 1000;
+            if (executionTime > timeout * 60) {
                 // Cancel playbook, and raise exception in case timeout occur:
                 cancelPlaybook(uuid, timeout);
                 throw new TimeoutException(

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleRunnerHttpClient.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleRunnerHttpClient.java
@@ -128,8 +128,12 @@ public class AnsibleRunnerHttpClient {
             String msg,
             Path logFile) {
         String jobEvents = getJobEventsDir(playUuid);
-        String event = getNextEvent(playUuid, lastEventId);
-        while(event != null){
+        while(true){
+            String event = getNextEvent(playUuid, lastEventId);
+            if (event == null) {
+                break;
+            }
+
             JsonNode currentNode = getEvent(jobEvents + event);
             String stdout = RunnerJsonNode.getStdout(currentNode);
 
@@ -191,7 +195,6 @@ public class AnsibleRunnerHttpClient {
             lastEvent = event;
             returnValue.setLastEventId(getLastEventId());
             lastEventId++;
-            event = getNextEvent(playUuid, lastEventId);
         }
         return lastEvent.isEmpty() ? lastEventId : getLastEventId();
     }

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleRunnerHttpClient.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleRunnerHttpClient.java
@@ -76,8 +76,7 @@ public class AnsibleRunnerHttpClient {
         int iteration = 0;
         setArtifactsDir(uuid);
         setReturnValue(uuid);
-        // retrieve timeout from engine constants.
-        while (!playHasEnded(uuid)) { //return -1 incase of an error)
+        while (!playHasEnded(uuid)) {
             if (lastEventID == -1) {
                 return returnValue;
             }

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleRunnerHttpClient.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleRunnerHttpClient.java
@@ -77,17 +77,17 @@ public class AnsibleRunnerHttpClient {
         setArtifactsDir(uuid);
         setReturnValue(uuid);
         while (!playHasEnded(uuid)) {
+            lastEventID = processEvents(uuid.toString(), lastEventID, fn, "", Paths.get(""));
             if (lastEventID == -1) {
                 return returnValue;
             }
+            iteration += POLL_INTERVAL / 1000;
             if (iteration > timeout * 60) {
                 // Cancel playbook, and raise exception in case timeout occur:
                 cancelPlaybook(uuid, timeout);
                 throw new TimeoutException(
                         "Play execution has reached timeout");
             }
-            lastEventID = processEvents(uuid.toString(), lastEventID, fn, "", Paths.get(""));
-            iteration += POLL_INTERVAL / 1000;
             Thread.sleep(POLL_INTERVAL);
         }
         returnValue.setAnsibleReturnCode(AnsibleReturnCode.OK);

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleRunnerHttpClient.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleRunnerHttpClient.java
@@ -16,7 +16,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -100,18 +99,18 @@ public class AnsibleRunnerHttpClient {
     }
 
     public String getNextEvent(String playUuid, int lastEventId) {
-        Optional<String> nextEvent = Optional.empty();
-        // ignoring incompleted json files, add to list only events that haven't been handles yet.
         String jobEvents = getJobEventsDir(playUuid);
-        if (Files.exists(Paths.get(jobEvents))) {
-            nextEvent = Stream.of(new File(jobEvents).listFiles())
-                    .map(File::getName)
-                    .filter(item -> !item.contains("partial"))
-                    .filter(item -> !item.endsWith(".tmp"))
-                    .filter(item -> item.startsWith((lastEventId + 1) + "-"))
-                    .findFirst();
+        if (!Files.exists(Paths.get(jobEvents))) {
+            return null;
         }
-        return nextEvent.isPresent() ? nextEvent.get() : null;
+        // ignoring incompleted json files, add to list only events that haven't been handles yet.
+        return Stream.of(new File(jobEvents).listFiles())
+                .map(File::getName)
+                .filter(item -> !item.contains("partial"))
+                .filter(item -> !item.endsWith(".tmp"))
+                .filter(item -> item.startsWith((lastEventId + 1) + "-"))
+                .findFirst()
+                .orElse(null);
     }
 
     public int getLastEventId() {


### PR DESCRIPTION
The artifacts created by ansible-runner have the id prefix, which we used to gather the events.
We were listing new artifacts by counting the number of previously processed artifacts and checking the new artifacts from that number as a prefix id. This approach causes multiple issues with async execution where the artifacts are not created in order but there could be a bit of time delay between them. For example, artifact 4 was created before 3.

The new approach fixes this issue by waiting for each file with an id prefix until the playbook finishes or times out.
