### PR TITLE
core: fix copying from MBS to image domain

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/CopyManagedBlockDiskCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/CopyManagedBlockDiskCommand.java
@@ -167,7 +167,7 @@ public class CopyManagedBlockDiskCommand<T extends CopyImageGroupWithDataCommand
         // Attach source to host (if source is Managed Block Storage)
         // TODO: handle failures
         if (sourceDomainType == StorageDomainType.ManagedBlockStorage) {
-            String sourcePath = attachVolume(createManagedBlockDiskFromDiskImage(sourceDisk));
+            String sourcePath = attachVolume((ManagedBlockStorageDisk) sourceDisk);
             getParameters().setSourcePath(sourcePath);
         }
     }


### PR DESCRIPTION
There is no need to reconstruct the `sourceDisk` as `ManagedBlockDisk` as it is already of this type if the source domain is a Managed Block Storage Domain, and it will fail later on as the conversion method `createManagedBlockDiskFromDiskImage` assigns the target's id to the constructed object which is incorrect, as this is the source disk.