### PR TITLE
Handle NULL in default/actual values in vdc_options

### DIFF
--- a/packaging/dbscripts/upgrade/04_05_0100_fix_04_04_0050_set_to_not_null.sql
+++ b/packaging/dbscripts/upgrade/04_05_0100_fix_04_04_0050_set_to_not_null.sql
@@ -1,2 +1,21 @@
+-- Make sure that forgotten options from ancient releases have default value
+UPDATE vdc_options
+  SET default_value = option_value
+  WHERE
+    default_value IS NULL
+    AND option_value IS NOT NULL;
+
+-- If there are still some crappy options, let's set default value to empty string
+UPDATE vdc_options
+  SET default_value = ''
+  WHERE
+    default_value IS NULL
+    AND option_value IS NULL;
+
+-- We shouldn't have any options with NULL values by now, but let's make sure
+UPDATE vdc_options
+  SET option_value = ''
+  WHERE option_value IS NULL;
+
 SELECT fn_db_change_column_null('vdc_options', 'default_value', false);
 SELECT fn_db_change_column_null('vdc_options', 'option_value', false);


### PR DESCRIPTION
We have discovered that some users still have some ancient options
present in vdc_options (even though they should be removed now), which
contains NULL in default/actual values.
We have fixed fn_db_change_column_type to properly set NULL/NOT NULL
constraints in https://gerrit.ovirt.org/117448 , but we missed above
that ancient options mentioned above still could exist, so we need to
fix those NULL default/actual values before setiing NOT NULL constrain.

Bug-Url: https://bugzilla.redhat.com/2077387
Signed-off-by: Martin Perina <mperina@redhat.com>
