### PR TITLE
core: handle missing allocation policy/format when converting

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/ConvertDiskCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/ConvertDiskCommand.java
@@ -374,10 +374,18 @@ public class ConvertDiskCommand<T extends ConvertDiskCommandParameters> extends 
     @Override
     public Map<String, String> getJobMessageProperties() {
         if (jobProperties == null) {
+            String allocationPolicy = getParameters().getPreallocation() != null ?
+                    getParameters().getPreallocation().toString() :
+                    getDiskImage().getVolumeType().toString();
+
+            String diskFormat = getParameters().getVolumeFormat() != null ?
+                    getParameters().getVolumeFormat().toString() :
+                    getDiskImage().getVolumeFormat().toString();
+
             jobProperties = super.getJobMessageProperties();
             jobProperties.put("diskname", getDiskImage().getName());
-            jobProperties.put("allocationpolicy", getParameters().getPreallocation().toString());
-            jobProperties.put("diskformat", getParameters().getVolumeFormat().toString());
+            jobProperties.put("allocationpolicy", allocationPolicy);
+            jobProperties.put("diskformat", diskFormat);
         }
 
         return super.getJobMessageProperties();


### PR DESCRIPTION
If allocation policy or format were not passed to the disk conversion endpoint it will fail to setup monitoring because of NPE.

This patch uses the existing allocation policy or format when it's missing to generate the message.