### PR TITLE
intl: Add missing localized enum

### DIFF
--- a/frontend/webadmin/modules/uicompat/src/main/java/org/ovirt/engine/ui/uicompat/LocalizedEnums.java
+++ b/frontend/webadmin/modules/uicompat/src/main/java/org/ovirt/engine/ui/uicompat/LocalizedEnums.java
@@ -1393,6 +1393,8 @@ public interface LocalizedEnums extends ConstantsWithLookup {
 
     String NfsVersion___V4_1();
 
+    String NfsVersion___V4_2();
+
     String NfsVersion___AUTO();
 
     String StorageFormatType___V1();


### PR DESCRIPTION
When testing engine UI with Selenium in the Firefox console we can see:

 console.warn: "Mon Apr 25 13:07:02 GMT+000 2022 org.ovirt.engine.ui.uicompat.EnumTranslator
                WARNING: Missing Enum resource 'V4_2'. Cannot find constant 'NfsVersion___V4_2';
                expecting a method name"

Let's add the java enum entry to match the one defined in the properties
file [1].

[1] https://github.com/oVirt/ovirt-engine/blob/27a8d1c3f678ef9efc9a300da8cc3c8a8c1afef0/frontend/webadmin/modules/uicompat/src/main/resources/org/ovirt/engine/ui/uicompat/LocalizedEnums.properties#L620

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
