### PR TITLE
restapi: fix hrefs in single GET disksnapshot request

### DIFF
--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendDiskSnapshotResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendDiskSnapshotResource.java
@@ -30,9 +30,11 @@ public class BackendDiskSnapshotResource
                 new IdQueryParameters(guid), Disk.class);
         diskSnapshot.setDisk(new Disk());
         diskSnapshot.getDisk().setId(diskId.toString());
+        diskSnapshot.getDisk().setHref(backendDiskSnapshotsResource.buildParentHref(diskId.toString(), false));
         diskSnapshot.setHref(backendDiskSnapshotsResource.buildHref(diskId.toString(), diskSnapshot.getId().toString()));
         if (diskSnapshot.getParent() != null) {
-            diskSnapshot.getParent().setHref(backendDiskSnapshotsResource.buildParentHref(diskId.toString(), true));
+            diskSnapshot.getParent().setHref(backendDiskSnapshotsResource.buildHref(diskId.toString(),
+                    diskSnapshot.getParent().getId()));
         }
         return diskSnapshot;
     }


### PR DESCRIPTION
Fixing GET api/disks/{diskid}/disksnapshots/{snapshotid}:
Correct href for <parent> and <disk> elements.
1. `<disk>` element was returned without href attribute
2. `<parent>` element had an incorrect href - buildParentHref() was
used, although the element is not related to the parent entity
resource, but rather represents the parent image of the snapshot.