### PR TITLE
Mark temp repo directory as safe for COPR 

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -4,10 +4,11 @@ installdeps:
 	dnf -y install git
 
 srpm: installdeps
-	# just to debug current COPR issues
-	echo "GITHASH=$(git rev-parse --short HEAD)"
-	git log -1
+	# From git 2.35.2 we need to mark temporary directory, where the project is cloned to, as safe, otherwise
+	# git commands won't work, and the remove afterwards to make git user config clean
+	git config --global --add safe.directory $(pwd)
 	$(eval SUFFIX=$(shell sh -c "echo '.git$$(git rev-parse --short HEAD)'"))
+	git config --global --unset safe.directory $(pwd)
 	# changing the spec file as passing -D won't preserve the suffix when rebuilding in mock
 	sed "s:%{?release_suffix}:${SUFFIX}:" -i ovirt-engine.spec.in
 	mkdir -p tmp.repos/SOURCES


### PR DESCRIPTION
When building from COPR the project is cloned into temporary directory,
which is not owned by current user. From git 2.35.2 such directory needs
to be marked as safe inn order git commands work correctly.