### PR TITLE
Fix import template from OVA

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -4,9 +4,9 @@ installdeps:
 	dnf -y install git
 
 srpm: installdeps
-	$(eval SUFFIX=$(shell sh -c "echo '.git$$(git rev-parse --short HEAD)'"))
+       # $(eval SUFFIX=$(shell sh -c "echo '.git$$(git rev-parse --short HEAD)'"))
 	# changing the spec file as passing -D won't preserve the suffix when rebuilding in mock
-	sed "s:%{?release_suffix}:${SUFFIX}:" -i ovirt-engine.spec.in
+       # sed "s:%{?release_suffix}:${SUFFIX}:" -i ovirt-engine.spec.in
 	mkdir -p tmp.repos/SOURCES
 	make dist
 	rpmbuild \

--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -4,9 +4,9 @@ installdeps:
 	dnf -y install git
 
 srpm: installdeps
-       # $(eval SUFFIX=$(shell sh -c "echo '.git$$(git rev-parse --short HEAD)'"))
+	$(eval SUFFIX=$(shell sh -c "echo '.git$$(git rev-parse --short HEAD)'"))
 	# changing the spec file as passing -D won't preserve the suffix when rebuilding in mock
-       # sed "s:%{?release_suffix}:${SUFFIX}:" -i ovirt-engine.spec.in
+	sed "s:%{?release_suffix}:${SUFFIX}:" -i ovirt-engine.spec.in
 	mkdir -p tmp.repos/SOURCES
 	make dist
 	rpmbuild \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,9 @@
 name: build
 on:
   push:
-    branches: [master]
+    branches: [master, ovirt-engine-4.5.0.z]
   pull_request:
-    branches: [master]
+    branches: [master, ovirt-engine-4.5.0.z]
   workflow_dispatch:
 
 jobs:

--- a/backend/manager/dependencies/common/pom.xml
+++ b/backend/manager/dependencies/common/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core.manager</groupId>
     <artifactId>dependencies</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>common-dependencies</artifactId>

--- a/backend/manager/dependencies/common/pom.xml
+++ b/backend/manager/dependencies/common/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core.manager</groupId>
     <artifactId>dependencies</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
 
   <artifactId>common-dependencies</artifactId>

--- a/backend/manager/dependencies/common/pom.xml
+++ b/backend/manager/dependencies/common/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core.manager</groupId>
     <artifactId>dependencies</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
 
   <artifactId>common-dependencies</artifactId>

--- a/backend/manager/dependencies/common/pom.xml
+++ b/backend/manager/dependencies/common/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core.manager</groupId>
     <artifactId>dependencies</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>common-dependencies</artifactId>

--- a/backend/manager/dependencies/pom.xml
+++ b/backend/manager/dependencies/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>dependencies</artifactId>

--- a/backend/manager/dependencies/pom.xml
+++ b/backend/manager/dependencies/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
 
   <artifactId>dependencies</artifactId>

--- a/backend/manager/dependencies/pom.xml
+++ b/backend/manager/dependencies/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>dependencies</artifactId>

--- a/backend/manager/dependencies/pom.xml
+++ b/backend/manager/dependencies/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
 
   <artifactId>dependencies</artifactId>

--- a/backend/manager/dependencies/tools/pom.xml
+++ b/backend/manager/dependencies/tools/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core.manager</groupId>
     <artifactId>dependencies</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
 
   <artifactId>tools-dependencies</artifactId>

--- a/backend/manager/dependencies/tools/pom.xml
+++ b/backend/manager/dependencies/tools/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core.manager</groupId>
     <artifactId>dependencies</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>tools-dependencies</artifactId>

--- a/backend/manager/dependencies/tools/pom.xml
+++ b/backend/manager/dependencies/tools/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core.manager</groupId>
     <artifactId>dependencies</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
 
   <artifactId>tools-dependencies</artifactId>

--- a/backend/manager/dependencies/tools/pom.xml
+++ b/backend/manager/dependencies/tools/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core.manager</groupId>
     <artifactId>dependencies</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>tools-dependencies</artifactId>

--- a/backend/manager/extensions-tool/pom.xml
+++ b/backend/manager/extensions-tool/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
 
   <artifactId>extensions-tool</artifactId>

--- a/backend/manager/extensions-tool/pom.xml
+++ b/backend/manager/extensions-tool/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
 
   <artifactId>extensions-tool</artifactId>

--- a/backend/manager/extensions-tool/pom.xml
+++ b/backend/manager/extensions-tool/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>extensions-tool</artifactId>

--- a/backend/manager/extensions-tool/pom.xml
+++ b/backend/manager/extensions-tool/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>extensions-tool</artifactId>

--- a/backend/manager/logutils/pom.xml
+++ b/backend/manager/logutils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>logutils</artifactId>

--- a/backend/manager/logutils/pom.xml
+++ b/backend/manager/logutils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
 
   <artifactId>logutils</artifactId>

--- a/backend/manager/logutils/pom.xml
+++ b/backend/manager/logutils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>logutils</artifactId>

--- a/backend/manager/logutils/pom.xml
+++ b/backend/manager/logutils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
 
   <artifactId>logutils</artifactId>

--- a/backend/manager/modules/aaa/pom.xml
+++ b/backend/manager/modules/aaa/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>aaa</artifactId>

--- a/backend/manager/modules/aaa/pom.xml
+++ b/backend/manager/modules/aaa/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
 
   <artifactId>aaa</artifactId>

--- a/backend/manager/modules/aaa/pom.xml
+++ b/backend/manager/modules/aaa/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>aaa</artifactId>

--- a/backend/manager/modules/aaa/pom.xml
+++ b/backend/manager/modules/aaa/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
 
   <artifactId>aaa</artifactId>

--- a/backend/manager/modules/auth-plugin/pom.xml
+++ b/backend/manager/modules/auth-plugin/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>auth-plugin</artifactId>

--- a/backend/manager/modules/auth-plugin/pom.xml
+++ b/backend/manager/modules/auth-plugin/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
 
   <artifactId>auth-plugin</artifactId>

--- a/backend/manager/modules/auth-plugin/pom.xml
+++ b/backend/manager/modules/auth-plugin/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>auth-plugin</artifactId>

--- a/backend/manager/modules/auth-plugin/pom.xml
+++ b/backend/manager/modules/auth-plugin/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
 
   <artifactId>auth-plugin</artifactId>

--- a/backend/manager/modules/bll/pom.xml
+++ b/backend/manager/modules/bll/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
 
   <artifactId>bll</artifactId>

--- a/backend/manager/modules/bll/pom.xml
+++ b/backend/manager/modules/bll/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>bll</artifactId>

--- a/backend/manager/modules/bll/pom.xml
+++ b/backend/manager/modules/bll/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>bll</artifactId>

--- a/backend/manager/modules/bll/pom.xml
+++ b/backend/manager/modules/bll/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
 
   <artifactId>bll</artifactId>

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/AnsiblePackOvaCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/AnsiblePackOvaCommand.java
@@ -1,6 +1,7 @@
 package org.ovirt.engine.core.bll;
 
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 
 import org.ovirt.engine.core.bll.context.CommandContext;
@@ -19,7 +20,8 @@ public class AnsiblePackOvaCommand <T extends AnsibleCommandParameters> extends 
 
     @Override
     protected AnsibleCommandConfig createCommand() {
-        int timeout = EngineLocalConfig.getInstance().getInteger("ANSIBLE_PLAYBOOK_EXEC_DEFAULT_TIMEOUT");
+        long timeout = TimeUnit.MINUTES.toSeconds(
+            EngineLocalConfig.getInstance().getInteger("ANSIBLE_PLAYBOOK_EXEC_DEFAULT_TIMEOUT"));
         Map<String, Object> vars = getParameters().getVariables();
         return new AnsibleCommandConfig()
                 .hosts(getVds())

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/GetFromOvaQuery.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/GetFromOvaQuery.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
@@ -47,7 +48,8 @@ public abstract class GetFromOvaQuery <T, P extends GetVmFromOvaQueryParameters>
     }
 
     private String runAnsibleQueryOvaInfoPlaybook() {
-        int timeout = EngineLocalConfig.getInstance().getInteger("ANSIBLE_PLAYBOOK_EXEC_DEFAULT_TIMEOUT");
+        long timeout = TimeUnit.MINUTES.toSeconds(
+            EngineLocalConfig.getInstance().getInteger("ANSIBLE_PLAYBOOK_EXEC_DEFAULT_TIMEOUT"));
         VDS host = vdsDao.get(getParameters().getVdsId());
         AnsibleCommandConfig command = new AnsibleCommandConfig()
                 .hosts(host)

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/MigrateVmCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/MigrateVmCommand.java
@@ -430,7 +430,7 @@ public class MigrateVmCommand<T extends MigrateVmParameters> extends RunVmComman
             maxIncomingMigrations = maxOutgoingMigrations = effectiveMigrationPolicy.getMaxMigrations();
         }
         if (getVm().getCpuPinningPolicy() == CpuPinningPolicy.DEDICATED) {
-            cpuSets = CpuPinningHelper.getAllPinnedPCpus(getDedicatedCpuPinning(getDestinationVdsManager())).stream().sorted()
+            cpuSets = CpuPinningHelper.getAllPinnedPCpus(getDedicatedCpuPinning(getDestinationVdsManager())).stream()
                     .map(Object::toString).collect(Collectors.toList());
             String numaPinningString = vmHandler.createNumaPinningForDedicated(getVm(), getDestinationVdsId());
             numaNodeSets = NumaPinningHelper.parseNumaSets(numaPinningString);

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ExportOvaCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ExportOvaCommand.java
@@ -2,6 +2,7 @@ package org.ovirt.engine.core.bll.exportimport;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
@@ -94,7 +95,8 @@ public abstract class ExportOvaCommand<T extends ExportOvaParameters> extends Co
     }
 
     private ValidationResult validateTargetFolder() {
-        int timeout = EngineLocalConfig.getInstance().getInteger("ANSIBLE_PLAYBOOK_EXEC_DEFAULT_TIMEOUT");
+        long timeout = TimeUnit.MINUTES.toSeconds(
+            EngineLocalConfig.getInstance().getInteger("ANSIBLE_PLAYBOOK_EXEC_DEFAULT_TIMEOUT"));
         AnsibleCommandConfig commandConfig = new AnsibleCommandConfig()
                 .hosts(getVds())
                 .variable("target_directory", getParameters().getDirectory())

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ExtractOvaCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ExtractOvaCommand.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -113,7 +114,8 @@ public class ExtractOvaCommand<T extends ConvertOvaParameters> extends VmCommand
     }
 
     private boolean runAnsibleImportOvaPlaybook(String disksPathToFormat) {
-        int timeout = EngineLocalConfig.getInstance().getInteger("ANSIBLE_PLAYBOOK_EXEC_DEFAULT_TIMEOUT");
+        long timeout = TimeUnit.MINUTES.toSeconds(
+            EngineLocalConfig.getInstance().getInteger("ANSIBLE_PLAYBOOK_EXEC_DEFAULT_TIMEOUT"));
         AnsibleCommandConfig commandConfig = new AnsibleCommandConfig()
                 .hosts(getVds())
                 .variable("ovirt_import_ova_path", getParameters().getOvaPath())

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ImportVmTemplateCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ImportVmTemplateCommand.java
@@ -5,7 +5,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import javax.inject.Inject;
 
@@ -154,18 +153,7 @@ public class ImportVmTemplateCommand<T extends ImportVmTemplateParameters> exten
             if (!getParameters().isImagesExistOnTargetStorageDomain()) {
                 updateDiskSizeByQcowImageInfo(image);
             } else {
-                Set<Guid> storageDomains = getParameters().getImageToAvailableStorageDomains().get(image.getImageId());
-                Guid sdToUse;
-
-                // Try to use the target SD, otherwise fallback to one of the available SDs
-                // for the image
-                if (storageDomains.contains(getStorageDomainId())) {
-                    sdToUse = getStorageDomainId();
-                } else {
-                    sdToUse = storageDomains.stream().findFirst().get();
-                }
-
-                updateDiskSizeByQcowImageInfo(image, sdToUse);
+                updateDiskSizeByQcowImageInfo(image, image.getStorageIds().get(0));
             }
 
             if (getParameters().isImportAsNewEntity()) {

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ImportVmTemplateFromConfigurationCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ImportVmTemplateFromConfigurationCommand.java
@@ -641,6 +641,18 @@ public class ImportVmTemplateFromConfigurationCommand<T extends ImportVmTemplate
 
     @Override
     protected void updateDiskSizeByQcowImageInfo(DiskImage diskImage, Guid storageId) {
+        Set<Guid> storageDomains = getParameters().getImageToAvailableStorageDomains().get(diskImage.getImageId());
+
+        if (storageDomains != null && !storageDomains.isEmpty()) {
+            // Try to use the target SD, otherwise fallback to one of the available SDs
+            // for the image
+            if (storageDomains.contains(getStorageDomainId())) {
+                storageId = getStorageDomainId();
+            } else {
+                storageId = storageDomains.stream().findFirst().get();
+            }
+        }
+
         if (!Guid.isNullOrEmpty(storageId)) {
             super.updateDiskSizeByQcowImageInfo(diskImage, storageId);
             return;

--- a/backend/manager/modules/branding/pom.xml
+++ b/backend/manager/modules/branding/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
   <artifactId>branding</artifactId>
   <packaging>jar</packaging>

--- a/backend/manager/modules/branding/pom.xml
+++ b/backend/manager/modules/branding/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
   <artifactId>branding</artifactId>
   <packaging>jar</packaging>

--- a/backend/manager/modules/branding/pom.xml
+++ b/backend/manager/modules/branding/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
   <artifactId>branding</artifactId>
   <packaging>jar</packaging>

--- a/backend/manager/modules/branding/pom.xml
+++ b/backend/manager/modules/branding/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
   <artifactId>branding</artifactId>
   <packaging>jar</packaging>

--- a/backend/manager/modules/builtin-extensions/pom.xml
+++ b/backend/manager/modules/builtin-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
   <groupId>org.ovirt.engine.extension.aaa</groupId>
   <artifactId>builtin</artifactId>

--- a/backend/manager/modules/builtin-extensions/pom.xml
+++ b/backend/manager/modules/builtin-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
   <groupId>org.ovirt.engine.extension.aaa</groupId>
   <artifactId>builtin</artifactId>

--- a/backend/manager/modules/builtin-extensions/pom.xml
+++ b/backend/manager/modules/builtin-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
   <groupId>org.ovirt.engine.extension.aaa</groupId>
   <artifactId>builtin</artifactId>

--- a/backend/manager/modules/builtin-extensions/pom.xml
+++ b/backend/manager/modules/builtin-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
   <groupId>org.ovirt.engine.extension.aaa</groupId>
   <artifactId>builtin</artifactId>

--- a/backend/manager/modules/common/pom.xml
+++ b/backend/manager/modules/common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>common</artifactId>

--- a/backend/manager/modules/common/pom.xml
+++ b/backend/manager/modules/common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>common</artifactId>

--- a/backend/manager/modules/common/pom.xml
+++ b/backend/manager/modules/common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
 
   <artifactId>common</artifactId>

--- a/backend/manager/modules/common/pom.xml
+++ b/backend/manager/modules/common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
 
   <artifactId>common</artifactId>

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/ImportVmTemplateFromConfParameters.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/ImportVmTemplateFromConfParameters.java
@@ -18,6 +18,7 @@ public class ImportVmTemplateFromConfParameters extends ImportVmTemplateParamete
     private Map<String, String> clusterMap;
     private Map<String, String> roleMap;
     private Map<String, String> domainMap;
+    private Map<Guid, Set<Guid>> imageToAvailableStorageDomains = new HashMap<>();
 
     private Set<DbUser> dbUsers;
     private Map<String, Set<String>> userToRoles  = new HashMap<>();
@@ -117,5 +118,13 @@ public class ImportVmTemplateFromConfParameters extends ImportVmTemplateParamete
     @Override
     public void setExternalVnicProfileMappings(Collection<ExternalVnicProfileMapping> externalVnicProfileMappings) {
         this.externalVnicProfileMappings = Objects.requireNonNull(externalVnicProfileMappings);
+    }
+
+    public Map<Guid, Set<Guid>> getImageToAvailableStorageDomains() {
+        return imageToAvailableStorageDomains;
+    }
+
+    public void setImageToAvailableStorageDomains(Map<Guid, Set<Guid>> imageToAvailableStorageDomains) {
+        this.imageToAvailableStorageDomains = imageToAvailableStorageDomains;
     }
 }

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/ImportVmTemplateParameters.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/ImportVmTemplateParameters.java
@@ -1,10 +1,8 @@
 package org.ovirt.engine.core.common.action;
 
 import java.io.Serializable;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import javax.validation.Valid;
 
@@ -87,16 +85,6 @@ public class ImportVmTemplateParameters extends MoveOrCopyParameters implements 
 
     public void setDiskTemplateMap(Map<Guid, DiskImage> diskTemplateMap) {
         this.diskTemplateMap = diskTemplateMap;
-    }
-
-    private Map<Guid, Set<Guid>> imageToAvailableStorageDomains = new HashMap<>();
-
-    public Map<Guid, Set<Guid>> getImageToAvailableStorageDomains() {
-        return imageToAvailableStorageDomains;
-    }
-
-    public void setImageToAvailableStorageDomains(Map<Guid, Set<Guid>> imageToAvailableStorageDomains) {
-        this.imageToAvailableStorageDomains = imageToAvailableStorageDomains;
     }
 
     public ImportVmTemplateParameters() {

--- a/backend/manager/modules/compat/pom.xml
+++ b/backend/manager/modules/compat/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>compat</artifactId>

--- a/backend/manager/modules/compat/pom.xml
+++ b/backend/manager/modules/compat/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>compat</artifactId>

--- a/backend/manager/modules/compat/pom.xml
+++ b/backend/manager/modules/compat/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
 
   <artifactId>compat</artifactId>

--- a/backend/manager/modules/compat/pom.xml
+++ b/backend/manager/modules/compat/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
 
   <artifactId>compat</artifactId>

--- a/backend/manager/modules/dal/pom.xml
+++ b/backend/manager/modules/dal/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
   <artifactId>dal</artifactId>
   <packaging>jar</packaging>

--- a/backend/manager/modules/dal/pom.xml
+++ b/backend/manager/modules/dal/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
   <artifactId>dal</artifactId>
   <packaging>jar</packaging>

--- a/backend/manager/modules/dal/pom.xml
+++ b/backend/manager/modules/dal/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
   <artifactId>dal</artifactId>
   <packaging>jar</packaging>

--- a/backend/manager/modules/dal/pom.xml
+++ b/backend/manager/modules/dal/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
   <artifactId>dal</artifactId>
   <packaging>jar</packaging>

--- a/backend/manager/modules/docs/pom.xml
+++ b/backend/manager/modules/docs/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
 
   <artifactId>docs</artifactId>

--- a/backend/manager/modules/docs/pom.xml
+++ b/backend/manager/modules/docs/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>docs</artifactId>

--- a/backend/manager/modules/docs/pom.xml
+++ b/backend/manager/modules/docs/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>docs</artifactId>

--- a/backend/manager/modules/docs/pom.xml
+++ b/backend/manager/modules/docs/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
 
   <artifactId>docs</artifactId>

--- a/backend/manager/modules/enginesso/pom.xml
+++ b/backend/manager/modules/enginesso/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>manager-modules</artifactId>
         <groupId>org.ovirt.engine.core</groupId>
-        <version>4.5.0.4-SNAPSHOT</version>
+        <version>4.5.0.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/backend/manager/modules/enginesso/pom.xml
+++ b/backend/manager/modules/enginesso/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>manager-modules</artifactId>
         <groupId>org.ovirt.engine.core</groupId>
-        <version>4.5.0.3</version>
+        <version>4.5.0.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/backend/manager/modules/enginesso/pom.xml
+++ b/backend/manager/modules/enginesso/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>manager-modules</artifactId>
         <groupId>org.ovirt.engine.core</groupId>
-        <version>4.5.0.3-SNAPSHOT</version>
+        <version>4.5.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/backend/manager/modules/enginesso/pom.xml
+++ b/backend/manager/modules/enginesso/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>manager-modules</artifactId>
         <groupId>org.ovirt.engine.core</groupId>
-        <version>4.5.0.4</version>
+        <version>4.5.0.5-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/backend/manager/modules/extensions-manager/pom.xml
+++ b/backend/manager/modules/extensions-manager/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>extensions-manager</artifactId>

--- a/backend/manager/modules/extensions-manager/pom.xml
+++ b/backend/manager/modules/extensions-manager/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>extensions-manager</artifactId>

--- a/backend/manager/modules/extensions-manager/pom.xml
+++ b/backend/manager/modules/extensions-manager/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
 
   <artifactId>extensions-manager</artifactId>

--- a/backend/manager/modules/extensions-manager/pom.xml
+++ b/backend/manager/modules/extensions-manager/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
 
   <artifactId>extensions-manager</artifactId>

--- a/backend/manager/modules/logger/pom.xml
+++ b/backend/manager/modules/logger/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
 
   <artifactId>logger</artifactId>

--- a/backend/manager/modules/logger/pom.xml
+++ b/backend/manager/modules/logger/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>logger</artifactId>

--- a/backend/manager/modules/logger/pom.xml
+++ b/backend/manager/modules/logger/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
 
   <artifactId>logger</artifactId>

--- a/backend/manager/modules/logger/pom.xml
+++ b/backend/manager/modules/logger/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>logger</artifactId>

--- a/backend/manager/modules/microbenchmarks/pom.xml
+++ b/backend/manager/modules/microbenchmarks/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>benchmarks</artifactId>

--- a/backend/manager/modules/microbenchmarks/pom.xml
+++ b/backend/manager/modules/microbenchmarks/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
 
   <artifactId>benchmarks</artifactId>

--- a/backend/manager/modules/microbenchmarks/pom.xml
+++ b/backend/manager/modules/microbenchmarks/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
 
   <artifactId>benchmarks</artifactId>

--- a/backend/manager/modules/microbenchmarks/pom.xml
+++ b/backend/manager/modules/microbenchmarks/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>benchmarks</artifactId>

--- a/backend/manager/modules/pom.xml
+++ b/backend/manager/modules/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
 
   <artifactId>manager-modules</artifactId>

--- a/backend/manager/modules/pom.xml
+++ b/backend/manager/modules/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>manager-modules</artifactId>

--- a/backend/manager/modules/pom.xml
+++ b/backend/manager/modules/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
 
   <artifactId>manager-modules</artifactId>

--- a/backend/manager/modules/pom.xml
+++ b/backend/manager/modules/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>manager-modules</artifactId>

--- a/backend/manager/modules/restapi/apidoc/pom.xml
+++ b/backend/manager/modules/restapi/apidoc/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
 
   <artifactId>restapi-apidoc</artifactId>

--- a/backend/manager/modules/restapi/apidoc/pom.xml
+++ b/backend/manager/modules/restapi/apidoc/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>restapi-apidoc</artifactId>

--- a/backend/manager/modules/restapi/apidoc/pom.xml
+++ b/backend/manager/modules/restapi/apidoc/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
 
   <artifactId>restapi-apidoc</artifactId>

--- a/backend/manager/modules/restapi/apidoc/pom.xml
+++ b/backend/manager/modules/restapi/apidoc/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>restapi-apidoc</artifactId>

--- a/backend/manager/modules/restapi/interface/common/jaxrs/pom.xml
+++ b/backend/manager/modules/restapi/interface/common/jaxrs/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>common-parent</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
 
   <artifactId>interface-common-jaxrs</artifactId>

--- a/backend/manager/modules/restapi/interface/common/jaxrs/pom.xml
+++ b/backend/manager/modules/restapi/interface/common/jaxrs/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>common-parent</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>interface-common-jaxrs</artifactId>

--- a/backend/manager/modules/restapi/interface/common/jaxrs/pom.xml
+++ b/backend/manager/modules/restapi/interface/common/jaxrs/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>common-parent</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
 
   <artifactId>interface-common-jaxrs</artifactId>

--- a/backend/manager/modules/restapi/interface/common/jaxrs/pom.xml
+++ b/backend/manager/modules/restapi/interface/common/jaxrs/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>common-parent</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>interface-common-jaxrs</artifactId>

--- a/backend/manager/modules/restapi/interface/common/pom.xml
+++ b/backend/manager/modules/restapi/interface/common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>interface</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
 
   <artifactId>common-parent</artifactId>

--- a/backend/manager/modules/restapi/interface/common/pom.xml
+++ b/backend/manager/modules/restapi/interface/common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>interface</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>common-parent</artifactId>

--- a/backend/manager/modules/restapi/interface/common/pom.xml
+++ b/backend/manager/modules/restapi/interface/common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>interface</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>common-parent</artifactId>

--- a/backend/manager/modules/restapi/interface/common/pom.xml
+++ b/backend/manager/modules/restapi/interface/common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>interface</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
 
   <artifactId>common-parent</artifactId>

--- a/backend/manager/modules/restapi/interface/definition/pom.xml
+++ b/backend/manager/modules/restapi/interface/definition/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>interface</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>restapi-definition</artifactId>

--- a/backend/manager/modules/restapi/interface/definition/pom.xml
+++ b/backend/manager/modules/restapi/interface/definition/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>interface</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>restapi-definition</artifactId>

--- a/backend/manager/modules/restapi/interface/definition/pom.xml
+++ b/backend/manager/modules/restapi/interface/definition/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>interface</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
 
   <artifactId>restapi-definition</artifactId>

--- a/backend/manager/modules/restapi/interface/definition/pom.xml
+++ b/backend/manager/modules/restapi/interface/definition/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>interface</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
 
   <artifactId>restapi-definition</artifactId>

--- a/backend/manager/modules/restapi/interface/pom.xml
+++ b/backend/manager/modules/restapi/interface/pom.xml
@@ -5,7 +5,7 @@ ven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
 
   <artifactId>interface</artifactId>

--- a/backend/manager/modules/restapi/interface/pom.xml
+++ b/backend/manager/modules/restapi/interface/pom.xml
@@ -5,7 +5,7 @@ ven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
 
   <artifactId>interface</artifactId>

--- a/backend/manager/modules/restapi/interface/pom.xml
+++ b/backend/manager/modules/restapi/interface/pom.xml
@@ -5,7 +5,7 @@ ven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>interface</artifactId>

--- a/backend/manager/modules/restapi/interface/pom.xml
+++ b/backend/manager/modules/restapi/interface/pom.xml
@@ -5,7 +5,7 @@ ven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>interface</artifactId>

--- a/backend/manager/modules/restapi/jaxrs/pom.xml
+++ b/backend/manager/modules/restapi/jaxrs/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>restapi-jaxrs</artifactId>

--- a/backend/manager/modules/restapi/jaxrs/pom.xml
+++ b/backend/manager/modules/restapi/jaxrs/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
 
   <artifactId>restapi-jaxrs</artifactId>

--- a/backend/manager/modules/restapi/jaxrs/pom.xml
+++ b/backend/manager/modules/restapi/jaxrs/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
 
   <artifactId>restapi-jaxrs</artifactId>

--- a/backend/manager/modules/restapi/jaxrs/pom.xml
+++ b/backend/manager/modules/restapi/jaxrs/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>restapi-jaxrs</artifactId>

--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendVmBackupsResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendVmBackupsResource.java
@@ -58,7 +58,7 @@ public class BackendVmBackupsResource
                 backup.getSnapshot().setVm(vm);
             }
 
-            collection.getBackups().add(addLinks(backup));
+            collection.getBackups().add(addLinks(backup, Vm.class));
         }
         return collection;
     }

--- a/backend/manager/modules/restapi/pom.xml
+++ b/backend/manager/modules/restapi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
 
   <artifactId>restapi-parent</artifactId>

--- a/backend/manager/modules/restapi/pom.xml
+++ b/backend/manager/modules/restapi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>restapi-parent</artifactId>

--- a/backend/manager/modules/restapi/pom.xml
+++ b/backend/manager/modules/restapi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>restapi-parent</artifactId>

--- a/backend/manager/modules/restapi/pom.xml
+++ b/backend/manager/modules/restapi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
 
   <artifactId>restapi-parent</artifactId>

--- a/backend/manager/modules/restapi/types/pom.xml
+++ b/backend/manager/modules/restapi/types/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
 
   <artifactId>restapi-types</artifactId>

--- a/backend/manager/modules/restapi/types/pom.xml
+++ b/backend/manager/modules/restapi/types/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
 
   <artifactId>restapi-types</artifactId>

--- a/backend/manager/modules/restapi/types/pom.xml
+++ b/backend/manager/modules/restapi/types/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>restapi-types</artifactId>

--- a/backend/manager/modules/restapi/types/pom.xml
+++ b/backend/manager/modules/restapi/types/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>restapi-types</artifactId>

--- a/backend/manager/modules/restapi/webapp/pom.xml
+++ b/backend/manager/modules/restapi/webapp/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>restapi-webapp</artifactId>

--- a/backend/manager/modules/restapi/webapp/pom.xml
+++ b/backend/manager/modules/restapi/webapp/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
 
   <artifactId>restapi-webapp</artifactId>

--- a/backend/manager/modules/restapi/webapp/pom.xml
+++ b/backend/manager/modules/restapi/webapp/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
 
   <artifactId>restapi-webapp</artifactId>

--- a/backend/manager/modules/restapi/webapp/pom.xml
+++ b/backend/manager/modules/restapi/webapp/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>restapi-webapp</artifactId>

--- a/backend/manager/modules/root/pom.xml
+++ b/backend/manager/modules/root/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
 
   <artifactId>root-war</artifactId>

--- a/backend/manager/modules/root/pom.xml
+++ b/backend/manager/modules/root/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>root-war</artifactId>

--- a/backend/manager/modules/root/pom.xml
+++ b/backend/manager/modules/root/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
 
   <artifactId>root-war</artifactId>

--- a/backend/manager/modules/root/pom.xml
+++ b/backend/manager/modules/root/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>root-war</artifactId>

--- a/backend/manager/modules/scheduler/pom.xml
+++ b/backend/manager/modules/scheduler/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>scheduler</artifactId>

--- a/backend/manager/modules/scheduler/pom.xml
+++ b/backend/manager/modules/scheduler/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
 
   <artifactId>scheduler</artifactId>

--- a/backend/manager/modules/scheduler/pom.xml
+++ b/backend/manager/modules/scheduler/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>scheduler</artifactId>

--- a/backend/manager/modules/scheduler/pom.xml
+++ b/backend/manager/modules/scheduler/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
 
   <artifactId>scheduler</artifactId>

--- a/backend/manager/modules/searchbackend/pom.xml
+++ b/backend/manager/modules/searchbackend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>searchbackend</artifactId>

--- a/backend/manager/modules/searchbackend/pom.xml
+++ b/backend/manager/modules/searchbackend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
 
   <artifactId>searchbackend</artifactId>

--- a/backend/manager/modules/searchbackend/pom.xml
+++ b/backend/manager/modules/searchbackend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>searchbackend</artifactId>

--- a/backend/manager/modules/searchbackend/pom.xml
+++ b/backend/manager/modules/searchbackend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
 
   <artifactId>searchbackend</artifactId>

--- a/backend/manager/modules/services/pom.xml
+++ b/backend/manager/modules/services/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>services</artifactId>

--- a/backend/manager/modules/services/pom.xml
+++ b/backend/manager/modules/services/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
 
   <artifactId>services</artifactId>

--- a/backend/manager/modules/services/pom.xml
+++ b/backend/manager/modules/services/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>services</artifactId>

--- a/backend/manager/modules/services/pom.xml
+++ b/backend/manager/modules/services/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
 
   <artifactId>services</artifactId>

--- a/backend/manager/modules/utils/pom.xml
+++ b/backend/manager/modules/utils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
 
   <artifactId>utils</artifactId>

--- a/backend/manager/modules/utils/pom.xml
+++ b/backend/manager/modules/utils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>utils</artifactId>

--- a/backend/manager/modules/utils/pom.xml
+++ b/backend/manager/modules/utils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
 
   <artifactId>utils</artifactId>

--- a/backend/manager/modules/utils/pom.xml
+++ b/backend/manager/modules/utils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>utils</artifactId>

--- a/backend/manager/modules/uutils/pom.xml
+++ b/backend/manager/modules/uutils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
 
   <artifactId>uutils</artifactId>

--- a/backend/manager/modules/uutils/pom.xml
+++ b/backend/manager/modules/uutils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
 
   <artifactId>uutils</artifactId>

--- a/backend/manager/modules/uutils/pom.xml
+++ b/backend/manager/modules/uutils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>uutils</artifactId>

--- a/backend/manager/modules/uutils/pom.xml
+++ b/backend/manager/modules/uutils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>uutils</artifactId>

--- a/backend/manager/modules/vdsbroker/pom.xml
+++ b/backend/manager/modules/vdsbroker/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
 
   <artifactId>vdsbroker</artifactId>

--- a/backend/manager/modules/vdsbroker/pom.xml
+++ b/backend/manager/modules/vdsbroker/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
 
   <artifactId>vdsbroker</artifactId>

--- a/backend/manager/modules/vdsbroker/pom.xml
+++ b/backend/manager/modules/vdsbroker/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>vdsbroker</artifactId>

--- a/backend/manager/modules/vdsbroker/pom.xml
+++ b/backend/manager/modules/vdsbroker/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>vdsbroker</artifactId>

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/builder/vminfo/LibvirtVmXmlBuilder.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/builder/vminfo/LibvirtVmXmlBuilder.java
@@ -1040,7 +1040,9 @@ public class LibvirtVmXmlBuilder {
     private void writeCpuPinningPolicyMetadata() {
         CpuPinningPolicy cpuPinningPolicy = vm.getCpuPinningPolicy();
         // CpuPinningPolicy.NONE may happen when the engine generates CPU pinning based on the NUMA pinning.
-        if (vm.getVmPinning() != null && cpuPinningPolicy == CpuPinningPolicy.NONE) {
+        // VDSM doesn't recognize 'resize and pin numa' we need to switch it to 'manual'.
+        if (cpuPinningPolicy == CpuPinningPolicy.RESIZE_AND_PIN_NUMA ||
+                vm.getVmPinning() != null && cpuPinningPolicy == CpuPinningPolicy.NONE) {
             cpuPinningPolicy = CpuPinningPolicy.MANUAL;
         }
         writer.writeElement(OVIRT_VM_URI, "cpuPolicy", cpuPinningPolicy.name().toLowerCase());

--- a/backend/manager/modules/welcome/pom.xml
+++ b/backend/manager/modules/welcome/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>welcome</artifactId>

--- a/backend/manager/modules/welcome/pom.xml
+++ b/backend/manager/modules/welcome/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>welcome</artifactId>

--- a/backend/manager/modules/welcome/pom.xml
+++ b/backend/manager/modules/welcome/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
 
   <artifactId>welcome</artifactId>

--- a/backend/manager/modules/welcome/pom.xml
+++ b/backend/manager/modules/welcome/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
 
   <artifactId>welcome</artifactId>

--- a/backend/manager/pom.xml
+++ b/backend/manager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>backend</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
   <artifactId>manager</artifactId>
   <packaging>pom</packaging>

--- a/backend/manager/pom.xml
+++ b/backend/manager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>backend</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
   <artifactId>manager</artifactId>
   <packaging>pom</packaging>

--- a/backend/manager/pom.xml
+++ b/backend/manager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>backend</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
   <artifactId>manager</artifactId>
   <packaging>pom</packaging>

--- a/backend/manager/pom.xml
+++ b/backend/manager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>backend</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
   <artifactId>manager</artifactId>
   <packaging>pom</packaging>

--- a/backend/manager/sso-client-registration-tool/pom.xml
+++ b/backend/manager/sso-client-registration-tool/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
 
   <artifactId>sso-client-registration-tool</artifactId>

--- a/backend/manager/sso-client-registration-tool/pom.xml
+++ b/backend/manager/sso-client-registration-tool/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>sso-client-registration-tool</artifactId>

--- a/backend/manager/sso-client-registration-tool/pom.xml
+++ b/backend/manager/sso-client-registration-tool/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
 
   <artifactId>sso-client-registration-tool</artifactId>

--- a/backend/manager/sso-client-registration-tool/pom.xml
+++ b/backend/manager/sso-client-registration-tool/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>sso-client-registration-tool</artifactId>

--- a/backend/manager/tools/pom.xml
+++ b/backend/manager/tools/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
 
   <artifactId>tools</artifactId>

--- a/backend/manager/tools/pom.xml
+++ b/backend/manager/tools/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>tools</artifactId>

--- a/backend/manager/tools/pom.xml
+++ b/backend/manager/tools/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>tools</artifactId>

--- a/backend/manager/tools/pom.xml
+++ b/backend/manager/tools/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
 
   <artifactId>tools</artifactId>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
 
   <artifactId>backend</artifactId>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>backend</artifactId>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
 
   <artifactId>backend</artifactId>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>backend</artifactId>

--- a/build-tools-root/checkstyles/pom.xml
+++ b/build-tools-root/checkstyles/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>build-tools-root</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
   <artifactId>checkstyles</artifactId>
   <packaging>jar</packaging>

--- a/build-tools-root/checkstyles/pom.xml
+++ b/build-tools-root/checkstyles/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>build-tools-root</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
   <artifactId>checkstyles</artifactId>
   <packaging>jar</packaging>

--- a/build-tools-root/checkstyles/pom.xml
+++ b/build-tools-root/checkstyles/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>build-tools-root</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
   <artifactId>checkstyles</artifactId>
   <packaging>jar</packaging>

--- a/build-tools-root/checkstyles/pom.xml
+++ b/build-tools-root/checkstyles/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>build-tools-root</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
   <artifactId>checkstyles</artifactId>
   <packaging>jar</packaging>

--- a/build-tools-root/ovirt-checkstyle-extension/pom.xml
+++ b/build-tools-root/ovirt-checkstyle-extension/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>build-tools-root</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
   <artifactId>ovirt-checkstyle-extension</artifactId>
   <name>oVirt Checkstyle Checks</name>

--- a/build-tools-root/ovirt-checkstyle-extension/pom.xml
+++ b/build-tools-root/ovirt-checkstyle-extension/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>build-tools-root</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
   <artifactId>ovirt-checkstyle-extension</artifactId>
   <name>oVirt Checkstyle Checks</name>

--- a/build-tools-root/ovirt-checkstyle-extension/pom.xml
+++ b/build-tools-root/ovirt-checkstyle-extension/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>build-tools-root</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
   <artifactId>ovirt-checkstyle-extension</artifactId>
   <name>oVirt Checkstyle Checks</name>

--- a/build-tools-root/ovirt-checkstyle-extension/pom.xml
+++ b/build-tools-root/ovirt-checkstyle-extension/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>build-tools-root</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
   <artifactId>ovirt-checkstyle-extension</artifactId>
   <name>oVirt Checkstyle Checks</name>

--- a/build-tools-root/ovirt-findbugs-filters/pom.xml
+++ b/build-tools-root/ovirt-findbugs-filters/pom.xml
@@ -14,7 +14,7 @@ SPDX-License-Identifier: Apache-2.0
 
   <groupId>org.ovirt.engine</groupId>
   <artifactId>ovirt-findbugs-filters</artifactId>
-  <version>4.5.0.4</version>
+  <version>4.5.0.5-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>oVirt Findbugs Filters</name>

--- a/build-tools-root/ovirt-findbugs-filters/pom.xml
+++ b/build-tools-root/ovirt-findbugs-filters/pom.xml
@@ -14,7 +14,7 @@ SPDX-License-Identifier: Apache-2.0
 
   <groupId>org.ovirt.engine</groupId>
   <artifactId>ovirt-findbugs-filters</artifactId>
-  <version>4.5.0.3</version>
+  <version>4.5.0.4-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>oVirt Findbugs Filters</name>

--- a/build-tools-root/ovirt-findbugs-filters/pom.xml
+++ b/build-tools-root/ovirt-findbugs-filters/pom.xml
@@ -14,7 +14,7 @@ SPDX-License-Identifier: Apache-2.0
 
   <groupId>org.ovirt.engine</groupId>
   <artifactId>ovirt-findbugs-filters</artifactId>
-  <version>4.5.0.4-SNAPSHOT</version>
+  <version>4.5.0.4</version>
   <packaging>jar</packaging>
 
   <name>oVirt Findbugs Filters</name>

--- a/build-tools-root/ovirt-findbugs-filters/pom.xml
+++ b/build-tools-root/ovirt-findbugs-filters/pom.xml
@@ -14,7 +14,7 @@ SPDX-License-Identifier: Apache-2.0
 
   <groupId>org.ovirt.engine</groupId>
   <artifactId>ovirt-findbugs-filters</artifactId>
-  <version>4.5.0.3-SNAPSHOT</version>
+  <version>4.5.0.3</version>
   <packaging>jar</packaging>
 
   <name>oVirt Findbugs Filters</name>

--- a/build-tools-root/pom.xml
+++ b/build-tools-root/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
   <artifactId>build-tools-root</artifactId>
   <packaging>pom</packaging>

--- a/build-tools-root/pom.xml
+++ b/build-tools-root/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
   <artifactId>build-tools-root</artifactId>
   <packaging>pom</packaging>

--- a/build-tools-root/pom.xml
+++ b/build-tools-root/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
   <artifactId>build-tools-root</artifactId>
   <packaging>pom</packaging>

--- a/build-tools-root/pom.xml
+++ b/build-tools-root/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
   <artifactId>build-tools-root</artifactId>
   <packaging>pom</packaging>

--- a/ear/pom.xml
+++ b/ear/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
 
   <artifactId>engine-server-ear</artifactId>

--- a/ear/pom.xml
+++ b/ear/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>engine-server-ear</artifactId>

--- a/ear/pom.xml
+++ b/ear/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>engine-server-ear</artifactId>

--- a/ear/pom.xml
+++ b/ear/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
 
   <artifactId>engine-server-ear</artifactId>

--- a/frontend/brands/ovirt-brand/pom.xml
+++ b/frontend/brands/ovirt-brand/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>brands-all</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>ovirt-brand</artifactId>

--- a/frontend/brands/ovirt-brand/pom.xml
+++ b/frontend/brands/ovirt-brand/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>brands-all</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
 
   <artifactId>ovirt-brand</artifactId>

--- a/frontend/brands/ovirt-brand/pom.xml
+++ b/frontend/brands/ovirt-brand/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>brands-all</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
 
   <artifactId>ovirt-brand</artifactId>

--- a/frontend/brands/ovirt-brand/pom.xml
+++ b/frontend/brands/ovirt-brand/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>brands-all</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>ovirt-brand</artifactId>

--- a/frontend/brands/pom.xml
+++ b/frontend/brands/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>frontend-all</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
   <artifactId>brands-all</artifactId>
   <packaging>pom</packaging>

--- a/frontend/brands/pom.xml
+++ b/frontend/brands/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>frontend-all</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
   <artifactId>brands-all</artifactId>
   <packaging>pom</packaging>

--- a/frontend/brands/pom.xml
+++ b/frontend/brands/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>frontend-all</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
   <artifactId>brands-all</artifactId>
   <packaging>pom</packaging>

--- a/frontend/brands/pom.xml
+++ b/frontend/brands/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>frontend-all</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
   <artifactId>brands-all</artifactId>
   <packaging>pom</packaging>

--- a/frontend/pom.xml
+++ b/frontend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
   <artifactId>frontend-all</artifactId>
   <groupId>org.ovirt.engine.ui</groupId>

--- a/frontend/pom.xml
+++ b/frontend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
   <artifactId>frontend-all</artifactId>
   <groupId>org.ovirt.engine.ui</groupId>

--- a/frontend/pom.xml
+++ b/frontend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
   <artifactId>frontend-all</artifactId>
   <groupId>org.ovirt.engine.ui</groupId>

--- a/frontend/pom.xml
+++ b/frontend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
   <artifactId>frontend-all</artifactId>
   <groupId>org.ovirt.engine.ui</groupId>

--- a/frontend/webadmin/modules/frontend-assemblies/pom.xml
+++ b/frontend/webadmin/modules/frontend-assemblies/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>webadmin-modules</artifactId>
     <groupId>org.ovirt.engine.ui</groupId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
   <artifactId>frontend-assemblies</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/frontend-assemblies/pom.xml
+++ b/frontend/webadmin/modules/frontend-assemblies/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>webadmin-modules</artifactId>
     <groupId>org.ovirt.engine.ui</groupId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
   <artifactId>frontend-assemblies</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/frontend-assemblies/pom.xml
+++ b/frontend/webadmin/modules/frontend-assemblies/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>webadmin-modules</artifactId>
     <groupId>org.ovirt.engine.ui</groupId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
   <artifactId>frontend-assemblies</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/frontend-assemblies/pom.xml
+++ b/frontend/webadmin/modules/frontend-assemblies/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>webadmin-modules</artifactId>
     <groupId>org.ovirt.engine.ui</groupId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
   <artifactId>frontend-assemblies</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/frontend/pom.xml
+++ b/frontend/webadmin/modules/frontend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
   <artifactId>frontend</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/frontend/pom.xml
+++ b/frontend/webadmin/modules/frontend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
   <artifactId>frontend</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/frontend/pom.xml
+++ b/frontend/webadmin/modules/frontend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
   <artifactId>frontend</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/frontend/pom.xml
+++ b/frontend/webadmin/modules/frontend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
   <artifactId>frontend</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/gwt-aop/pom.xml
+++ b/frontend/webadmin/modules/gwt-aop/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
   <artifactId>gwt-aop</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/gwt-aop/pom.xml
+++ b/frontend/webadmin/modules/gwt-aop/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
   <artifactId>gwt-aop</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/gwt-aop/pom.xml
+++ b/frontend/webadmin/modules/gwt-aop/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
   <artifactId>gwt-aop</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/gwt-aop/pom.xml
+++ b/frontend/webadmin/modules/gwt-aop/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
   <artifactId>gwt-aop</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/gwt-common/pom.xml
+++ b/frontend/webadmin/modules/gwt-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
   <artifactId>gwt-common</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/gwt-common/pom.xml
+++ b/frontend/webadmin/modules/gwt-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
   <artifactId>gwt-common</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/gwt-common/pom.xml
+++ b/frontend/webadmin/modules/gwt-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
   <artifactId>gwt-common</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/gwt-common/pom.xml
+++ b/frontend/webadmin/modules/gwt-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
   <artifactId>gwt-common</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/gwt-extension/pom.xml
+++ b/frontend/webadmin/modules/gwt-extension/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
   <artifactId>gwt-extension</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/gwt-extension/pom.xml
+++ b/frontend/webadmin/modules/gwt-extension/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
   <artifactId>gwt-extension</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/gwt-extension/pom.xml
+++ b/frontend/webadmin/modules/gwt-extension/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
   <artifactId>gwt-extension</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/gwt-extension/pom.xml
+++ b/frontend/webadmin/modules/gwt-extension/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
   <artifactId>gwt-extension</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/pom.xml
+++ b/frontend/webadmin/modules/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-all</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
   <artifactId>webadmin-modules</artifactId>
   <packaging>pom</packaging>

--- a/frontend/webadmin/modules/pom.xml
+++ b/frontend/webadmin/modules/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-all</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
   <artifactId>webadmin-modules</artifactId>
   <packaging>pom</packaging>

--- a/frontend/webadmin/modules/pom.xml
+++ b/frontend/webadmin/modules/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-all</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
   <artifactId>webadmin-modules</artifactId>
   <packaging>pom</packaging>

--- a/frontend/webadmin/modules/pom.xml
+++ b/frontend/webadmin/modules/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-all</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
   <artifactId>webadmin-modules</artifactId>
   <packaging>pom</packaging>

--- a/frontend/webadmin/modules/uicommonweb/pom.xml
+++ b/frontend/webadmin/modules/uicommonweb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.ovirt.engine.ui</groupId>
         <artifactId>webadmin-modules</artifactId>
-        <version>4.5.0.3-SNAPSHOT</version>
+        <version>4.5.0.3</version>
     </parent>
 
     <artifactId>uicommonweb</artifactId>

--- a/frontend/webadmin/modules/uicommonweb/pom.xml
+++ b/frontend/webadmin/modules/uicommonweb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.ovirt.engine.ui</groupId>
         <artifactId>webadmin-modules</artifactId>
-        <version>4.5.0.4</version>
+        <version>4.5.0.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>uicommonweb</artifactId>

--- a/frontend/webadmin/modules/uicommonweb/pom.xml
+++ b/frontend/webadmin/modules/uicommonweb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.ovirt.engine.ui</groupId>
         <artifactId>webadmin-modules</artifactId>
-        <version>4.5.0.3</version>
+        <version>4.5.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>uicommonweb</artifactId>

--- a/frontend/webadmin/modules/uicommonweb/pom.xml
+++ b/frontend/webadmin/modules/uicommonweb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.ovirt.engine.ui</groupId>
         <artifactId>webadmin-modules</artifactId>
-        <version>4.5.0.4-SNAPSHOT</version>
+        <version>4.5.0.4</version>
     </parent>
 
     <artifactId>uicommonweb</artifactId>

--- a/frontend/webadmin/modules/uicompat/pom.xml
+++ b/frontend/webadmin/modules/uicompat/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
   <artifactId>uicompat</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/uicompat/pom.xml
+++ b/frontend/webadmin/modules/uicompat/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
   <artifactId>uicompat</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/uicompat/pom.xml
+++ b/frontend/webadmin/modules/uicompat/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
   <artifactId>uicompat</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/uicompat/pom.xml
+++ b/frontend/webadmin/modules/uicompat/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
   <artifactId>uicompat</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/webadmin/pom.xml
+++ b/frontend/webadmin/modules/webadmin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>webadmin-modules</artifactId>
     <groupId>org.ovirt.engine.ui</groupId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
   <artifactId>webadmin</artifactId>
   <packaging>war</packaging>

--- a/frontend/webadmin/modules/webadmin/pom.xml
+++ b/frontend/webadmin/modules/webadmin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>webadmin-modules</artifactId>
     <groupId>org.ovirt.engine.ui</groupId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
   <artifactId>webadmin</artifactId>
   <packaging>war</packaging>

--- a/frontend/webadmin/modules/webadmin/pom.xml
+++ b/frontend/webadmin/modules/webadmin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>webadmin-modules</artifactId>
     <groupId>org.ovirt.engine.ui</groupId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
   <artifactId>webadmin</artifactId>
   <packaging>war</packaging>

--- a/frontend/webadmin/modules/webadmin/pom.xml
+++ b/frontend/webadmin/modules/webadmin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>webadmin-modules</artifactId>
     <groupId>org.ovirt.engine.ui</groupId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
   <artifactId>webadmin</artifactId>
   <packaging>war</packaging>

--- a/frontend/webadmin/pom.xml
+++ b/frontend/webadmin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>frontend-all</artifactId>
-    <version>4.5.0.3</version>
+    <version>4.5.0.4-SNAPSHOT</version>
   </parent>
   <artifactId>webadmin-all</artifactId>
   <packaging>pom</packaging>

--- a/frontend/webadmin/pom.xml
+++ b/frontend/webadmin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>frontend-all</artifactId>
-    <version>4.5.0.3-SNAPSHOT</version>
+    <version>4.5.0.3</version>
   </parent>
   <artifactId>webadmin-all</artifactId>
   <packaging>pom</packaging>

--- a/frontend/webadmin/pom.xml
+++ b/frontend/webadmin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>frontend-all</artifactId>
-    <version>4.5.0.4-SNAPSHOT</version>
+    <version>4.5.0.4</version>
   </parent>
   <artifactId>webadmin-all</artifactId>
   <packaging>pom</packaging>

--- a/frontend/webadmin/pom.xml
+++ b/frontend/webadmin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>frontend-all</artifactId>
-    <version>4.5.0.4</version>
+    <version>4.5.0.5-SNAPSHOT</version>
   </parent>
   <artifactId>webadmin-all</artifactId>
   <packaging>pom</packaging>

--- a/i18n/pom.xml
+++ b/i18n/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.ovirt.engine.i18n</groupId>
   <artifactId>i18n-tools</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>1.0.0</version>
   <packaging>jar</packaging>
 
   <name>oVirt Engine i18n tools</name>

--- a/i18n/pom.xml
+++ b/i18n/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.ovirt.engine.i18n</groupId>
   <artifactId>i18n-tools</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>oVirt Engine i18n tools</name>

--- a/mavenmake/pom.xml
+++ b/mavenmake/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.ovirt.engine</groupId>
         <artifactId>root</artifactId>
-        <version>4.5.0.3</version>
+        <version>4.5.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>make</artifactId>

--- a/mavenmake/pom.xml
+++ b/mavenmake/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.ovirt.engine</groupId>
         <artifactId>root</artifactId>
-        <version>4.5.0.3-SNAPSHOT</version>
+        <version>4.5.0.3</version>
     </parent>
 
     <artifactId>make</artifactId>

--- a/mavenmake/pom.xml
+++ b/mavenmake/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.ovirt.engine</groupId>
         <artifactId>root</artifactId>
-        <version>4.5.0.4-SNAPSHOT</version>
+        <version>4.5.0.4</version>
     </parent>
 
     <artifactId>make</artifactId>

--- a/mavenmake/pom.xml
+++ b/mavenmake/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.ovirt.engine</groupId>
         <artifactId>root</artifactId>
-        <version>4.5.0.4</version>
+        <version>4.5.0.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>make</artifactId>

--- a/ovirt-engine.spec.in
+++ b/ovirt-engine.spec.in
@@ -567,9 +567,9 @@ Requires:	%{name}-setup-plugin-vmconsole-proxy-helper = %{version}-%{release}
 Requires:	%{name}-setup-plugin-cinderlib = %{version}-%{release}
 Requires:	%{name}-setup-plugin-imageio = %{version}-%{release}
 Requires:	%{name}-dwh-setup >= 4.4.1.2
-%if !%{rhv_build}
-Requires:	ovirt-engine-keycloak-setup
-%endif
+#%if !%{rhv_build}
+#Requires:	ovirt-engine-keycloak-setup
+#%endif
 Requires:	ovirt-engine-extension-aaa-jdbc >= 1.2.0
 Requires:	openssh
 Requires:       postgresql-server >= 12.0

--- a/ovirt-engine.spec.in
+++ b/ovirt-engine.spec.in
@@ -1395,6 +1395,9 @@ fi
 %{engine_data}/setup/bin/ovirt-engine-health
 
 %changelog
+* Thu Apr 14 2022 Sandro Bonazzola <sbonazzo@redhat.com> - 4.5.0.3
+- Bump version to 4.5.0.3
+
 * Fri Apr 08 2022 Sandro Bonazzola <sbonazzo@redhat.com> - 4.5.0.2
 - Bump version to 4.5.0.2
 

--- a/ovirt-engine.spec.in
+++ b/ovirt-engine.spec.in
@@ -1395,6 +1395,9 @@ fi
 %{engine_data}/setup/bin/ovirt-engine-health
 
 %changelog
+* Tue Apr 19 2022 Sandro Bonazzola <sbonazzo@redhat.com> - 4.5.0.4
+- Bump version to 4.5.0.4
+
 * Thu Apr 14 2022 Sandro Bonazzola <sbonazzo@redhat.com> - 4.5.0.3
 - Bump version to 4.5.0.3
 

--- a/packaging/ansible-runner-service-project/project/roles/ovirt-host-deploy-vdsm/tasks/configure.yml
+++ b/packaging/ansible-runner-service-project/project/roles/ovirt-host-deploy-vdsm/tasks/configure.yml
@@ -64,9 +64,9 @@
   command: vdsm-tool configure --force
   changed_when: True
 
-- name: Verify fapolicyd.rules file
+- name: Check existence of /etc/fapolicyd/rules.d directory
   stat:
-    path: /etc/fapolicyd/fapolicyd.rules
+    path: /etc/fapolicyd/rules.d
   register: fapolicy_rules
 
 - name: collect facts about system services

--- a/packaging/ansible-runner-service-project/project/roles/ovirt-host-deploy-vdsm/tasks/configure.yml
+++ b/packaging/ansible-runner-service-project/project/roles/ovirt-host-deploy-vdsm/tasks/configure.yml
@@ -64,6 +64,11 @@
   command: vdsm-tool configure --force
   changed_when: True
 
+- name: Verify fapolicyd.rules file
+  stat:
+    path: /etc/fapolicyd/fapolicyd.rules
+  register: fapolicy_rules
+
 - name: collect facts about system services
   service_facts:
 
@@ -84,6 +89,6 @@
      name: fapolicyd
 
   when:
-    - ansible_distribution == 'RedHat'
+    - fapolicy_rules.stat.exists
     - "'fapolicyd.service' in services"
     - ansible_facts.services["fapolicyd.service"].state == 'running'

--- a/packaging/setup/ovirt_engine_setup/engine/constants.py
+++ b/packaging/setup/ovirt_engine_setup/engine/constants.py
@@ -234,22 +234,6 @@ class FileLocations(object):
         'nssdb',
     )
 
-    ANSIBLE_RUNNER_SERVICE_CONF = os.path.join(
-        SYSCONFDIR,
-        'ansible-runner-service',
-        'config.yaml',
-    )
-
-    ANSIBLE_RUNNER_SERVICE_PROJECT = os.path.join(
-        OVIRT_ENGINE_DATADIR,
-        'ansible-runner-service-project',
-    )
-
-    ANSIBLE_RUNNER_PROJECT = os.path.join(
-        OVIRT_ENGINE_LOCALSTATEDIR,
-        'ansible-runner-project',
-    )
-
     DIR_HTTPD = os.path.join(
         SYSCONFDIR,
         'httpd',
@@ -264,12 +248,6 @@ class FileLocations(object):
         DIR_WWW,
         'runnner',
         'runner.wsgi',
-    )
-
-    HTTPD_CONF_ANSIBLE_RUNNER_SERVICE = os.path.join(
-        DIR_HTTPD,
-        'conf.d',
-        'zz-ansible-runner-service.conf',
     )
 
     HTTPD_CONF_OVIRT_ENGINE = os.path.join(

--- a/packaging/setup/ovirt_engine_setup/engine/constants.py
+++ b/packaging/setup/ovirt_engine_setup/engine/constants.py
@@ -244,10 +244,10 @@ class FileLocations(object):
         'www',
     )
 
-    HTTPD_RUNNER_WSGI_SCRIPT = os.path.join(
-        DIR_WWW,
-        'runnner',
-        'runner.wsgi',
+    HTTPD_CONF_ANSIBLE_RUNNER_SERVICE = os.path.join(
+        DIR_HTTPD,
+        'conf.d',
+        'zz-ansible-runner-service.conf',
     )
 
     HTTPD_CONF_OVIRT_ENGINE = os.path.join(
@@ -344,8 +344,6 @@ class Defaults(object):
     DEFAULT_CONFIG_STORAGE_IS_LOCAL = False
 
     DEFAULT_CLEAR_TASKS_WAIT_PERIOD = 20
-
-    DEFAULT_ANSIBLE_RUNNER_SERVICE_PORT = '50001'
 
     DEFAULT_DB_HOST = 'localhost'
     DEFAULT_DB_PORT = 5432

--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/apache/__init__.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/apache/__init__.py
@@ -12,16 +12,16 @@
 
 from otopi import util
 
+from . import ars_cleanup
 from . import engine
 from . import root
-from . import runner
 
 
 @util.export
 def createPlugins(context):
     engine.Plugin(context=context)
     root.Plugin(context=context)
-    runner.Plugin(context=context)
+    ars_cleanup.Plugin(context=context)
 
 
 # vim: expandtab tabstop=4 shiftwidth=4

--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/apache/__init__.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/apache/__init__.py
@@ -14,12 +14,14 @@ from otopi import util
 
 from . import engine
 from . import root
+from . import runner
 
 
 @util.export
 def createPlugins(context):
     engine.Plugin(context=context)
     root.Plugin(context=context)
+    runner.Plugin(context=context)
 
 
 # vim: expandtab tabstop=4 shiftwidth=4

--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/apache/ars_cleanup.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/apache/ars_cleanup.py
@@ -7,7 +7,7 @@
 #
 
 
-"""Apache ansible-runner plugin."""
+"""Apache ansible-runner-service cleanup plugin."""
 
 
 import gettext
@@ -29,7 +29,7 @@ def _(m):
 
 @util.export
 class Plugin(plugin.PluginBase):
-    """Cleanup of the ansible-runner plugin."""
+    """Apache ansible-runner-service cleanup plugin."""
 
     def __init__(self, context):
         super(Plugin, self).__init__(context=context)

--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/apache/runner.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/apache/runner.py
@@ -1,0 +1,86 @@
+#
+# ovirt-engine-setup -- ovirt engine setup
+#
+# Copyright oVirt Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+
+
+"""Apache ansible-runner plugin."""
+
+
+import gettext
+import os
+
+from otopi import constants as otopicons
+from otopi import plugin
+from otopi import util
+
+from ovirt_engine_setup import constants as osetupcons
+from ovirt_engine_setup.engine import constants as oenginecons
+from ovirt_engine_setup.engine_common import constants as oengcommcons
+from ovirt_engine_setup.transactions import RemoveFileTransaction
+
+
+def _(m):
+    return gettext.dgettext(message=m, domain='ovirt-engine-setup')
+
+
+@util.export
+class Plugin(plugin.PluginBase):
+    """Cleanup of the ansible-runner plugin."""
+
+    def __init__(self, context):
+        super(Plugin, self).__init__(context=context)
+
+    @plugin.event(
+        stage=plugin.Stages.STAGE_MISC,
+        condition=lambda self: self.environment[
+            oenginecons.CoreEnv.ENABLE
+        ] and not self.environment[
+            osetupcons.CoreEnv.DEVELOPER_MODE
+        ] and os.path.exists(
+            oenginecons.FileLocations.HTTPD_CONF_ANSIBLE_RUNNER_SERVICE
+        ),
+    )
+    def _misc(self):
+        if not self._can_remove(
+            oenginecons.FileLocations.HTTPD_CONF_ANSIBLE_RUNNER_SERVICE
+        ):
+            return
+
+        self.environment[oengcommcons.ApacheEnv.NEED_RESTART] = True
+
+        self.environment[otopicons.CoreEnv.MAIN_TRANSACTION].append(
+            RemoveFileTransaction(
+                oenginecons.FileLocations.HTTPD_CONF_ANSIBLE_RUNNER_SERVICE
+            )
+        )
+
+    def _can_remove(self, installed_file):
+        """
+        Return True if installed_file can be removed safely. Return False if
+        the file was not installed by previous setup, or was changed.
+        """
+        uninstall_info = self.environment[
+            osetupcons.CoreEnv.UNINSTALL_FILES_INFO
+        ].get(installed_file)
+
+        # Did we install this file?
+        if not uninstall_info:
+            return False
+
+        # Did it change since we installed it?
+        if uninstall_info.get("changed"):
+            self.logger.warn(
+                _(
+                    "Cannot remove {}, file was changed"
+                ).format(installed_file)
+            )
+            return False
+
+        return True
+
+
+# vim: expandtab tabstop=4 shiftwidth=4

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.ovirt.engine</groupId>
   <artifactId>root</artifactId>
-  <version>4.5.0.4-SNAPSHOT</version>
+  <version>4.5.0.4</version>
   <packaging>pom</packaging>
   <name>ovirt-root</name>
   <description>oVirt Engine Root Project</description>
@@ -773,7 +773,7 @@
             <dependency>
               <groupId>org.ovirt.engine</groupId>
               <artifactId>ovirt-findbugs-filters</artifactId>
-              <version>4.5.0.4-SNAPSHOT</version>
+              <version>4.5.0.4</version>
             </dependency>
           </dependencies>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.ovirt.engine</groupId>
   <artifactId>root</artifactId>
-  <version>4.5.0.4</version>
+  <version>4.5.0.5-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>ovirt-root</name>
   <description>oVirt Engine Root Project</description>
@@ -773,7 +773,7 @@
             <dependency>
               <groupId>org.ovirt.engine</groupId>
               <artifactId>ovirt-findbugs-filters</artifactId>
-              <version>4.5.0.4</version>
+              <version>4.5.0.5-SNAPSHOT</version>
             </dependency>
           </dependencies>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.ovirt.engine</groupId>
   <artifactId>root</artifactId>
-  <version>4.5.0.3</version>
+  <version>4.5.0.4-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>ovirt-root</name>
   <description>oVirt Engine Root Project</description>
@@ -773,7 +773,7 @@
             <dependency>
               <groupId>org.ovirt.engine</groupId>
               <artifactId>ovirt-findbugs-filters</artifactId>
-              <version>4.5.0.3</version>
+              <version>4.5.0.4-SNAPSHOT</version>
             </dependency>
           </dependencies>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.ovirt.engine</groupId>
   <artifactId>root</artifactId>
-  <version>4.5.0.3-SNAPSHOT</version>
+  <version>4.5.0.3</version>
   <packaging>pom</packaging>
   <name>ovirt-root</name>
   <description>oVirt Engine Root Project</description>
@@ -773,7 +773,7 @@
             <dependency>
               <groupId>org.ovirt.engine</groupId>
               <artifactId>ovirt-findbugs-filters</artifactId>
-              <version>4.5.0.3-SNAPSHOT</version>
+              <version>4.5.0.3</version>
             </dependency>
           </dependencies>
         </plugin>


### PR DESCRIPTION
When importing a template from OVA we don't go through ImportVmTemplateFromConfiguration and therefore getImageToAvailableStorageDomains() returns an empty map and later we fail with NPE.

This patch changes the fix for https://bugzilla.redhat.com/2043124 to be specific for ImportVmTemplateFromConfiguration and so other import-template flows would not face this issue.

Bug-Url: https://bugzilla.redhat.com/2074916