### PR TITLE
core: do not process capabilities when we don't have any

### DIFF
--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/VdsManager.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/VdsManager.java
@@ -637,20 +637,18 @@ public class VdsManager {
         try {
             invokeGetHardwareInfo(vds, caps);
             processRefreshCapabilitiesResponse(new AtomicBoolean(), vds, vds.clone(), caps);
+
+            updateDynamicData(vds.getDynamicData());
+            updateNumaData(vds);
+
+            // Update VDS after testing special hardware capabilities
+            monitoringStrategy.processHardwareCapabilities(vds);
+
+            // Always check VdsVersion
+            resourceManager.getEventListener().handleVdsVersion(vds.getId());
         } catch (Throwable t) {
             logRefreshCapabilitiesFailure(t);
             throw t;
-        } finally {
-            if (vds != null) {
-                updateDynamicData(vds.getDynamicData());
-                updateNumaData(vds);
-
-                // Update VDS after testing special hardware capabilities
-                monitoringStrategy.processHardwareCapabilities(vds);
-
-                // Always check VdsVersion
-                resourceManager.getEventListener().handleVdsVersion(vds.getId());
-            }
         }
     }
 


### PR DESCRIPTION
When RefreshCapabilities call fails there' sno point in processing
results. Let it raise.
