### PR TITLE
Change resize and pin cpu pinning policy within VM metadata

### DIFF
--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/builder/vminfo/LibvirtVmXmlBuilder.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/builder/vminfo/LibvirtVmXmlBuilder.java
@@ -1040,7 +1040,9 @@ public class LibvirtVmXmlBuilder {
     private void writeCpuPinningPolicyMetadata() {
         CpuPinningPolicy cpuPinningPolicy = vm.getCpuPinningPolicy();
         // CpuPinningPolicy.NONE may happen when the engine generates CPU pinning based on the NUMA pinning.
-        if (vm.getVmPinning() != null && cpuPinningPolicy == CpuPinningPolicy.NONE) {
+        // VDSM doesn't recognize 'resize and pin numa' we need to switch it to 'manual'.
+        if (cpuPinningPolicy == CpuPinningPolicy.RESIZE_AND_PIN_NUMA ||
+                vm.getVmPinning() != null && cpuPinningPolicy == CpuPinningPolicy.NONE) {
             cpuPinningPolicy = CpuPinningPolicy.MANUAL;
         }
         writer.writeElement(OVIRT_VM_URI, "cpuPolicy", cpuPinningPolicy.name().toLowerCase());


### PR DESCRIPTION
VDSM does not recognizing `resize and pin NUMA` policy. To let VDSM act
as expected the policy it needs is `manual`, as we have CPU pinning in
this policy and they are part of the shared pool.

Change-Id: Ic742086b8626009e177b0f22c77e268fd501d3c1
Bug-Url: https://bugzilla.redhat.com/2074582
Signed-off-by: Liran Rotenberg <lrotenbe@redhat.com>