### PR TITLE
Map console disconnect action delay in VmMapper

### DIFF
--- a/backend/manager/modules/restapi/types/src/main/java/org/ovirt/engine/api/restapi/types/VmMapper.java
+++ b/backend/manager/modules/restapi/types/src/main/java/org/ovirt/engine/api/restapi/types/VmMapper.java
@@ -131,6 +131,7 @@ public class VmMapper extends VmBaseMapper {
         staticVm.setBiosType(entity.getBiosType());
         staticVm.setCustomCpuName(entity.getCustomCpuName());
         staticVm.setConsoleDisconnectAction(entity.getConsoleDisconnectAction());
+        staticVm.setConsoleDisconnectActionDelay(entity.getConsoleDisconnectActionDelay());
         staticVm.setSmallIconId(entity.getSmallIconId());
         staticVm.setLargeIconId(entity.getLargeIconId());
         staticVm.setQuotaId(entity.getQuotaId());


### PR DESCRIPTION
It was missing and therefore this setting wasn't copied from templates to vm pools.

Bug-Url: https://bugzilla.redhat.com/2076054