### PR TITLE
core: reverse snapshots list

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/snapshots/RemoveDiskSnapshotsCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/snapshots/RemoveDiskSnapshotsCommand.java
@@ -232,13 +232,16 @@ public class RemoveDiskSnapshotsCommand<T extends RemoveDiskSnapshotsParameters>
 
     private void sortImages() {
 
-        // Sort images from parent to leaf (active) - needed only once as the sorted list is
-        // being saved in the parameters.  The conditions to check vary between cold and live
-        // merge (and we can't yet run isLiveMerge()), so we just use an explicit flag.
         if (!getParameters().isImageIdsSorted()) {
             // Retrieve and sort the entire chain of images
             List<DiskImage> images = getAllImagesForDisk();
             ImagesHandler.sortImageList(images);
+
+            // We reverse the list here because since 4.4 we use block commit which merges the child into
+            // the snapshot we remove. To prevent a situation where the child was already removed we need
+            // reverse the list to ensure the children are removed first, so we don't attempt to remove them
+            // again.
+            Collections.reverse(images);
 
             // Get a sorted list of the selected images
             List<DiskImage> sortedImages =


### PR DESCRIPTION
Currently, when removing individual disk snapshots, they are grouped
by their respective disk_id and are removed together, in the order from
the parent to the child. For example:
A <- S2 <- S1

And we select disks from S1 and S2, S1 will be removed first and then
S2. However, since block commit was introduced, we only do forward
merges, meaning when removing S1, the child S2, will be the one removed
after its contents are merged into S1. So when the operation attempts to
merge S2, it will no longer exist.

This patch fixes the issue by reversing the order of images to start the
operation the other way around.

Bug-Url: https://bugzilla.redhat.com/2070451