### PR TITLE
build: use maven 3.6 --no-transfer-progress

### DIFF
--- a/.automation/build-srpm.sh
+++ b/.automation/build-srpm.sh
@@ -20,6 +20,7 @@ MILESTONE=master
 # GH RPM builds will be used only for OST so Firefox and Chrome are enough
 # GWT build memory needs to be limited
 EXTRA_BUILD_FLAGS=""
+EXTRA_BUILD_FLAGS="${EXTRA_BUILD_FLAGS} --no-transfer-progress"
 EXTRA_BUILD_FLAGS="${EXTRA_BUILD_FLAGS} -Dgwt.userAgent=gecko1_8,safari"
 EXTRA_BUILD_FLAGS="${EXTRA_BUILD_FLAGS} -Dgwt.compiler.localWorkers=1"
 EXTRA_BUILD_FLAGS="${EXTRA_BUILD_FLAGS} -Dgwt.jvmArgs='-Xms1G -Xmx3G'"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
 
         # Configure CS8 repositories
         dnf config-manager --enable powertools
-        dnf module enable -y pki-deps javapackages-tools
+        dnf module enable -y pki-deps javapackages-tools maven:3.6
 
     - name: Prepare CentOS Stream 9 environment
       if: ${{ matrix.shortcut == 'cs9' }}

--- a/ovirt-engine.spec.in
+++ b/ovirt-engine.spec.in
@@ -264,7 +264,7 @@ BuildArch:	noarch
 BuildRequires:  perl
 %else
 BuildRequires:	assertj-core >= 2.2.0
-BuildRequires:	maven >= 3.5.0
+BuildRequires:	maven >= 3.6.0
 BuildRequires:  maven-enforcer-plugin
 %endif
 


### PR DESCRIPTION
The github action CI build log tends to contain a large amount of
log lines for the transfer progress of downloading dependencies.
This can make a prohibitively large log file to be able to view
it on the github action page.

Use maven 3.6 and the option `--no-transfer-progress` to vastly reduce
the log output to where we can actually scroll the the bottom of the
output on the action's web page.

Note: maven is a separate module on centos 8 stream.  Copr chroot
configs will need to be checked.  Enabling at least maven 3.6 is
requried.