### PR TITLE
ansible: Set explicit owner/permissions for hosted_engine_conf

### DIFF
--- a/packaging/ansible-runner-service-project/project/roles/ovirt-host-deploy-hosted-engine/tasks/deploy.yml
+++ b/packaging/ansible-runner-service-project/project/roles/ovirt-host-deploy-hosted-engine/tasks/deploy.yml
@@ -27,7 +27,9 @@
   copy:
     src: "{{ hosted_engine_tmp_cfg_file }}"
     dest: "{{ hosted_engine_conf }}"
-    mode: preserve
+    owner: 'vdsm'
+    group: 'kvm'
+    mode: 0440
 
 - name: Update host ID in hosted engine configuration
   lineinfile:


### PR DESCRIPTION
A recent change somewhere, not sure, creates the file
/etc/ovirt-hosted-engine/hosted-engine.conf with root:root, 0400.
ovirt-ha-broker fails to read it like this.
So: Fix, by setting explicitly the owner/group/permissions we want for
this file.

Change-Id: I4525273a1146854d808ea2ef8bc31b1741d61004
Signed-off-by: Yedidyah Bar David <didi@redhat.com>