### PR TITLE
Block on execution of ImportVmFromConfiguration

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/VmCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/VmCommand.java
@@ -545,9 +545,8 @@ public abstract class VmCommand<T extends VmOperationParameterBase> extends Comm
         VmLeaseParameters params = new VmLeaseParameters(getStoragePoolId(), leaseStorageDomainId, vmId);
         params.setParentCommand(getActionType());
         params.setParentParameters(getParameters());
-        if (getParameters().getEntityInfo() == null) {
-            getParameters().setEntityInfo(new EntityInfo(VdcObjectType.VM, vmId));
-        }
+        params.setEntityInfo(getParameters().getEntityInfo() != null ? getParameters().getEntityInfo()
+                : new EntityInfo(VdcObjectType.VM, vmId));
         ActionReturnValue returnValue = runInternalActionWithTasksContext(ActionType.RemoveVmLease, params);
         if (returnValue.getSucceeded()) {
             getTaskIdList().addAll(returnValue.getInternalVdsmTaskIdList());
@@ -576,9 +575,8 @@ public abstract class VmCommand<T extends VmOperationParameterBase> extends Comm
         }
         params.setParentCommand(getActionType());
         params.setParentParameters(getParameters());
-        if (getParameters().getEntityInfo() == null) {
-            getParameters().setEntityInfo(new EntityInfo(VdcObjectType.VM, vmId));
-        }
+        params.setEntityInfo(getParameters().getEntityInfo() != null ? getParameters().getEntityInfo()
+                : new EntityInfo(VdcObjectType.VM, vmId));
         ActionReturnValue returnValue = runInternalActionWithTasksContext(ActionType.AddVmLease, params);
         if (returnValue.getSucceeded()) {
             getTaskIdList().addAll(returnValue.getInternalVdsmTaskIdList());


### PR DESCRIPTION
we don't normally to this but in case of ImportVmFromConfiguration it makes
some sense to invoke it as a blocking (sync) operation since it doesn't involve
disk operation so if may only have async operation related to vm leases which are
relatively quick. The main reason to do this is that some backup applications
relied on getting Created response and can't cope with Accepted but it also makes
to do that because it is often the case that clients try to start the VM right
after the execution of ImportVmFromConfiguration is completed.

Bug-Url: https://bugzilla.redhat.com/2074112
Signed-off-by: Arik Hadas <ahadas@redhat.com>