### PR TITLE
Live Storage Migration - correctly calculate image initial size

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/CloneImageGroupVolumesStructureCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/CloneImageGroupVolumesStructureCommand.java
@@ -184,6 +184,27 @@ public class CloneImageGroupVolumesStructureCommand<T extends CloneImageGroupVol
         runInternalActionWithTasksContext(ActionType.CreateVolumeContainer, parameters);
     }
 
+    /**
+     * Method's calculation logic is described by the following table.
+     *
+     * type             src type        dst type        vol format          initial size
+     * =======================================================================================
+     * active           file            file            qcow2               null
+     * active           block           file            qcow2               null
+     * active           file            block           qcow2               3 chunks
+     * active           block           block           qcow2               3 chunks
+     * ---------------------------------------------------------------------------------------
+     * internal         file            file            raw                 null
+     * internal         file            file            qcow2               null
+     * internal         file            block           raw                 null
+     * internal         file            block           qcow2               measure
+     * internal         block           block           raw                 null
+     * internal         block           block           qcow2               measure
+     *
+     * Notes:
+     *  1. "chunks" stands for {@link org.ovirt.engine.core.common.config.ConfigValues#VolumeUtilizationChunkInMB}
+     *  2. "measure" stands for {@link ActionType#MeasureVolume} command's return value.
+     */
     private Long determineImageInitialSize(Image sourceImage,
             VolumeFormat destFormat,
             Guid storagePoolId,

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/FeatureSupported.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/FeatureSupported.java
@@ -447,4 +447,14 @@ public class FeatureSupported {
     public static boolean isDedicatePolicySupported(Version version) {
         return supportedInConfig(ConfigValues.IsDedicatedSupported, version);
     }
+
+    /**
+     * Check if replicate extend (allocating snapshot with initial size during Live Storage Migration) is supported.
+     *
+     * @param version Compatibility version to check for.
+     * @return true if replicate extend is supported during Live Storage Migration
+     */
+    public static boolean isReplicateExtendSupported(Version version) {
+        return Version.v4_7.lessOrEquals(version);
+    }
 }

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/CloneImageGroupVolumesStructureCommandParameters.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/CloneImageGroupVolumesStructureCommandParameters.java
@@ -13,6 +13,7 @@ public class CloneImageGroupVolumesStructureCommandParameters extends ImagesActi
     private Guid destImageGroupId;
     private Guid destImageId;
     private List<DiskImage> destImages = new ArrayList<>();
+    private boolean isLiveMigration = false;
 
     public CloneImageGroupVolumesStructureCommandParameters() {
     }
@@ -77,5 +78,13 @@ public class CloneImageGroupVolumesStructureCommandParameters extends ImagesActi
 
     public void setDestImages(List<DiskImage> destImages) {
         this.destImages = destImages;
+    }
+
+    public boolean isLiveMigration() {
+        return isLiveMigration;
+    }
+
+    public void setLiveMigration(boolean isLiveMigration) {
+        this.isLiveMigration = isLiveMigration;
     }
 }

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/vdscommands/VmReplicateDiskParameters.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/vdscommands/VmReplicateDiskParameters.java
@@ -5,6 +5,14 @@ import org.ovirt.engine.core.compat.Guid;
 
 public class VmReplicateDiskParameters extends VdsAndVmIDVDSParametersBase {
 
+    private Guid storagePoolId;
+    private Guid srcStorageDomainId;
+    private Guid targetStorageDomainId;
+    private Guid imageGroupId;
+    private Guid imageId;
+    private String diskType;
+    private boolean needExtend = true;
+
     public VmReplicateDiskParameters(Guid vdsId,
             Guid vmId,
             Guid storagePoolId,
@@ -73,12 +81,13 @@ public class VmReplicateDiskParameters extends VdsAndVmIDVDSParametersBase {
         this.diskType = diskType;
     }
 
-    private Guid storagePoolId;
-    private Guid srcStorageDomainId;
-    private Guid targetStorageDomainId;
-    private Guid imageGroupId;
-    private Guid imageId;
-    private String diskType;
+    public boolean isNeedExtend() {
+        return needExtend;
+    }
+
+    public void setNeedExtend(boolean needExtend) {
+        this.needExtend = needExtend;
+    }
 
     @Override
     protected ToStringBuilder appendAttributes(ToStringBuilder tsb) {
@@ -87,7 +96,9 @@ public class VmReplicateDiskParameters extends VdsAndVmIDVDSParametersBase {
                 .append("srcStorageDomainId", getSrcStorageDomainId())
                 .append("targetStorageDomainId", getTargetStorageDomainId())
                 .append("imageGroupId", getImageGroupId())
-                .append("imageId", getImageId());
+                .append("imageId", getImageId())
+                .append("diskType", getDiskType())
+                .append("needExtend", isNeedExtend());
     }
 
 }

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/jsonrpc/JsonRpcVdsServer.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/jsonrpc/JsonRpcVdsServer.java
@@ -1426,26 +1426,30 @@ public class JsonRpcVdsServer implements IVdsServer {
         return new GlusterServersListReturn(response);
     }
 
-    @SuppressWarnings("rawtypes")
     @Override
-    public StatusOnlyReturn diskReplicateStart(String vmUUID, Map srcDisk, Map dstDisk) {
+    public StatusOnlyReturn diskReplicateStart(String vmUUID,
+            Map<String, Object> srcDisk,
+            Map<String, Object> dstDisk,
+            boolean needExtend) {
         JsonRpcRequest request =
                 new RequestBuilder("VM.diskReplicateStart").withParameter("vmID", vmUUID)
                         .withParameter("srcDisk", srcDisk)
                         .withParameter("dstDisk", dstDisk)
+                        .withParameter("needExtend", needExtend)
                         .build();
         Map<String, Object> response = new FutureMap(this.client, request);
         return new StatusOnlyReturn(response);
     }
 
-    @SuppressWarnings("rawtypes")
     @Override
-    public StatusOnlyReturn diskReplicateFinish(String vmUUID, Map srcDisk, Map dstDisk) {
-        JsonRpcRequest request =
-                new RequestBuilder("VM.diskReplicateFinish").withParameter("vmID", vmUUID)
-                        .withParameter("srcDisk", srcDisk)
-                        .withParameter("dstDisk", dstDisk)
-                        .build();
+    public StatusOnlyReturn diskReplicateFinish(String vmUUID,
+            Map<String, Object> srcDisk,
+            Map<String, Object> dstDisk) {
+        JsonRpcRequest request = new RequestBuilder("VM.diskReplicateFinish")
+                .withParameter("vmID", vmUUID)
+                .withParameter("srcDisk", srcDisk)
+                .withParameter("dstDisk", dstDisk)
+                .build();
         Map<String, Object> response = new FutureMap(this.client, request);
         return new StatusOnlyReturn(response);
     }

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/IVdsServer.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/IVdsServer.java
@@ -326,9 +326,14 @@ public interface IVdsServer {
 
     GlusterServersListReturn glusterServersList();
 
-    StatusOnlyReturn diskReplicateStart(String vmUUID, Map srcDisk, Map dstDisk);
+    StatusOnlyReturn diskReplicateStart(String vmUUID,
+            Map<String, Object> srcDisk,
+            Map<String, Object> dstDisk,
+            boolean needExtend);
 
-    StatusOnlyReturn diskReplicateFinish(String vmUUID, Map srcDisk, Map dstDisk);
+    StatusOnlyReturn diskReplicateFinish(String vmUUID,
+            Map<String, Object> srcDisk,
+            Map<String, Object> dstDisk);
 
     StatusOnlyReturn glusterVolumeProfileStart(String volumeName);
 

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/NullVdsServer.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/NullVdsServer.java
@@ -569,11 +569,16 @@ public class NullVdsServer implements IVdsServer {
         return null;
     }
 
-    @Override public StatusOnlyReturn diskReplicateStart(String vmUUID, Map srcDisk, Map dstDisk) {
+    @Override public StatusOnlyReturn diskReplicateStart(String vmUUID,
+            Map<String, Object> srcDisk,
+            Map<String, Object> dstDisk,
+            boolean needExtend) {
         return null;
     }
 
-    @Override public StatusOnlyReturn diskReplicateFinish(String vmUUID, Map srcDisk, Map dstDisk) {
+    @Override public StatusOnlyReturn diskReplicateFinish(String vmUUID,
+            Map<String, Object> srcDisk,
+            Map<String, Object> dstDisk) {
         return null;
     }
 

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/VmReplicateDiskStartVDSCommand.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/VmReplicateDiskStartVDSCommand.java
@@ -10,8 +10,10 @@ public class VmReplicateDiskStartVDSCommand<P extends VmReplicateDiskParameters>
 
     @Override
     protected void executeVdsBrokerCommand() {
-        status = getBroker().diskReplicateStart(
-                getParameters().getVmId().toString(), getSrcDisk(), getDstDisk());
+        status = getBroker().diskReplicateStart(getParameters().getVmId().toString(),
+                getSrcDisk(),
+                getDstDisk(),
+                getParameters().isNeedExtend());
         proceedProxyReturnValue();
     }
 }


### PR DESCRIPTION
Adding image initial size calculation for Live Storage Migration flows for disks
that reside on Block Storage Domain.
Relevant for cluster version 4.7 or above.

Bug-Url: https://bugzilla.redhat.com/1958032