### PR TITLE
Fix query in single GET disksnapshot request

### DIFF
--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendDiskSnapshotResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendDiskSnapshotResource.java
@@ -7,7 +7,7 @@ import org.ovirt.engine.api.model.DiskSnapshot;
 import org.ovirt.engine.api.resource.DiskSnapshotResource;
 import org.ovirt.engine.core.common.action.ActionType;
 import org.ovirt.engine.core.common.action.RemoveDiskSnapshotsParameters;
-import org.ovirt.engine.core.common.queries.DiskSnapshotsQueryParameters;
+import org.ovirt.engine.core.common.queries.IdQueryParameters;
 import org.ovirt.engine.core.common.queries.QueryType;
 import org.ovirt.engine.core.compat.Guid;
 
@@ -26,10 +26,8 @@ public class BackendDiskSnapshotResource
 
     @Override
     public DiskSnapshot get() {
-        // TODO: GetAllDiskSnapshots is an incorrect query to use here, it fetches all the disk snapshots, so the one
-        // returned here is not necessarily the one requested
-        DiskSnapshot diskSnapshot = performGet(QueryType.GetAllDiskSnapshots,
-                new DiskSnapshotsQueryParameters(diskId, true, false), Disk.class);
+        DiskSnapshot diskSnapshot = performGet(QueryType.GetDiskSnapshotByImageId,
+                new IdQueryParameters(guid), Disk.class);
         diskSnapshot.setDisk(new Disk());
         diskSnapshot.getDisk().setId(diskId.toString());
         diskSnapshot.setHref(backendDiskSnapshotsResource.buildHref(diskId.toString(), diskSnapshot.getId().toString()));


### PR DESCRIPTION
Fixing GET api/disks/{diskid}/disksnapshots/{snapshotid}:
Return correct snapshot, when more than one snapshot existed
for the disk. Incorrect query (GetAllDiskSnapshots) was used to fetch
a single snapshot. Now using GetDiskSnapshotByImageId instead.

Bug-Url: https://bugzilla.redhat.com/2013696