### PR TITLE
Fix wrong dedicated migration assignments

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/MigrateVmCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/MigrateVmCommand.java
@@ -430,7 +430,7 @@ public class MigrateVmCommand<T extends MigrateVmParameters> extends RunVmComman
             maxIncomingMigrations = maxOutgoingMigrations = effectiveMigrationPolicy.getMaxMigrations();
         }
         if (getVm().getCpuPinningPolicy() == CpuPinningPolicy.DEDICATED) {
-            cpuSets = CpuPinningHelper.getAllPinnedPCpus(getDedicatedCpuPinning(getDestinationVdsManager())).stream().sorted()
+            cpuSets = CpuPinningHelper.getAllPinnedPCpus(getDedicatedCpuPinning(getDestinationVdsManager())).stream()
                     .map(Object::toString).collect(Collectors.toList());
             String numaPinningString = vmHandler.createNumaPinningForDedicated(getVm(), getDestinationVdsId());
             numaNodeSets = NumaPinningHelper.parseNumaSets(numaPinningString);


### PR DESCRIPTION
When invoking a migration the cpusets is sent to VDSM as a list. The index of each list represents the virtual CPU and the value is the physical CPU we are taking. Sorting the values is wrong, as it results a wrong mapping, causing split cores and split sockets.

Bug-Url: https://bugzilla.redhat.com/2075037