### PR TITLE
fix: add fapolicy exclusion rule

### DIFF
--- a/packaging/ansible-runner-service-project/project/roles/ovirt-host-deploy-vdsm/tasks/configure.yml
+++ b/packaging/ansible-runner-service-project/project/roles/ovirt-host-deploy-vdsm/tasks/configure.yml
@@ -64,23 +64,25 @@
   command: vdsm-tool configure --force
   changed_when: True
 
-- name: add vdsm-mom allow rule to fapolicy
-  copy:
-   dest: /etc/fapolicyd/rules.d/32-allow-vdsm-mom.rules
-   group: fapolicyd
-   mode: '0644'
-   remote_src: yes
-   content: |
-     allow perm=any trust=1 : dir=/etc/vdsm/mom.d/ ftype=text/x-lisp
-  when: ansible_distribution == 'RedHat'
-
 - name: collect facts about system services
   service_facts:
 
-- name: restart fapolicy service
-  systemd:
-   state: restarted
-   name: fapolicyd
+- block:
+  - name: add vdsm-mom allow rule to fapolicy
+    copy:
+     dest: /etc/fapolicyd/rules.d/32-allow-vdsm-mom.rules
+     group: fapolicyd
+     mode: '0644'
+     remote_src: yes
+     content: |
+       allow perm=any trust=1 : dir=/etc/vdsm/mom.d/ ftype=text/x-lisp
+
+  - name: restart fapolicy service
+    systemd:
+     state: restarted
+     name: fapolicyd
+
   when:
+    - ansible_distribution == 'RedHat'
     - "'fapolicyd.service' in services"
     - ansible_facts.services["fapolicyd.service"].state == 'running'


### PR DESCRIPTION
adding exclusion rule to fapolicy for vdsm-mom was a condition by the os
distro. since rhv host doesn't have fapolicy it caused a failure.
add the exclusion rule to fapolicy only when fapolicy service is
running.