### PR TITLE
Update README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -60,6 +60,7 @@ Install the following system components:
 - ovirt-ansible-roles >= 1.2.0
 - ovirt-imageio-daemon >= 2.0.6
 - ovirt-engine-metrics (optional)
+- ovirt-provider-ovn (optional)
 - python3-ovirt-engine-sdk4 (optional)
 - ansible-lint / python3-ansible-lint (optional)
 - python3-flake8 / pyflakes (optional)
@@ -99,22 +100,6 @@ There are 2 programs which provide 'javac'.
 
 Enter to keep the current selection[+], or type selection number: 2
 
-```
-- Maven >= 3.5 is required, download and extract if not installed using
-distribution package management, and add to PATH.
-
-Fedora 30
-```console
-$ sudo dnf module install maven
-```
-
-- verify your `mvn` version:
-```console
-$ mvn -v | head -1
-Apache Maven 3.5.4 (Red Hat 3.5.4-5)
-
-```
-
 - export `JAVA_HOME` if `mvn` is not executing using java-11:
 ```console
 #put this in your ~/.bashrc
@@ -130,20 +115,8 @@ is to install following packages:
 - ovirt-engine-wildfly
 - ovirt-engine-wildfly-overlay
 
-Both packages can be installed from ovirt-master-snapshot-static repository:
-
-  [ovirt-master-snapshot-static]
-  name=Latest oVirt master additional nightly snapshot
-  baseurl=http://resources.ovirt.org/pub/ovirt-master-snapshot-static/rpm/@DIST@$releasever/
-  enabled=1
-  skip_if_unavailable=1
-  gpgcheck=0
-
-Please replace `@DIST@` with `fc` for Fedora or `el` for Centos/RHEL.
-
-Alternatively, repository list can be updated.
-
-- For CentOS Stream 8 use:
+Both packages can be installed from oVirt COPR CentOS repositories.
+Repository list can be updated using the following commands:
 +
   $ sudo dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-8
   $ sudo dnf install -y ovirt-release-master
@@ -154,46 +127,6 @@ https://copr.fedorainfracloud.org/coprs/ovirt/ovirt-master-snapshot/[copr master
 OVN/OVS is an optional dependency. If you want to use it, check the requirements in the
 ovirt-engine.spec.in file for a list of packages. Otherwise, you should reply 'No'
 when asked about it by engine-setup.
-
-For Fedora prerequisites installation, following commands can be applied:
-
-- Enable oVirt packages for Fedora
-+
-  $ sudo dnf copr enable -y nsoffer/ioprocess-preview
-  $ sudo dnf copr enable -y nsoffer/ovirt-imageio-preview
-
-- Install additional packages
-+
-  $ sudo dnf install -y $(cat automation/check-patch.packages)
-
-Install additional packages for Fedora:
-
-  $ sudo yum install -y \
-        ansible-core \
-        ansible-runner \
-        bind-utils \
-        libxml2-python \
-        m2crypto \
-        mailcap \
-        openssl \
-        ovirt-ansible-collection \
-        ovirt-engine-metrics \
-        ovirt-engine-wildfly \
-        ovirt-engine-wildfly-overlay \
-        ovirt-setup-lib \
-        python3-daemon \
-        python3-dateutil \
-        python3-jinja2 \
-        python-ovirt-engine-sdk4 \
-        unzip
-
-Optional packages for Fedora:
-
-  $ sudo yum install -y \
-        python3-docker-py \
-        python3-flake8 \
-        python3-isort \
-        python3-pycodestyle
 
 ==== System settings
 
@@ -235,7 +168,7 @@ better to have VM's starting allocation and maximum allocation set to the same v
 
 Initialize PostgreSQL configuration files:
 
-  $ sudo postgresql-setup --initdb --unit postgresql # fedora
+  $ sudo postgresql-setup --initdb --unit postgresql
 
 Configure PostgreSQL to accept user and password:
 

--- a/README.adoc
+++ b/README.adoc
@@ -11,23 +11,21 @@ Welcome to the oVirt Engine - Open Virtualization Manager source repository.
 
 Patches are welcome!
 
-Please submit patches to [gerrit.ovirt.org:ovirt-engine](https://gerrit.ovirt.org/#/admin/projects/ovirt-engine).
-If you are not familiar with the review process for Gerrit patches you can read about
-[Working with oVirt Gerrit](https://ovirt.org/develop/dev-process/working-with-gerrit.html)
-on the [oVirt](https://ovirt.org/) website.
-
-**NOTE**: We might not notice pull requests that you create on Github, because we only use Github for backups.
+Please submit patches to https://github.com/oVirt/ovirt-engine[github.com:ovirt-engine].
+If you are not familiar with the review process you can read about
+https://ovirt.org/develop/dev-process/working-with-github.html[Working with oVirt on GitHub]
+on the https://ovirt.org/[oVirt] website.
 
 
 === Found a bug or documentation issue?
 To submit a bug or suggest an enhancement for oVirt Engine please use
-[oVirt Bugzilla for ovirt-engine product](https://bugzilla.redhat.com/enter_bug.cgi?product=ovirt-engine).
+https://bugzilla.redhat.com/enter_bug.cgi?product=ovirt-engine[oVirt Bugzilla for ovirt-engine product].
 
 If you find a documentation issue on the oVirt website please navigate and click "Report an issue on GitHub" in the page footer.
 
 
 == Still need help?
-If you have any other questions, please join [oVirt Users forum / mailing list](https://lists.ovirt.org/admin/lists/users.ovirt.org/) and ask there.
+If you have any other questions, please join https://lists.ovirt.org/admin/lists/users.ovirt.org/[oVirt Users forum / mailing list] and ask there.
 
 
 
@@ -339,7 +337,7 @@ dist:: Create source tarball out of git repository.
 maven:: Force execution of maven.
 generated-files:: Create file from templates (.in files).
 +
-  When creating new templates, generated files will be automatically appears in .gitignore, updated .gitignore should be part of commiting new templates.
+  When creating new templates, generated files will be automatically appears in .gitignore, updated .gitignore should be part of committing new templates.
 
 
 ===== Build customization


### PR DESCRIPTION
- Fix links syntax from markdown to asciidoc and remove outdated links.
- Remove some deprecated Fedora 30 parts and update prerequisites section.


Signed-off-by: Albert Esteve <aesteve@redhat.com>