### PR TITLE
packaging: setup: Clarify how to ignore the global maintenance check

### DIFF
--- a/packaging/setup/plugins/ovirt-engine-common/ovirt-engine/system/he.py
+++ b/packaging/setup/plugins/ovirt-engine-common/ovirt-engine/system/he.py
@@ -118,6 +118,11 @@ class Plugin(plugin.PluginBase):
                 'Maintenance" mode before running engine-setup, or the '
                 'hosted-engine HA agent might kill the machine, which '
                 'might corrupt your data.\n'
+                'If you want to enforce this tool to continue, skipping this '
+                'check, you can re-run it with this additional option:\n'
+                '--otopi-environment='
+                f'{osetupcons.ConfigEnv.CONTINUE_SETUP_ON_HE_VM}'
+                '=bool:True'
             ))
             raise RuntimeError(_(
                 'Hosted Engine setup detected, '


### PR DESCRIPTION
Import from gerrit: https://gerrit.ovirt.org/c/ovirt-engine/+/118403
Submitted by @didib 

```
We have an environment key allowing to skip the check for global
maintenance, but do not document it anywhere. Mention it in the error
message that this check outputs.

Change-Id: Ida4eb134fec4c29340e02ae2012839a3ca2af07e
Bug-Url: https://bugzilla.redhat.com/1700460
Signed-off-by: Yedidyah Bar David <didi@redhat.com>
```