### PR TITLE
core: always update volume size when creating a new image

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/HibernateVmCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/HibernateVmCommand.java
@@ -27,6 +27,7 @@ import org.ovirt.engine.core.common.asynctasks.EntityInfo;
 import org.ovirt.engine.core.common.businessentities.Snapshot.SnapshotType;
 import org.ovirt.engine.core.common.businessentities.StorageDomain;
 import org.ovirt.engine.core.common.businessentities.VMStatus;
+import org.ovirt.engine.core.common.businessentities.storage.DiskContentType;
 import org.ovirt.engine.core.common.businessentities.storage.DiskImage;
 import org.ovirt.engine.core.common.errors.EngineException;
 import org.ovirt.engine.core.common.errors.EngineMessage;
@@ -279,7 +280,7 @@ public class HibernateVmCommand<T extends VmOperationParameterBase> extends VmOp
     private DiskImage getMemoryDumpDisk(List<ActionReturnValue> returnValues) {
         for (ActionReturnValue returnValue : returnValues) {
             DiskImage disk = returnValue.getActionReturnValue();
-            if (disk.getSize() != MemoryUtils.METADATA_SIZE_IN_BYTES) {
+            if (disk.getContentType() == DiskContentType.MEMORY_DUMP_VOLUME) {
                 return disk;
             }
         }
@@ -290,7 +291,7 @@ public class HibernateVmCommand<T extends VmOperationParameterBase> extends VmOp
     private DiskImage getMemoryMetadataDisk(List<ActionReturnValue> returnValues) {
         for (ActionReturnValue returnValue : returnValues) {
             DiskImage disk = returnValue.getActionReturnValue();
-            if (disk.getSize() == MemoryUtils.METADATA_SIZE_IN_BYTES) {
+            if (disk.getContentType() == DiskContentType.MEMORY_METADATA_VOLUME) {
                 return disk;
             }
         }

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/BaseImagesCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/BaseImagesCommand.java
@@ -384,6 +384,9 @@ public abstract class BaseImagesCommand<T extends ImagesActionsParametersBase> e
                                 newStorageDomainID,
                                 getDestinationDiskImage());
                     }
+
+                    // Update image's size if it's changed
+                    getDestinationDiskImage().setSize(newImageIRS.getSize());
                 }
             } catch (EngineException e) {
                 // Logging only


### PR DESCRIPTION
Vdsm often aligns the size of the volume when creating, and the volume
will end up having a different size in the engine than what is on the
storage. This is already handled when a new disk is created but not when
a new snapshot is created.

Since there is already a getVolumeInfo request at the end of snapshot
creation, we can use this opportunity to update the size of the volume
as well.

Bug-Url: https://bugzilla.redhat.com/1852308