### PR TITLE
restapi: restore suggestedParent

### DIFF
--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendVmBackupsResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendVmBackupsResource.java
@@ -58,7 +58,7 @@ public class BackendVmBackupsResource
                 backup.getSnapshot().setVm(vm);
             }
 
-            collection.getBackups().add(addLinks(backup));
+            collection.getBackups().add(addLinks(backup, Vm.class));
         }
         return collection;
     }


### PR DESCRIPTION
Restore the suggestedParent Vm.class in:
```java
collection.getBackups().add(addLinks(map(entity), Vm.class));
```

Previously removed in https://github.com/oVirt/ovirt-engine/pull/174

Bug-Url: https://bugzilla.redhat.com/2075435