### PR TITLE
restapi: prefer parentType over subclasses in getParent

### DIFF
--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/util/LinkHelper.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/util/LinkHelper.java
@@ -225,18 +225,26 @@ public class LinkHelper {
      * @return           the parent object, or null if not set
      */
     private static <R extends BaseResource> BaseResource getParent(R model, Class<?> parentType) {
+        Object assignedFromParent = null;
+
+        // Try to match a method whose parent matches parentType first, only fallback to a subclass if parentType was
+        // not found in the list.
         for (Method method : getRelevantMethods(model.getClass())) {
             try {
                 Object potentialParent = method.invoke(model);
+                if (potentialParent != null && potentialParent.getClass().equals(parentType)) {
+                    return (BaseResource) potentialParent;
+                }
                 if (potentialParent != null && parentType.isAssignableFrom(potentialParent.getClass())) {
-                    return (BaseResource)potentialParent;
+                    assignedFromParent = potentialParent;
                 }
             } catch (Exception e) {
                 log.error("Error invoking method when adding links to an API entity", e);
                 continue;
             }
         }
-        return null;
+
+        return (BaseResource) assignedFromParent;
     }
 
     /**


### PR DESCRIPTION
Currently [LinkHelper#getParent](https://github.com/oVirt/ovirt-engine/blob/6e6ea81436587e6b936de02f0fc1cc48b2544a66/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/util/LinkHelper.java#L227-L240) may return subclasses even if the parentType exists in the methods list. This makes the returned resource unpredictable as the method list does not have any guaranteed order.
To fix this, this patch tries to match parentType first, and only if it is not in the list it will fallback to a subclass.

In the bug the parent is `Vm`, but since `Backup` also has a reference to the `Snapshot` model it may be chosen over the suggested `parentType` because it's a subclass of `Vm`.

Bug-Url: https://bugzilla.redhat.com/2080728
