### PR TITLE
Null check in ClusterAdditionalStatusColumn

### DIFF
--- a/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/widget/table/column/ClusterAdditionalStatusColumn.java
+++ b/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/widget/table/column/ClusterAdditionalStatusColumn.java
@@ -64,7 +64,7 @@ public class ClusterAdditionalStatusColumn extends EntityAdditionalStatusColumn<
             images.add(getImageSafeHtml(IconType.EXCLAMATION));
         }
 
-        if (!object.getHostNamesOutOfSync().isEmpty()) {
+        if (object.getHostNamesOutOfSync() != null && !object.getHostNamesOutOfSync().isEmpty()) {
             images.add(templates.brokenLinkRed());
         }
 


### PR DESCRIPTION
When rendering the ClusterAdditionalStatusColumn, the cluster.getHostNamesOutOfSync() might be null if the
async backend query failed. As a result, we get the NP exception because we check only if the string is empty, not if it is null. This patch adds a null check to ClusterAdditionalStatusColumn::getEntityValue.