### PR TITLE
Refactor AnsibleRunner execution

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/AnsibleCallback.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/AnsibleCallback.java
@@ -62,16 +62,12 @@ public class AnsibleCallback implements CommandCallback {
         AnsibleReturnValue ret = new AnsibleReturnValue(AnsibleReturnCode.ERROR);
         ret.setLogFile(runnerClient.getLogger().getLogFile());
         String msg = "";
-        int totalEvents;
         // Get the current status of the playbook:
         AnsibleRunnerClient.PlaybookStatus playbookStatus = runnerClient.getPlaybookStatus(playUuid);
         String status = playbookStatus.getStatus();
         msg = playbookStatus.getMsg();
-        // Process the events if the playbook is running:
-        totalEvents = runnerClient.getTotalEvents(playUuid);
 
-        if (msg.equalsIgnoreCase("running") || msg.equalsIgnoreCase("successful")
-                && command.getParameters().getLastEventId() < totalEvents) {
+        if (msg.equalsIgnoreCase("running")) {
             command.getParameters().setLastEventId(runnerClient.processEvents(
                     playUuid, fn));
             return;

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/AnsibleCallback.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/AnsibleCallback.java
@@ -13,7 +13,7 @@ import org.ovirt.engine.core.common.AuditLogType;
 import org.ovirt.engine.core.common.action.AnsibleCommandParameters;
 import org.ovirt.engine.core.common.utils.ansible.AnsibleReturnCode;
 import org.ovirt.engine.core.common.utils.ansible.AnsibleReturnValue;
-import org.ovirt.engine.core.common.utils.ansible.AnsibleRunnerHttpClient;
+import org.ovirt.engine.core.common.utils.ansible.AnsibleRunnerClient;
 import org.ovirt.engine.core.common.utils.ansible.AnsibleRunnerLogger;
 import org.ovirt.engine.core.compat.CommandStatus;
 import org.ovirt.engine.core.compat.Guid;
@@ -35,7 +35,7 @@ public class AnsibleCallback implements CommandCallback {
     private CommandCoordinatorUtil commandCoordinatorUtil;
 
     @Inject
-    private AnsibleRunnerHttpClient runnerClient;
+    private AnsibleRunnerClient runnerClient;
 
     @Inject
     private VdsDao vdsDao;
@@ -64,7 +64,7 @@ public class AnsibleCallback implements CommandCallback {
         String msg = "";
         int totalEvents;
         // Get the current status of the playbook:
-        AnsibleRunnerHttpClient.PlaybookStatus playbookStatus = runnerClient.getPlaybookStatus(playUuid);
+        AnsibleRunnerClient.PlaybookStatus playbookStatus = runnerClient.getPlaybookStatus(playUuid);
         String status = playbookStatus.getStatus();
         msg = playbookStatus.getMsg();
         // Process the events if the playbook is running:

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/AnsibleCallback.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/AnsibleCallback.java
@@ -73,7 +73,7 @@ public class AnsibleCallback implements CommandCallback {
         if (msg.equalsIgnoreCase("running") || msg.equalsIgnoreCase("successful")
                 && command.getParameters().getLastEventId() < totalEvents) {
             command.getParameters().setLastEventId(runnerClient.processEvents(
-                    playUuid, command.getParameters().getLastEventId(), fn, msg, ret.getLogFile()));
+                    playUuid, fn));
             return;
         } else if (msg.equalsIgnoreCase("successful")) {
             log.info("Playbook (Play uuid = {}, command = {}) has completed!",

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/AnsibleCommandBase.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/AnsibleCommandBase.java
@@ -17,7 +17,7 @@ import org.ovirt.engine.core.common.utils.ansible.AnsibleCommandConfig;
 import org.ovirt.engine.core.common.utils.ansible.AnsibleExecutor;
 import org.ovirt.engine.core.common.utils.ansible.AnsibleReturnCode;
 import org.ovirt.engine.core.common.utils.ansible.AnsibleReturnValue;
-import org.ovirt.engine.core.common.utils.ansible.AnsibleRunnerHttpClient;
+import org.ovirt.engine.core.common.utils.ansible.AnsibleRunnerClient;
 import org.ovirt.engine.core.compat.CommandStatus;
 
 public abstract class AnsibleCommandBase <T extends AnsibleCommandParameters> extends CommandBase<T> {
@@ -26,7 +26,7 @@ public abstract class AnsibleCommandBase <T extends AnsibleCommandParameters> ex
     private AnsibleExecutor ansibleExecutor;
 
     @Inject
-    private AnsibleRunnerHttpClient runnerClient;
+    private AnsibleRunnerClient runnerClient;
 
     @Inject
     @Typed(AnsibleCallback.class)

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/AnsibleImageMeasureCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/AnsibleImageMeasureCommand.java
@@ -13,14 +13,14 @@ import org.ovirt.engine.core.common.errors.EngineError;
 import org.ovirt.engine.core.common.errors.EngineException;
 import org.ovirt.engine.core.common.utils.ansible.AnsibleCommandConfig;
 import org.ovirt.engine.core.common.utils.ansible.AnsibleConstants;
-import org.ovirt.engine.core.common.utils.ansible.AnsibleRunnerHttpClient;
+import org.ovirt.engine.core.common.utils.ansible.AnsibleRunnerClient;
 
 @NonTransactiveCommandAttribute
 public class AnsibleImageMeasureCommand <T extends AnsibleImageMeasureCommandParameters> extends AnsibleCommandBase<T> {
     public static final Pattern DISK_TARGET_SIZE_PATTERN = Pattern.compile("required size: ([0-9]+).*", Pattern.DOTALL);
 
     @Inject
-    private AnsibleRunnerHttpClient runnerClient;
+    private AnsibleRunnerClient runnerClient;
 
     public AnsibleImageMeasureCommand(T parameters, CommandContext cmdContext) {
         super(parameters, cmdContext);

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/GetFromOvaQuery.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/GetFromOvaQuery.java
@@ -21,7 +21,7 @@ import org.ovirt.engine.core.common.utils.ansible.AnsibleConstants;
 import org.ovirt.engine.core.common.utils.ansible.AnsibleExecutor;
 import org.ovirt.engine.core.common.utils.ansible.AnsibleReturnCode;
 import org.ovirt.engine.core.common.utils.ansible.AnsibleReturnValue;
-import org.ovirt.engine.core.common.utils.ansible.AnsibleRunnerHttpClient;
+import org.ovirt.engine.core.common.utils.ansible.AnsibleRunnerClient;
 import org.ovirt.engine.core.dao.VdsDao;
 import org.ovirt.engine.core.utils.EngineLocalConfig;
 
@@ -32,7 +32,7 @@ public abstract class GetFromOvaQuery <T, P extends GetVmFromOvaQueryParameters>
     @Inject
     private AnsibleExecutor ansibleExecutor;
     @Inject
-    private AnsibleRunnerHttpClient runnerClient;
+    private AnsibleRunnerClient runnerClient;
 
     public GetFromOvaQuery(P parameters, EngineContext engineContext) {
         super(parameters, engineContext);

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ExtractOvaCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ExtractOvaCommand.java
@@ -32,7 +32,7 @@ import org.ovirt.engine.core.common.utils.ansible.AnsibleConstants;
 import org.ovirt.engine.core.common.utils.ansible.AnsibleExecutor;
 import org.ovirt.engine.core.common.utils.ansible.AnsibleReturnCode;
 import org.ovirt.engine.core.common.utils.ansible.AnsibleReturnValue;
-import org.ovirt.engine.core.common.utils.ansible.AnsibleRunnerHttpClient;
+import org.ovirt.engine.core.common.utils.ansible.AnsibleRunnerClient;
 import org.ovirt.engine.core.common.vdscommands.VDSReturnValue;
 import org.ovirt.engine.core.compat.CommandStatus;
 import org.ovirt.engine.core.compat.Guid;
@@ -50,7 +50,7 @@ public class ExtractOvaCommand<T extends ConvertOvaParameters> extends VmCommand
     @Inject
     private AnsibleExecutor ansibleExecutor;
     @Inject
-    private AnsibleRunnerHttpClient runnerClient;
+    private AnsibleRunnerClient runnerClient;
     @Inject
     private VmHandler vmHandler;
     @Inject

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/host/HostUpgradeManager.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/host/HostUpgradeManager.java
@@ -24,7 +24,7 @@ import org.ovirt.engine.core.common.utils.ansible.AnsibleConstants;
 import org.ovirt.engine.core.common.utils.ansible.AnsibleExecutor;
 import org.ovirt.engine.core.common.utils.ansible.AnsibleReturnCode;
 import org.ovirt.engine.core.common.utils.ansible.AnsibleReturnValue;
-import org.ovirt.engine.core.common.utils.ansible.AnsibleRunnerHttpClient;
+import org.ovirt.engine.core.common.utils.ansible.AnsibleRunnerClient;
 import org.ovirt.engine.core.dal.dbbroker.auditloghandling.AuditLogDirector;
 import org.ovirt.engine.core.dal.dbbroker.auditloghandling.AuditLogable;
 import org.ovirt.engine.core.dal.dbbroker.auditloghandling.AuditLogableImpl;
@@ -51,7 +51,7 @@ public class HostUpgradeManager implements UpdateAvailable, Updateable {
     private AnsibleExecutor ansibleExecutor;
 
     @Inject
-    private AnsibleRunnerHttpClient runnerClient;
+    private AnsibleRunnerClient runnerClient;
 
     @Inject
     private ClusterDao clusterDao;

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/hostdeploy/InstallVdsInternalCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/hostdeploy/InstallVdsInternalCommand.java
@@ -49,7 +49,7 @@ import org.ovirt.engine.core.common.utils.ansible.AnsibleConstants;
 import org.ovirt.engine.core.common.utils.ansible.AnsibleExecutor;
 import org.ovirt.engine.core.common.utils.ansible.AnsibleReturnCode;
 import org.ovirt.engine.core.common.utils.ansible.AnsibleReturnValue;
-import org.ovirt.engine.core.common.utils.ansible.AnsibleRunnerHttpClient;
+import org.ovirt.engine.core.common.utils.ansible.AnsibleRunnerClient;
 import org.ovirt.engine.core.compat.Guid;
 import org.ovirt.engine.core.dal.dbbroker.auditloghandling.AuditLogable;
 import org.ovirt.engine.core.dal.dbbroker.auditloghandling.AuditLogableImpl;
@@ -91,7 +91,7 @@ public class InstallVdsInternalCommand<T extends InstallVdsParameters> extends V
     private AnsibleExecutor ansibleExecutor;
 
     @Inject
-    private AnsibleRunnerHttpClient runnerClient;
+    private AnsibleRunnerClient runnerClient;
 
     @Inject
     private NetworkHelper networkHelper;

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleClientFactory.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleClientFactory.java
@@ -9,9 +9,9 @@ public class AnsibleClientFactory {
     @Inject
     private AnsibleCommandLogFileFactory ansibleCommandLogFileFactory;
 
-    public AnsibleRunnerHttpClient create(AnsibleCommandConfig command) {
+    public AnsibleRunnerClient create(AnsibleCommandConfig command) {
         AnsibleRunnerLogger runnerLogger = ansibleCommandLogFileFactory.create(command);
-        AnsibleRunnerHttpClient client = new AnsibleRunnerHttpClient();
+        AnsibleRunnerClient client = new AnsibleRunnerClient();
         client.setLogger(runnerLogger);
         return client;
     }

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleCommandConfig.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleCommandConfig.java
@@ -279,8 +279,8 @@ public class AnsibleCommandConfig implements LogFileConfig, PlaybookConfig {
     }
 
     private File setupAnsibleRunnerExecutionDir() throws IOException {
-        File tempProject = new File(String.format("%1$s/%2$s/", AnsibleConstants.ANSIBLE_RUNNER_PATH, this.uuid));
-        tempProject.mkdirs();
+        File privateDataDir = new File(String.format("%1$s/%2$s/", AnsibleConstants.ANSIBLE_RUNNER_PATH, this.uuid));
+        privateDataDir.mkdirs();
 
         File env = new File(String.format("%1$s/%2$s/env", AnsibleConstants.ANSIBLE_RUNNER_PATH, this.uuid));
         env.mkdir();
@@ -290,7 +290,7 @@ public class AnsibleCommandConfig implements LogFileConfig, PlaybookConfig {
             EngineLocalConfig.getInstance().getPKIDir().toString(),
             "/keys/engine_id_rsa");
         Path linkToEngineSshKey = Paths.get(
-            tempProject.toString(),
+            privateDataDir.toString(),
             "/env/ssh_key");
         Files.createSymbolicLink(linkToEngineSshKey, engineSshKey);
 
@@ -303,7 +303,7 @@ public class AnsibleCommandConfig implements LogFileConfig, PlaybookConfig {
         // Create a host inventory file in project inventory/host, which will be passed to the playbook by ansible-runner.
         createHostFile(inventory);
 
-        return tempProject;
+        return privateDataDir;
     }
 
     private void createHostFile(File inventory) {

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleExecutor.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleExecutor.java
@@ -147,10 +147,8 @@ public class AnsibleExecutor {
         }
 
         AnsibleReturnValue ret = new AnsibleReturnValue(AnsibleReturnCode.ERROR);
-        int lastEventId = 0;
 
         String playUuid = null;
-        String msg = "";
         AnsibleRunnerHttpClient runnerClient = null;
         try {
             runnerClient = ansibleClientFactory.create(commandConfig);
@@ -160,7 +158,7 @@ public class AnsibleExecutor {
             List<String> command = commandConfig.build();
 
             // Run the playbook:
-            runnerClient.runPlaybook(command, timeout);
+            runnerClient.runPlaybook(command, timeout, playUuid);
 
             if (async) {
                 ret.setPlayUuid(playUuid);
@@ -168,7 +166,7 @@ public class AnsibleExecutor {
                 return ret;
             }
 
-            ret = runnerClient.artifactHandler(commandConfig.getUuid(), lastEventId, timeout, fn);
+            ret = runnerClient.artifactHandler(commandConfig.getUuid(), timeout, fn);
         } catch (InventoryException ex) {
             String message = ex.getMessage();
             log.error("Error executing playbook: {}", message);
@@ -182,8 +180,7 @@ public class AnsibleExecutor {
         } finally {
             // Make sure all events are proccessed even in case of failure:
             if (playUuid != null && runnerClient != null && !async) {
-                lastEventId = runnerClient.getLastEventId();
-                runnerClient.processEvents(playUuid, lastEventId, fn, msg, ret.getLogFile());
+                runnerClient.processEvents(playUuid, fn);
             }
         }
 

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleExecutor.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleExecutor.java
@@ -149,7 +149,7 @@ public class AnsibleExecutor {
         AnsibleReturnValue ret = new AnsibleReturnValue(AnsibleReturnCode.ERROR);
 
         String playUuid = null;
-        AnsibleRunnerHttpClient runnerClient = null;
+        AnsibleRunnerClient runnerClient = null;
         try {
             runnerClient = ansibleClientFactory.create(commandConfig);
             playUuid = commandConfig.getUuid().toString();

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleRunnerClient.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleRunnerClient.java
@@ -36,15 +36,15 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 
 @Singleton
-public class AnsibleRunnerHttpClient {
-    private static Logger log = LoggerFactory.getLogger(AnsibleRunnerHttpClient.class);
+public class AnsibleRunnerClient {
+    private static Logger log = LoggerFactory.getLogger(AnsibleRunnerClient.class);
     private ObjectMapper mapper;
     private AnsibleRunnerLogger runnerLogger;
     private JsonNode lastEvent;
     private static final int POLL_INTERVAL = 3000;
     private AnsibleReturnValue returnValue;
 
-    public AnsibleRunnerHttpClient() {
+    public AnsibleRunnerClient() {
         this.mapper = JsonMapper
                 .builder()
                 .findAndAddModules()
@@ -197,17 +197,13 @@ public class AnsibleRunnerHttpClient {
         }
     }
 
-    public void cancelPlaybook(UUID uuid) throws Exception {
-        this.cancelPlaybook(uuid, 0);
-    }
-
     public void cancelPlaybook(UUID uuid, int timeout) throws Exception {
         File privateDataDir = new File(String.format("%1$s/%2$s/", AnsibleConstants.ANSIBLE_RUNNER_PATH, uuid));
         File output = new File(String.format("%1$s/engine-cancel-output.log", privateDataDir));
         String command = String.format("ansible-runner stop %1$s", privateDataDir);
         ProcessBuilder ansibleProcessBuilder = new ProcessBuilder(command).redirectErrorStream(true).redirectOutput(output);
         Process ansibleProcess = ansibleProcessBuilder.start();
-        if (timeout != 0 && !ansibleProcess.waitFor(timeout, TimeUnit.MINUTES)) {
+        if (!ansibleProcess.waitFor(timeout, TimeUnit.MINUTES)) {
             throw new Exception("Timeout occurred while canceling Ansible playbook.");
         }
         if (ansibleProcess.exitValue() != 0) {

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleRunnerClient.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleRunnerClient.java
@@ -62,7 +62,7 @@ public class AnsibleRunnerClient {
 
     public AnsibleReturnValue artifactHandler(UUID uuid, int timeout, BiConsumer<String, String> fn)
             throws Exception {
-        int iteration = 0;
+        int executionTime = 0;
         int processRet = 0;
         this.setReturnValue(uuid);
         // retrieve timeout from engine constants.
@@ -79,7 +79,6 @@ public class AnsibleRunnerClient {
                         "Play execution has reached timeout");
             }
             processRet = this.processEvents(uuid.toString(), fn);
-            iteration += POLL_INTERVAL / 1000;
             Thread.sleep(POLL_INTERVAL);
         }
         this.returnValue.setAnsibleReturnCode(AnsibleReturnCode.OK);

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleRunnerLogger.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleRunnerLogger.java
@@ -17,7 +17,7 @@ import com.fasterxml.jackson.databind.json.JsonMapper;
 
 public class AnsibleRunnerLogger {
 
-    private static Logger logger = LoggerFactory.getLogger(AnsibleRunnerHttpClient.class);
+    private static Logger logger = LoggerFactory.getLogger(AnsibleRunnerClient.class);
     private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss z");
     private static final String NEW_LINE = System.getProperty("line.separator");
     private static final ObjectMapper mapper = JsonMapper.builder().findAndAddModules().build();

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/RunnerJsonNode.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/RunnerJsonNode.java
@@ -63,6 +63,10 @@ public final class RunnerJsonNode {
         return node.get("data").get("play_uuid").textValue();
     }
 
+    public static String playCounter(JsonNode node) {
+        return node.get("counter").toString();
+    }
+
     /**
      * Return if status is notfound.
      */

--- a/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/common/utils/ansible/AnsibleRunnerHttpClientTest.java
+++ b/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/common/utils/ansible/AnsibleRunnerHttpClientTest.java
@@ -30,7 +30,7 @@ public class AnsibleRunnerHttpClientTest {
     HttpClient httpClient;
 
     @InjectMocks
-    AnsibleRunnerHttpClient client;
+    AnsibleRunnerClient client;
 
 
     @ParameterizedTest


### PR DESCRIPTION
Continuation of: https://github.com/oVirt/ovirt-engine/pull/237
Changes in ansible-runner exection:
- Rename `AnsibleRunnerHttpClient` to `AnsibleRunnerClient`
- From `AnsibleRunnerClient` removal of `synchronized executeLock`. We are no longer writing to one log file so we don't need to have a synchronized lock.
- Change `lastEvent` from `String` to `JsonNode` so we can gather data from it easier.
- Cahnge `lastEventID` to `counter` from `lastEvent`.
- Log start of the playbook to engine-start-output.log
- Log cancel of the playbook to engine-cancel-output.log