### PR TITLE
Improve certificate renewal

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/host/HostUpgradeManager.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/host/HostUpgradeManager.java
@@ -155,7 +155,7 @@ public class HostUpgradeManager implements UpdateAvailable, Updateable {
     private void setAnsibleCommandConfigVars(AnsibleCommandConfig command, final VDS host) {
         //The number of days allowed before certificate expiration.
         //(less time left than this requires enrolling for new certificate).
-        Integer daysAllowedUntilExpiration = Config.<Integer> getValue(ConfigValues.CertExpirationAlertPeriodInDays);
+        Integer daysAllowedUntilExpiration = Config.<Integer> getValue(ConfigValues.CertExpirationWarnPeriodInDays);
         //The date in the future (in seconds), against which to validate the certificates.
         //For example if we allow certificates which expire in 7 days or more, this
         //variable will contain a seconds-since-1/1/1970 representation 7 days from the current moment.

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/validator/HostValidator.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/validator/HostValidator.java
@@ -162,7 +162,8 @@ public class HostValidator {
 
     public ValidationResult validateStatusForEnrollCertificate() {
         return ValidationResult.failWith(EngineMessage.CANNOT_ENROLL_CERTIFICATE_HOST_STATUS_ILLEGAL)
-                .unless(host.getStatus() == VDSStatus.Maintenance || host.getStatus() == VDSStatus.InstallFailed);
+                .unless(host.getStatus() == VDSStatus.Maintenance || host.getStatus() == VDSStatus.InstallFailed
+                        || host.getStatus() == VDSStatus.NonResponsive);
     }
 
     public ValidationResult supportsDeployingHostedEngine(HostedEngineDeployConfiguration heConfig,

--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/hosts/HostListModel.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/hosts/HostListModel.java
@@ -1713,8 +1713,10 @@ public class HostListModel<E> extends ListWithSimpleDetailsModel<E, VDS> impleme
         getApproveCommand().setIsExecutionAllowed(approveAvailability);
 
         boolean installAvailability = false;
+        boolean nonResponsive = false;
         if (singleHostSelected(items)) {
             VDS host = items.get(0);
+            nonResponsive = host.getStatus() == VDSStatus.NonResponsive;
             installAvailability = host.getStatus() == VDSStatus.InstallFailed ||
                     host.getStatus() == VDSStatus.Maintenance;
         }
@@ -1736,7 +1738,7 @@ public class HostListModel<E> extends ListWithSimpleDetailsModel<E, VDS> impleme
             upgradeAvailability = canUpgradeHost(host);
         }
         getUpgradeCommand().setIsExecutionAllowed(upgradeAvailability);
-        getEnrollCertificateCommand().setIsExecutionAllowed(installAvailability);
+        getEnrollCertificateCommand().setIsExecutionAllowed(installAvailability || nonResponsive);
 
         getMaintenanceCommand().setIsExecutionAllowed(items.size() > 0
                 && ActionUtils.canExecute(items, VDS.class, ActionType.MaintenanceVds));

--- a/packaging/ansible-runner-service-project/project/ovirt-host-upgrade.yml
+++ b/packaging/ansible-runner-service-project/project/ovirt-host-upgrade.yml
@@ -35,6 +35,8 @@
           - 'ca': "{{ ovirt_vdsm_trust_store }}/{{ ovirt_vdsm_spice_ca_file }}"
             'cert': "{{ ovirt_vdsm_trust_store }}/{{ ovirt_vdsm_spice_cert_file }}"
         register: iscorrect
+        # If the certificate is invalid, an error code is returned and we must proceed, not stop.
+        ignore_errors: yes
 
       - name: Get host certificate info
         command: openssl x509 -noout -ext subjectAltName -in "{{ ovirt_vdsm_trust_store }}/{{ ovirt_vdsm_cert_file }}"

--- a/packaging/ansible-runner-service-project/project/roles/ovirt-host-deploy-ovn-certificates/tasks/main.yml
+++ b/packaging/ansible-runner-service-project/project/roles/ovirt-host-deploy-ovn-certificates/tasks/main.yml
@@ -69,6 +69,19 @@
       mode: 0440
       remote_src: yes
 
+  - name: Populate service facts
+    service_facts:
+
+  - name: Restart OVN services
+    service:
+      name: "{{ item }}"
+      state: restarted
+    loop:
+      - openvswitch.service
+      - openvswitch-ipsec.service
+      - ovn-controller.service
+    when: "ansible_facts.services.get(item, {}).get('status') == 'enabled'"
+
   always:
     - name: Remove temp file
       file:

--- a/packaging/ansible-runner-service-project/project/roles/ovirt-host-deploy-vdsm-certificates/tasks/main.yml
+++ b/packaging/ansible-runner-service-project/project/roles/ovirt-host-deploy-vdsm-certificates/tasks/main.yml
@@ -165,6 +165,18 @@
       dest: "{{ ovirt_vdsm_trust_store }}/{{ ovirt_qemu_client_key_file }}"
       state: link
 
+  - name: Populate service facts
+    service_facts:
+
+  - name: Restart services
+    service:
+      name: "{{ item }}"
+      state: restarted
+    loop:
+      - libvirtd.service
+      - ovirt-imageio.service
+    when: "ansible_facts.services.get(item, {}).get('status') == 'enabled' or ansible_facts.services.get(item, {}).get('state') == 'running'""
+
   always:
     - name: Remove temp file
       file:

--- a/packaging/bin/pki-enroll-openssh-cert.sh
+++ b/packaging/bin/pki-enroll-openssh-cert.sh
@@ -68,7 +68,7 @@ ID=""
 HOST=""
 PRINCIPALS=""
 OPTIONS="clear,permit-pty"
-DAYS="398"
+DAYS="1827"
 while [ -n "$1" ]; do
 	x="$1"
 	v="${x#*=}"

--- a/packaging/dbscripts/upgrade/pre_upgrade/0000_config.sql
+++ b/packaging/dbscripts/upgrade/pre_upgrade/0000_config.sql
@@ -647,7 +647,7 @@ select fn_db_add_config_value('VdsRefreshRate','2','general');
 select fn_db_add_config_value('vdsRetries','0','general');
 select fn_db_add_config_value('vdsTimeout','180','general');
 select fn_db_add_config_value('WindowsGuestAgentUpdateCheckInternal', '180', 'general');
-select fn_db_add_config_value('VdsCertificateValidityInDays','398','general');
+select fn_db_add_config_value('VdsCertificateValidityInDays','1827','general');
 --Handling Virtual Machine Domain Name
 select fn_db_add_config_value_for_versions_up_to('VM32BitMaxMemorySizeInMB','20480','4.7');
 select fn_db_add_config_value_for_versions_up_to('VM64BitMaxMemorySizeInMB','6291456','4.5');
@@ -1412,6 +1412,9 @@ select fn_db_update_default_config_value('NvramPersistenceSupported', 'false', '
 
 -- Increase default ServerRebootTimeout from 5 to 10 minutes
 select fn_db_update_default_config_value('ServerRebootTimeout', '300', '600', 'general', false);
+
+-- Increase the lifetime of VDS certificates from 398 to 3650 days
+select fn_db_update_default_config_value('VdsCertificateValidityInDays', '398', '1827', 'general', false);
 
 ------------------------------------------------------------------------------------
 --                  Split config section

--- a/packaging/dbscripts/upgrade/pre_upgrade/0000_config.sql
+++ b/packaging/dbscripts/upgrade/pre_upgrade/0000_config.sql
@@ -858,7 +858,7 @@ select fn_db_add_config_value('BootstrapCommand',
 select fn_db_add_config_value('BootstrapPackageDirectory', '/usr/share/ovirt-host-deploy/interface-3', 'general');
 select fn_db_add_config_value('BootstrapPackageName', 'ovirt-host-deploy.tar', 'general');
 select fn_db_add_config_value('CertExpirationAlertPeriodInDays', '30', 'general');
-select fn_db_add_config_value('CertExpirationWarnPeriodInDays', '120', 'general');
+select fn_db_add_config_value('CertExpirationWarnPeriodInDays', '365', 'general');
 select fn_db_add_config_value('DBI18NPrefix', '', 'general');
 select fn_db_add_config_value('DBLikeSyntax', 'ILIKE', 'general');
 select fn_db_add_config_value('DBPagingSyntax', ' WHERE RowNum BETWEEN %1$s AND %2$s', 'general');
@@ -1311,7 +1311,7 @@ select fn_db_update_config_value('ServerCPUList',
 select fn_db_update_config_value('AgentAppName','ovirt-guest-agent-common,ovirt-guest-agent,qemu-guest-agent','general');
 
 select fn_db_update_config_value('CertExpirationAlertPeriodInDays', '30', 'general');
-select fn_db_update_config_value('CertExpirationWarnPeriodInDays', '120', 'general');
+select fn_db_update_config_value('CertExpirationWarnPeriodInDays', '365', 'general');
 
 ------------------------------------------------------------------------------------
 --   Update only if default not changed section

--- a/packaging/etc/engine-config/engine-config.properties
+++ b/packaging/etc/engine-config/engine-config.properties
@@ -604,3 +604,5 @@ CertExpirationAlertPeriodInDays.description=Number of days to issue alerts befor
 CertExpirationAlertPeriodInDays.type=Integer
 CertExpirationWarnPeriodInDays.description=Number of days to issue warnings before certificate expiration and to renew the certificate on host upgrades.
 CertExpirationWarnPeriodInDays.type=Integer
+VdsCertificateValidityInDays.description=Number of days which the hypervisor certificate is valid for.
+VdsCertificateValidityInDays.type=Integer

--- a/packaging/etc/engine-config/engine-config.properties
+++ b/packaging/etc/engine-config/engine-config.properties
@@ -600,3 +600,7 @@ RemainingMacsInPoolWarningThreshold.description="Determines the number of remain
 RemainingMacsInPoolWarningThreshold.type=Integer
 IsDedicatedSupported.description=Enable dedicated CPU pinning policy support.
 IsDedicatedSupported.type=Boolean
+CertExpirationAlertPeriodInDays.description=Number of days to issue alerts before certificate expiration.
+CertExpirationAlertPeriodInDays.type=Integer
+CertExpirationWarnPeriodInDays.description=Number of days to issue warnings before certificate expiration and to renew the certificate on host upgrades.
+CertExpirationWarnPeriodInDays.type=Integer


### PR DESCRIPTION
This should fix some of the problems that users not paying proper attention to certificate expiration warnings and alerts may experience:
- Host certificate lifetimes are much longer now.
- Host certificates are renewed much earlier on host upgrade now.
- Enrolling host certificates in host upgrade actually works.
- It is possible to enroll certificates now when a host is non-responsive.
- ovn-controller is restarted after enrolling certificates.

**Read the corresponding commit messages for more details.**

Not renewing some of the vmconsole certificates will be handled in a separate PR later.

Related bugs:
- https://bugzilla.redhat.com/2079890
- https://bugzilla.redhat.com/2079835
- https://bugzilla.redhat.com/2079901