### PR TITLE
Fix import template from ova

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ImportVmTemplateCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ImportVmTemplateCommand.java
@@ -5,7 +5,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import javax.inject.Inject;
 
@@ -154,18 +153,7 @@ public class ImportVmTemplateCommand<T extends ImportVmTemplateParameters> exten
             if (!getParameters().isImagesExistOnTargetStorageDomain()) {
                 updateDiskSizeByQcowImageInfo(image);
             } else {
-                Set<Guid> storageDomains = getParameters().getImageToAvailableStorageDomains().get(image.getImageId());
-                Guid sdToUse;
-
-                // Try to use the target SD, otherwise fallback to one of the available SDs
-                // for the image
-                if (storageDomains.contains(getStorageDomainId())) {
-                    sdToUse = getStorageDomainId();
-                } else {
-                    sdToUse = storageDomains.stream().findFirst().get();
-                }
-
-                updateDiskSizeByQcowImageInfo(image, sdToUse);
+                updateDiskSizeByQcowImageInfo(image, image.getStorageIds().get(0));
             }
 
             if (getParameters().isImportAsNewEntity()) {

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ImportVmTemplateCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ImportVmTemplateCommand.java
@@ -151,7 +151,7 @@ public class ImportVmTemplateCommand<T extends ImportVmTemplateParameters> exten
             // If we import from a Storage Domain, we'll need to use the image's Storage
             // Domain ID and not the target domain's.
             if (!getParameters().isImagesExistOnTargetStorageDomain()) {
-                updateDiskSizeByQcowImageInfo(image);
+                updateDiskSizeByQcowImageInfo(image, getParameters().getSourceDomainId());
             } else {
                 updateDiskSizeByQcowImageInfo(image, image.getStorageIds().get(0));
             }
@@ -266,10 +266,6 @@ public class ImportVmTemplateCommand<T extends ImportVmTemplateParameters> exten
 
             getCompensationContext().snapshotNewEntity(diskDynamic);
         }
-    }
-
-    private void updateDiskSizeByQcowImageInfo(DiskImage diskImage) {
-        updateDiskSizeByQcowImageInfo(diskImage, getParameters().getSourceDomainId());
     }
 
     protected void updateDiskSizeByQcowImageInfo(DiskImage diskImage, Guid storageId) {

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ImportVmTemplateFromConfigurationCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ImportVmTemplateFromConfigurationCommand.java
@@ -641,6 +641,18 @@ public class ImportVmTemplateFromConfigurationCommand<T extends ImportVmTemplate
 
     @Override
     protected void updateDiskSizeByQcowImageInfo(DiskImage diskImage, Guid storageId) {
+        Set<Guid> storageDomains = getParameters().getImageToAvailableStorageDomains().get(diskImage.getImageId());
+
+        if (storageDomains != null && !storageDomains.isEmpty()) {
+            // Try to use the target SD, otherwise fallback to one of the available SDs
+            // for the image
+            if (storageDomains.contains(getStorageDomainId())) {
+                storageId = getStorageDomainId();
+            } else {
+                storageId = storageDomains.stream().findFirst().get();
+            }
+        }
+
         if (!Guid.isNullOrEmpty(storageId)) {
             super.updateDiskSizeByQcowImageInfo(diskImage, storageId);
             return;

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/ImportVmTemplateFromConfParameters.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/ImportVmTemplateFromConfParameters.java
@@ -18,6 +18,7 @@ public class ImportVmTemplateFromConfParameters extends ImportVmTemplateParamete
     private Map<String, String> clusterMap;
     private Map<String, String> roleMap;
     private Map<String, String> domainMap;
+    private Map<Guid, Set<Guid>> imageToAvailableStorageDomains = new HashMap<>();
 
     private Set<DbUser> dbUsers;
     private Map<String, Set<String>> userToRoles  = new HashMap<>();
@@ -117,5 +118,13 @@ public class ImportVmTemplateFromConfParameters extends ImportVmTemplateParamete
     @Override
     public void setExternalVnicProfileMappings(Collection<ExternalVnicProfileMapping> externalVnicProfileMappings) {
         this.externalVnicProfileMappings = Objects.requireNonNull(externalVnicProfileMappings);
+    }
+
+    public Map<Guid, Set<Guid>> getImageToAvailableStorageDomains() {
+        return imageToAvailableStorageDomains;
+    }
+
+    public void setImageToAvailableStorageDomains(Map<Guid, Set<Guid>> imageToAvailableStorageDomains) {
+        this.imageToAvailableStorageDomains = imageToAvailableStorageDomains;
     }
 }

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/ImportVmTemplateParameters.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/ImportVmTemplateParameters.java
@@ -1,10 +1,8 @@
 package org.ovirt.engine.core.common.action;
 
 import java.io.Serializable;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import javax.validation.Valid;
 
@@ -87,16 +85,6 @@ public class ImportVmTemplateParameters extends MoveOrCopyParameters implements 
 
     public void setDiskTemplateMap(Map<Guid, DiskImage> diskTemplateMap) {
         this.diskTemplateMap = diskTemplateMap;
-    }
-
-    private Map<Guid, Set<Guid>> imageToAvailableStorageDomains = new HashMap<>();
-
-    public Map<Guid, Set<Guid>> getImageToAvailableStorageDomains() {
-        return imageToAvailableStorageDomains;
-    }
-
-    public void setImageToAvailableStorageDomains(Map<Guid, Set<Guid>> imageToAvailableStorageDomains) {
-        this.imageToAvailableStorageDomains = imageToAvailableStorageDomains;
     }
 
     public ImportVmTemplateParameters() {


### PR DESCRIPTION
When importing a template from OVA we don't go through ImportVmTemplateFromConfiguration and therefore getImageToAvailableStorageDomains() returns an empty map and later we fail with NPE.

This patch changes the fix for https://bugzilla.redhat.com/2043124 to be specific for ImportVmTemplateFromConfiguration and so other import-template flows would not face this issue.

Bug-Url: https://bugzilla.redhat.com/2074916