### PR TITLE
packaging: setup: Do not fail if engine package is missing

### DIFF
--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine-common/distro-rpm/packages.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine-common/distro-rpm/packages.py
@@ -462,8 +462,10 @@ class Plugin(plugin.PluginBase):
                     '--queryformat=%{version}-%{release}',
                     oenginecons.Const.ENGINE_PACKAGE_NAME,
                 ),
+                raiseOnError=False,
             )
-            engineVersion = stdout[0]
+            if rc == 0:
+                engineVersion = stdout[0]
         if (
             engineVersion is not None and
             osetupcons.Const.DISPLAY_VERSION != engineVersion


### PR DESCRIPTION
We recently merged a patch to verify that the engine and setup packages'
versions match. This fails on a separate-DWH machine. Fix.

Bug-Url: https://bugzilla.redhat.com/2083230
Change-Id: I41b06309e59bbe52dffa30ae2d0f618d9ffca97d
Signed-off-by: Yedidyah Bar David <didi@redhat.com>
(cherry picked from commit aa7bfe99ca52438c8c85341eb49b0321e6a6d9ad)