### PR TITLE
spec: Require postgresql-jdbc < 42.2.14

### DIFF
--- a/ovirt-engine.spec.in
+++ b/ovirt-engine.spec.in
@@ -364,7 +364,7 @@ Requires:	libfastjson
 Requires:	liblognorm
 Requires:	libestr
 
-Requires:	postgresql-jdbc >= 42.2.3
+Requires:	postgresql-jdbc >= 42.2.3, postgresql-jdbc < 42.2.14
 
 Requires:	postgresql-server >= 12.0
 Requires:	postgresql-contrib >= 12.0


### PR DESCRIPTION
There is some issue with recent versions of postgresql-jdbc, TBD. For
now, just require an older version, until this is solved.

Change-Id: I4fe0594edf0302297c0df05e2f04eae599d14014
Bug-Url: https://bugzilla.redhat.com/2077794
Signed-off-by: Yedidyah Bar David <didi@redhat.com>