### PR TITLE
webadmin: Fix reseting of graphics

### DIFF
--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/ListModel.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/ListModel.java
@@ -142,10 +142,23 @@ public class ListModel<T> extends Model {
     }
 
     public ListModel() {
+        initChangeEvents();
+        initSelectionModels(isSingleSelectionOnly() ? OvirtSelectionModel.Mode.SINGLE_SELECTION : OvirtSelectionModel.Mode.MULTI_SELECTION);
+    }
+
+    public ListModel(OvirtSelectionModel.Mode selectionMode) {
+        initChangeEvents();
+        initSelectionModels(selectionMode);
+    }
+
+    private void initChangeEvents() {
         setSelectedItemChangedEvent(new Event<>(selectedItemChangedEventDefinition));
         setSelectedItemsChangedEvent(new Event<>(selectedItemsChangedEventDefinition));
         setItemsChangedEvent(new Event<>(itemsChangedEventDefinition));
-        this.selectionModel = new OvirtSelectionModel<>(isSingleSelectionOnly());
+    }
+
+    private void initSelectionModels(OvirtSelectionModel.Mode selectionMode) {
+        this.selectionModel = new OvirtSelectionModel<>(selectionMode);
         this.selectionModel.setDataDisplay(new HasDataMinimalDelegate<T>() {
             @Override
             public Iterable<T> getVisibleItems() {
@@ -347,7 +360,7 @@ public class ListModel<T> extends Model {
         return true;
     }
 
-    private final OvirtSelectionModel<T> selectionModel;
+    private OvirtSelectionModel<T> selectionModel;
 
     public OvirtSelectionModel<T> getSelectionModel() {
         return selectionModel;
@@ -359,9 +372,11 @@ public class ListModel<T> extends Model {
      * setSelectedItems.
      */
     private void synchronizeSelection() {
-        if (isSingleSelectionOnly()) {
+        switch (selectionModel.getMode()) {
+        case SINGLE_SELECTION:
             setSelectedItem(selectionModel.asSingleSelectionModel().getSelectedObject());
-        } else {
+            break;
+        case MULTI_SELECTION:
             List<T> selectedItems = selectionModel.getSelectedObjects();
             setSelectedItems(selectedItems);
             if (selectedItems.size() == 1) {
@@ -369,6 +384,9 @@ public class ListModel<T> extends Model {
             } else if (selectedItems.size() == 0) {
                 setSelectedItem(null);
             }
+            break;
+        default:
+            break;
         }
     }
 

--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/OvirtSelectionModel.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/OvirtSelectionModel.java
@@ -20,7 +20,7 @@ import com.google.gwt.view.client.SingleSelectionModel;
  */
 public class OvirtSelectionModel<T> implements SelectionModel<T> {
 
-    private enum Mode {
+    public enum Mode {
         SINGLE_SELECTION,
         MULTI_SELECTION,
         NO_SELECTION
@@ -29,19 +29,28 @@ public class OvirtSelectionModel<T> implements SelectionModel<T> {
     private final SelectionModel<T> delegate;
     private final Mode mode;
 
-    public OvirtSelectionModel(boolean singleSelectionOnly) {
-        this.mode = singleSelectionOnly ? Mode.SINGLE_SELECTION : Mode.MULTI_SELECTION;
-        this.delegate = singleSelectionOnly
-                ? new SingleSelectionModel<>(new QueryableEntityKeyProvider<>())
-                : new OrderedMultiSelectionModel<>(new QueryableEntityKeyProvider<>());
-
-    }
-
     public OvirtSelectionModel() {
-        this.mode = Mode.NO_SELECTION;
-        this.delegate = new NoSelectionModel<>();
+        this(Mode.NO_SELECTION);
     }
 
+    public OvirtSelectionModel(Mode mode) {
+        this.mode = mode;
+        switch (mode) {
+        case SINGLE_SELECTION:
+            this.delegate = new SingleSelectionModel<>(new QueryableEntityKeyProvider<>());
+            break;
+        case MULTI_SELECTION:
+            this.delegate = new OrderedMultiSelectionModel<>(new QueryableEntityKeyProvider<>());
+            break;
+        default:
+            this.delegate = new NoSelectionModel<>();
+            break;
+        }
+    }
+
+    public Mode getMode() {
+        return mode;
+    }
 
     @Override
     public HandlerRegistration addSelectionChangeHandler(Handler handler) {


### PR DESCRIPTION
When the BIOS type changed, the graphics list was always reset even though the video type stayed the same.

This was because the setting of the items and selected item was separated in https://gerrit.ovirt.org/c/ovirt-engine/+/118132

This patch goes back to setting the items and selected item at once but making sure that the selection model is not
used to avoid issues fixed by https://gerrit.ovirt.org/c/ovirt-engine/+/118132

Bug-Url: https://bugzilla.redhat.com/2078193