### PR TITLE
engine_setup: cleanup after ARS removal

### DIFF
--- a/packaging/setup/ovirt_engine_setup/engine/constants.py
+++ b/packaging/setup/ovirt_engine_setup/engine/constants.py
@@ -234,22 +234,6 @@ class FileLocations(object):
         'nssdb',
     )
 
-    ANSIBLE_RUNNER_SERVICE_CONF = os.path.join(
-        SYSCONFDIR,
-        'ansible-runner-service',
-        'config.yaml',
-    )
-
-    ANSIBLE_RUNNER_SERVICE_PROJECT = os.path.join(
-        OVIRT_ENGINE_DATADIR,
-        'ansible-runner-service-project',
-    )
-
-    ANSIBLE_RUNNER_PROJECT = os.path.join(
-        OVIRT_ENGINE_LOCALSTATEDIR,
-        'ansible-runner-project',
-    )
-
     DIR_HTTPD = os.path.join(
         SYSCONFDIR,
         'httpd',
@@ -264,12 +248,6 @@ class FileLocations(object):
         DIR_WWW,
         'runnner',
         'runner.wsgi',
-    )
-
-    HTTPD_CONF_ANSIBLE_RUNNER_SERVICE = os.path.join(
-        DIR_HTTPD,
-        'conf.d',
-        'zz-ansible-runner-service.conf',
     )
 
     HTTPD_CONF_OVIRT_ENGINE = os.path.join(

--- a/packaging/setup/ovirt_engine_setup/engine/constants.py
+++ b/packaging/setup/ovirt_engine_setup/engine/constants.py
@@ -244,10 +244,10 @@ class FileLocations(object):
         'www',
     )
 
-    HTTPD_RUNNER_WSGI_SCRIPT = os.path.join(
-        DIR_WWW,
-        'runnner',
-        'runner.wsgi',
+    HTTPD_CONF_ANSIBLE_RUNNER_SERVICE = os.path.join(
+        DIR_HTTPD,
+        'conf.d',
+        'zz-ansible-runner-service.conf',
     )
 
     HTTPD_CONF_OVIRT_ENGINE = os.path.join(
@@ -344,8 +344,6 @@ class Defaults(object):
     DEFAULT_CONFIG_STORAGE_IS_LOCAL = False
 
     DEFAULT_CLEAR_TASKS_WAIT_PERIOD = 20
-
-    DEFAULT_ANSIBLE_RUNNER_SERVICE_PORT = '50001'
 
     DEFAULT_DB_HOST = 'localhost'
     DEFAULT_DB_PORT = 5432

--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/apache/__init__.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/apache/__init__.py
@@ -12,16 +12,16 @@
 
 from otopi import util
 
+from . import ars_cleanup
 from . import engine
 from . import root
-from . import runner
 
 
 @util.export
 def createPlugins(context):
     engine.Plugin(context=context)
     root.Plugin(context=context)
-    runner.Plugin(context=context)
+    ars_cleanup.Plugin(context=context)
 
 
 # vim: expandtab tabstop=4 shiftwidth=4

--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/apache/__init__.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/apache/__init__.py
@@ -14,12 +14,14 @@ from otopi import util
 
 from . import engine
 from . import root
+from . import runner
 
 
 @util.export
 def createPlugins(context):
     engine.Plugin(context=context)
     root.Plugin(context=context)
+    runner.Plugin(context=context)
 
 
 # vim: expandtab tabstop=4 shiftwidth=4

--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/apache/ars_cleanup.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/apache/ars_cleanup.py
@@ -7,7 +7,7 @@
 #
 
 
-"""Apache ansible-runner plugin."""
+"""Apache ansible-runner-service cleanup plugin."""
 
 
 import gettext
@@ -29,7 +29,7 @@ def _(m):
 
 @util.export
 class Plugin(plugin.PluginBase):
-    """Cleanup of the ansible-runner plugin."""
+    """Apache ansible-runner-service cleanup plugin."""
 
     def __init__(self, context):
         super(Plugin, self).__init__(context=context)

--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/apache/runner.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/apache/runner.py
@@ -1,0 +1,86 @@
+#
+# ovirt-engine-setup -- ovirt engine setup
+#
+# Copyright oVirt Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+
+
+"""Apache ansible-runner plugin."""
+
+
+import gettext
+import os
+
+from otopi import constants as otopicons
+from otopi import plugin
+from otopi import util
+
+from ovirt_engine_setup import constants as osetupcons
+from ovirt_engine_setup.engine import constants as oenginecons
+from ovirt_engine_setup.engine_common import constants as oengcommcons
+from ovirt_engine_setup.transactions import RemoveFileTransaction
+
+
+def _(m):
+    return gettext.dgettext(message=m, domain='ovirt-engine-setup')
+
+
+@util.export
+class Plugin(plugin.PluginBase):
+    """Cleanup of the ansible-runner plugin."""
+
+    def __init__(self, context):
+        super(Plugin, self).__init__(context=context)
+
+    @plugin.event(
+        stage=plugin.Stages.STAGE_MISC,
+        condition=lambda self: self.environment[
+            oenginecons.CoreEnv.ENABLE
+        ] and not self.environment[
+            osetupcons.CoreEnv.DEVELOPER_MODE
+        ] and os.path.exists(
+            oenginecons.FileLocations.HTTPD_CONF_ANSIBLE_RUNNER_SERVICE
+        ),
+    )
+    def _misc(self):
+        if not self._can_remove(
+            oenginecons.FileLocations.HTTPD_CONF_ANSIBLE_RUNNER_SERVICE
+        ):
+            return
+
+        self.environment[oengcommcons.ApacheEnv.NEED_RESTART] = True
+
+        self.environment[otopicons.CoreEnv.MAIN_TRANSACTION].append(
+            RemoveFileTransaction(
+                oenginecons.FileLocations.HTTPD_CONF_ANSIBLE_RUNNER_SERVICE
+            )
+        )
+
+    def _can_remove(self, installed_file):
+        """
+        Return True if installed_file can be removed safely. Return False if
+        the file was not installed by previous setup, or was changed.
+        """
+        uninstall_info = self.environment[
+            osetupcons.CoreEnv.UNINSTALL_FILES_INFO
+        ].get(installed_file)
+
+        # Did we install this file?
+        if not uninstall_info:
+            return False
+
+        # Did it change since we installed it?
+        if uninstall_info.get("changed"):
+            self.logger.warn(
+                _(
+                    "Cannot remove {}, file was changed"
+                ).format(installed_file)
+            )
+            return False
+
+        return True
+
+
+# vim: expandtab tabstop=4 shiftwidth=4


### PR DESCRIPTION
Backport of https://github.com/oVirt/ovirt-engine/pull/257 which is required for successfull upgrade from 4.4.z.
Without this backport engine upgrade fails due to existing ansible-runner-service configuration, but missing ansible-runner-service packages which is obsoleted by ovirt-engine >= 4.5.0.
