### PR TITLE
Improve handling of the response of get capabilities

### DIFF
--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/monitoring/HostMonitoring.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/monitoring/HostMonitoring.java
@@ -202,7 +202,9 @@ public class HostMonitoring implements HostMonitoringInterface {
             try {
                 final AtomicBoolean processHardwareNeededAtomic = new AtomicBoolean();
                 VDSReturnValue caps = (VDSReturnValue) response.get("result");
-                vdsManager.invokeGetHardwareInfo(vds, caps);
+                if (caps.getSucceeded()) {
+                    vdsManager.getHardwareInfo(vds);
+                }
                 VDSStatus refreshReturnStatus = vdsManager.processRefreshCapabilitiesResponse(processHardwareNeededAtomic,
                         vds,
                         oldVds,
@@ -804,7 +806,9 @@ public class HostMonitoring implements HostMonitoringInterface {
             try {
                 final AtomicBoolean processHardwareCapsNeededTemp = new AtomicBoolean();
                 VDSReturnValue caps = (VDSReturnValue) response.get("result");
-                vdsManager.invokeGetHardwareInfo(vds, caps);
+                if (caps.getSucceeded()) {
+                    vdsManager.getHardwareInfo(vds);
+                }
                 vdsManager.processRefreshCapabilitiesResponse(processHardwareCapsNeededTemp,
                         vds,
                         oldVds,


### PR DESCRIPTION
This PR improves handleRefreshCapabilitiesResponse:
1. It first tries to process the response of get-capabilities, if that fails - it immediately logs that and returns an error
2. Only later it tries to get hardware data - if we manage to get a valid response from get-capabilities, it will most likely succeed with that but if not - we log that and continue because we hold the more important data already
3. The code that updates the database and notifies other components that we managed to refresh the host capabilities no longer runs within the same if-block that generates an error related to get-capabilities upon failure (but an appropriate exception would bubble up)