### PR TITLE
Fix fapolicyd configuration path

### DIFF
--- a/packaging/ansible-runner-service-project/project/roles/ovirt-host-deploy-vdsm/tasks/configure.yml
+++ b/packaging/ansible-runner-service-project/project/roles/ovirt-host-deploy-vdsm/tasks/configure.yml
@@ -64,9 +64,9 @@
   command: vdsm-tool configure --force
   changed_when: True
 
-- name: Verify fapolicyd.rules file
+- name: Check existence of /etc/fapolicyd/rules.d directory
   stat:
-    path: /etc/fapolicyd/fapolicyd.rules
+    path: /etc/fapolicyd/rules.d
   register: fapolicy_rules
 
 - name: collect facts about system services


### PR DESCRIPTION
Fixes fapolicy configuration path introduced in https://github.com/oVirt/ovirt-engine/pull/256

Signed-off-by: Martin Perina <mperina@redhat.com>
