### PR TITLE
Enable builds on ovirt-engine-4.5.0.z branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,9 @@
 name: build
 on:
   push:
-    branches: [master]
+    branches: [master, ovirt-engine-4.5.0.z]
   pull_request:
-    branches: [master]
+    branches: [master, ovirt-engine-4.5.0.z]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Build won't start without specifying a stable branch name in `.github/workflows/build.yml` in the relevant stable branch content

Signed-off-by: Martin Perina <mperina@redhat.com>
