### PR TITLE
setup, ansible: Add rules for ansible that runs as regular user

### DIFF
--- a/ovirt-engine.spec.in
+++ b/ovirt-engine.spec.in
@@ -1240,7 +1240,7 @@ fi
 %config %{_sysconfdir}/ovirt-engine-setup.conf.d/10-packaging.conf
 %{_bindir}/engine-upgrade-check
 %{engine_data}/conf/ovirt-engine-proxy.conf.v2.in
-%{engine_data}/conf/fapolicyd-55-allow-ovirt-jboss.rules.in
+%{engine_data}/conf/fapolicyd-55-allow-ovirt.rules.in
 %{engine_data}/conf/ovirt-engine-root-redirect.conf.in
 %{engine_data}/firewalld/ovirt-engine/
 %{engine_data}/setup/bin/ovirt-engine-upgrade-check

--- a/packaging/ansible-runner-service-project/project/roles/ovirt-host-deploy-vdsm/tasks/configure.yml
+++ b/packaging/ansible-runner-service-project/project/roles/ovirt-host-deploy-vdsm/tasks/configure.yml
@@ -76,6 +76,7 @@
      remote_src: yes
      content: |
        allow perm=any trust=1 : dir=/etc/vdsm/mom.d/ ftype=text/x-lisp
+       allow perm=any trust=1 : dir=/var/tmp/ ftype=text/x-python
 
   - name: restart fapolicy service
     systemd:

--- a/packaging/conf/fapolicyd-55-allow-ovirt-jboss.rules.in
+++ b/packaging/conf/fapolicyd-55-allow-ovirt-jboss.rules.in
@@ -1,5 +1,0 @@
-#
-# This is Ovirt Engine configuration and MUST NOT be changed manually
-#
-%java_lang=application/java-archive,text/x-java,application/x-java-applet,application/javascript,text/javascript
-allow perm=any trust=1 : dir=@JBOSS_RUNTIME_TMP_DIR@ ftype=%java_lang

--- a/packaging/conf/fapolicyd-55-allow-ovirt.rules.in
+++ b/packaging/conf/fapolicyd-55-allow-ovirt.rules.in
@@ -1,0 +1,5 @@
+#
+# This is Ovirt Engine configuration and MUST NOT be changed manually
+#
+%java=application/java-archive,text/x-java,application/x-java-applet,application/javascript,text/javascript,text/x-python
+allow perm=any trust=1 : dir=@ENGINE_RUNTIME_DIR@ ftype=%lang

--- a/packaging/setup/ovirt_engine_setup/engine_common/constants.py
+++ b/packaging/setup/ovirt_engine_setup/engine_common/constants.py
@@ -79,16 +79,16 @@ class FileLocations(object):
         OVIRT_ENGINE_PKIKEYSDIR,
         'apache.key.nopass',
     )
-    FAPOLICYD_ALLOW_OVIRT_JBOSS_RULE_TEMPLATE = os.path.join(
+    FAPOLICYD_ALLOW_OVIRT_ENGINE_RULE_TEMPLATE = os.path.join(
         osetupcons.FileLocations.OVIRT_SETUP_DATADIR,
         'conf',
-        'fapolicyd-55-allow-ovirt-jboss.rules.in',
+        'fapolicyd-55-allow-ovirt.rules.in',
     )
-    FAPOLICYD_ALLOW_OVIRT_JBOSS_RULE = os.path.join(
+    FAPOLICYD_ALLOW_OVIRT_ENGINE_RULE = os.path.join(
         SYSCONFDIR,
         'fapolicyd',
         'rules.d',
-        '55-allow-ovirt-jboss.rules',
+        '55-allow-ovirt.rules',
     )
 
 

--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/config/__init__.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/config/__init__.py
@@ -21,10 +21,10 @@ from . import appmode
 from . import ca
 from . import database
 from . import domain_type
+from . import fapolicyd
 from . import firewall
 from . import java
 from . import jboss
-from . import jboss_fapolicyd
 from . import notifier
 from . import options
 from . import protocols
@@ -55,7 +55,7 @@ def createPlugins(context):
     storage.Plugin(context=context)
     sso.Plugin(context=context)
     notifier.Plugin(context=context)
-    jboss_fapolicyd.Plugin(context=context)
+    fapolicyd.Plugin(context=context)
 
 
 # vim: expandtab tabstop=4 shiftwidth=4

--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/config/fapolicyd.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/config/fapolicyd.py
@@ -7,7 +7,7 @@
 #
 
 
-"""Jboss fapolicyd plugin."""
+"""Engine fapolicyd plugin."""
 
 
 import gettext
@@ -18,7 +18,6 @@ from otopi import filetransaction
 from otopi import plugin
 from otopi import util
 
-from ovirt_engine import configfile
 from ovirt_engine import util as outil
 
 from ovirt_engine_setup import constants as osetupcons
@@ -43,7 +42,7 @@ class Plugin(plugin.PluginBase):
     def _init(self):
         self.environment.setdefault(
             oengcommcons.FapolicydEnv.FAPOLICYD_ALLOW_OVIRT_RULE,
-            oengcommcons.FileLocations.FAPOLICYD_ALLOW_OVIRT_JBOSS_RULE
+            oengcommcons.FileLocations.FAPOLICYD_ALLOW_OVIRT_ENGINE_RULE
         )
 
     @plugin.event(
@@ -51,20 +50,16 @@ class Plugin(plugin.PluginBase):
         condition=lambda self: (
                 self.environment[oenginecons.CoreEnv.ENABLE] and
                 not os.path.exists(
-                    oengcommcons.FileLocations.FAPOLICYD_ALLOW_OVIRT_JBOSS_RULE
+                    oengcommcons.FileLocations.
+                    FAPOLICYD_ALLOW_OVIRT_ENGINE_RULE
                 ) and not self.environment[
                     osetupcons.CoreEnv.DEVELOPER_MODE
                 ]
         ),
     )
     def _misc(self):
-        config = configfile.ConfigFile([
-            oenginecons.FileLocations.OVIRT_ENGINE_SERVICE_CONFIG_DEFAULTS,
-            oenginecons.FileLocations.OVIRT_ENGINE_SERVICE_CONFIG
-        ])
-        engine_tmp_dir = os.path.join(
-            config.get('JBOSS_RUNTIME'),
-            'tmp'
+        engine_runtime_dir = (
+            oenginecons.FileLocations.OVIRT_ENGINE_LOCALSTATEDIR
         )
 
         self.environment[oengcommcons.FapolicydEnv.NEED_RESTART] = True
@@ -76,10 +71,10 @@ class Plugin(plugin.PluginBase):
                 content=outil.processTemplate(
                     template=(
                         oengcommcons.FileLocations.
-                        FAPOLICYD_ALLOW_OVIRT_JBOSS_RULE_TEMPLATE
+                        FAPOLICYD_ALLOW_OVIRT_ENGINE_RULE_TEMPLATE
                     ),
                     subst={
-                        '@JBOSS_RUNTIME_TMP_DIR@': engine_tmp_dir,
+                        '@ENGINE_RUNTIME_DIR@': engine_runtime_dir,
                     },
                 ),
                 modifiedList=self.environment[


### PR DESCRIPTION
The fapolicyd blocks ansible scripts for non-root users.
Add rules to engine and host for relavant directories.

Signed-off-by: Ales Musil <amusil@redhat.com>