### PR TITLE
certificates: Extend the lifetime of non-web Engine certificates

### DIFF
--- a/packaging/bin/pki-enroll-pkcs12.sh
+++ b/packaging/bin/pki-enroll-pkcs12.sh
@@ -9,6 +9,7 @@ enroll() {
 	local ovirt_san="$6"
 	local keep_key="$7"
 	local ca_file="$8"
+	local days="$9"
 
 	local req="${PKIDIR}/requests/${name}.req"
 	local cert="${PKIDIR}/certs/${name}.cer"
@@ -54,6 +55,7 @@ enroll() {
 		--eku="${ovirt_eku}" \
 		--san="${ovirt_san}" \
 		--ca-file="${ca_file}" \
+		--days="${days}" \
 		|| die "Cannot sign request"
 
 	touch "${pkcs12}"
@@ -86,6 +88,7 @@ Result will be at ${PKIDIR}/keys/PREFIX.p12
     --san=san             optional X.509 subject alternative name.
     --keep-key            reissue certificate based on previous request.
     --ca-file=file-name   CA base file name without extension.
+    --days=n              issue days.
 __EOF__
 }
 
@@ -100,6 +103,7 @@ trap cleanup 0
 OVIRT_KU=""
 OVIRT_EKU=""
 CA_FILE=ca
+DAYS=1827
 while [ -n "$1" ]; do
 	x="$1"
 	v="${x#*=}"
@@ -129,6 +133,9 @@ while [ -n "$1" ]; do
 		--ca-file=*)
 			CA_FILE="${v}"
 		;;
+		--days=*)
+			DAYS="${v}"
+		;;
 		--help)
 			usage
 			exit 0
@@ -144,4 +151,4 @@ done
 [ -n "${PASSWORD}" ] || die "Please specify password"
 [ -n "${SUBJECT}" ] || die "Please specify subject"
 
-enroll "${NAME}" "${PASSWORD}" "${SUBJECT}" "${OVIRT_KU}" "${OVIRT_EKU}" "${OVIRT_SAN}" "${KEEP_KEY}" "${CA_FILE}"
+enroll "${NAME}" "${PASSWORD}" "${SUBJECT}" "${OVIRT_KU}" "${OVIRT_EKU}" "${OVIRT_SAN}" "${KEEP_KEY}" "${CA_FILE}" "${DAYS}"

--- a/packaging/bin/pki-enroll-request.sh
+++ b/packaging/bin/pki-enroll-request.sh
@@ -72,7 +72,7 @@ trap cleanup 0
 NAME=""
 SUBJECT=""
 TIMEOUT="20"
-DAYS="398"
+DAYS="1827"
 OVIRT_KU=""
 OVIRT_EKU=""
 CA_FILE=ca

--- a/packaging/setup/ovirt_engine_setup/engine_common/pki_utils.py
+++ b/packaging/setup/ovirt_engine_setup/engine_common/pki_utils.py
@@ -88,20 +88,6 @@ def cert_has_SAN(logger, x509cert):
     return res
 
 
-def cert_validity_period_short_enough(logger, x509cert):
-    # input: x509cert: cryptography.x509.Certificate object
-    # return: bool
-    before = x509cert.not_valid_before
-    after = x509cert.not_valid_after
-    validity_in_days = ((after - before).days) - 1
-    logger.debug(
-        f"Certificate's validity is {validity_in_days} days. "
-        "HTTPS certificate validity shouldn't be longer than 398 days"
-    )
-    # HTTPS certificate validity shouldn't be longer than 398 days
-    return validity_in_days <= 398
-
-
 def ok_to_renew_cert(logger, x509cert, ca_cert, name, extract):
     # input:
     # - x509cert: cryptography.x509.Certificate object
@@ -112,8 +98,7 @@ def ok_to_renew_cert(logger, x509cert, ca_cert, name, extract):
     res = False
     if x509cert and (
         cert_expires(x509cert) or
-        not cert_has_SAN(logger, x509cert) or
-        not cert_validity_period_short_enough(logger, x509cert)
+        not cert_has_SAN(logger, x509cert)
     ):
         if not extract or ca_cert is None:
             # In remote machines (websocket-proxy/grafana), we do not

--- a/packaging/setup/plugins/ovirt-engine-rename/ovirt-engine/pki.py
+++ b/packaging/setup/plugins/ovirt-engine-rename/ovirt-engine/pki.py
@@ -231,7 +231,8 @@ class Plugin(plugin.PluginBase):
                         self.environment[osetupcons.RenameEnv.FQDN],
                     ),
                 ),
-            ),
+            )
+            + (('--days=398',) if entity['shortLife'] else ())
         )
 
         self.uninstall_files.extend(

--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/network/ovirtproviderovn.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/network/ovirtproviderovn.py
@@ -514,6 +514,7 @@ class Plugin(plugin.PluginBase):
                     'extract': True,
                     'user': oengcommcons.SystemEnv.USER_ROOT,
                     'keepKey': False,
+                    'shortLife': False,
                 },
                 {
                     'name':
@@ -521,6 +522,7 @@ class Plugin(plugin.PluginBase):
                     'extract': True,
                     'user': oengcommcons.SystemEnv.USER_ROOT,
                     'keepKey': False,
+                    'shortLife': False,
                 },
                 {
                     'name':
@@ -528,6 +530,7 @@ class Plugin(plugin.PluginBase):
                     'extract': True,
                     'user': oengcommcons.SystemEnv.USER_ROOT,
                     'keepKey': False,
+                    'shortLife': False,
                 }
             )
         )

--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/pki/ca.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/pki/ca.py
@@ -220,7 +220,8 @@ class Plugin(plugin.PluginBase):
                 )
             )
 
-    def _enrollCertificate(self, name, uninstall_files, keepKey=False):
+    def _enrollCertificate(self, name, uninstall_files, keepKey=False,
+                           shortLife=False):
         self.execute(
             (
                 oenginecons.FileLocations.OVIRT_ENGINE_PKI_CA_ENROLL,
@@ -244,7 +245,9 @@ class Plugin(plugin.PluginBase):
                         self.environment[osetupcons.ConfigEnv.FQDN],
                     ),
                 ),
-            ) + (('--keep-key',) if keepKey else ())
+            )
+            + (('--keep-key',) if keepKey else ())
+            + (('--days=398',) if shortLife else ())
         )
         uninstall_files.extend(
             (
@@ -262,30 +265,35 @@ class Plugin(plugin.PluginBase):
             'extract': False,
             'user': osetupcons.SystemEnv.USER_ENGINE,
             'keepKey': True,
+            'shortLife': False,
         },
         {
             'name': 'jboss',
             'extract': False,
             'user': osetupcons.SystemEnv.USER_ENGINE,
             'keepKey': False,
+            'shortLife': False,
         },
         {
             'name': 'websocket-proxy',
             'extract': True,
             'user': osetupcons.SystemEnv.USER_ENGINE,
             'keepKey': False,
+            'shortLife': True,
         },
         {
             'name': 'apache',
             'extract': True,
             'user': oengcommcons.SystemEnv.USER_ROOT,
             'keepKey': False,
+            'shortLife': True,
         },
         {
             'name': 'reports',
             'extract': True,
             'user': oengcommcons.SystemEnv.USER_ROOT,
             'keepKey': False,
+            'shortLife': False,
         },
     )
 
@@ -346,6 +354,7 @@ class Plugin(plugin.PluginBase):
                     entry['name'],
                     uninstall_files,
                     keepKey=entry['keepKey'] and renew,
+                    shortLife=entry['shortLife'],
                 )
                 os.chown(
                     pkcs12,


### PR DESCRIPTION
Non-web certificates are not subjects to the lifetime limitations
required by web browsers.  Let’s extend the lifetime of non-web Engine
certificates to 5 years (the same value as for the host certificates)
to make the certificate updates much less frequent.

Let’s also drop the check for long certificate lifetime.  All web
certificates should already have the shortened lifetime, otherwise
they wouldn’t work with current browsers.

Bug-Url: https://bugzilla.redhat.com/2079835