### PR TITLE
webadmin: Fix creating of a new template

### DIFF
--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/NewTemplateVmModelBehavior.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/NewTemplateVmModelBehavior.java
@@ -128,6 +128,7 @@ public class NewTemplateVmModelBehavior extends VmModelBehaviorBase<UnitVmModel>
             // it is not allowed to create sub-templates of Blank template
             getModel().getIsSubTemplate().setIsChangeable(false,
                     constants.someNonDefaultTemplateHasToExistFirst());
+            initTemplate();
             return;
         }
 


### PR DESCRIPTION
When creating a new template, the initTemplate() method is called after the list of base templates is loaded.
However, if there are no templates other than the Blank template, the list is not loaded and the initTemplate()
method is never called. As a result, the builders from VM to UnitVmModel are never called and the UnitVmModel
is not initialized properly. The attempt to create a new template fails.
![image](https://user-images.githubusercontent.com/2078072/167643337-724d9e58-74ec-478b-bb82-e977167cf527.png)
![image](https://user-images.githubusercontent.com/2078072/167643369-596a420a-9049-4de7-8880-f691f780ec8c.png)

This patch calls the initTemplate() method also for the cases when there are no base templates available and the Blank template is the only template present.