### PR TITLE
core: Use edited VM configuration when cloning

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/CloneVmCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/CloneVmCommand.java
@@ -612,6 +612,10 @@ public class CloneVmCommand<T extends CloneVmParameters> extends AddVmAndCloneIm
     }
 
     private void setupParameters() {
+        if (getParameters().isEdited()) {
+            getParameters().setEditedVm(getParameters().getVm());
+        }
+
         setVmId(Guid.newGuid());
         getParameters().setNewVmGuid(getVmId());
         VM vmToClone = getVm();
@@ -668,7 +672,7 @@ public class CloneVmCommand<T extends CloneVmParameters> extends AddVmAndCloneIm
     }
 
     private VmManagementParametersBase createUpdateVmParameters() {
-        VM editedVM = getParameters().getVm();
+        VM editedVM = getParameters().getEditedVm();
         editedVM.setId(getVmId());
         editedVM.setVmCreationDate(getVm().getVmCreationDate());
         editedVM.setCreatedByUserId(getVm().getCreatedByUserId());

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/CloneVmParameters.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/CloneVmParameters.java
@@ -23,6 +23,7 @@ public class CloneVmParameters extends AddVmParameters {
 
     private boolean edited;
 
+    // For internal use only
     private VM editedVm;
 
     public CloneVmParameters() {
@@ -68,6 +69,9 @@ public class CloneVmParameters extends AddVmParameters {
         return editedVm;
     }
 
+    /**
+     * This method is for internal use only, disregard in API.
+     */
     public void setEditedVm(VM editedVm) {
         this.editedVm = editedVm;
     }

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/CloneVmParameters.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/CloneVmParameters.java
@@ -23,6 +23,8 @@ public class CloneVmParameters extends AddVmParameters {
 
     private boolean edited;
 
+    private VM editedVm;
+
     public CloneVmParameters() {
 
     }
@@ -60,6 +62,14 @@ public class CloneVmParameters extends AddVmParameters {
 
     public void setEdited(boolean edited) {
         this.edited = edited;
+    }
+
+    public VM getEditedVm() {
+        return editedVm;
+    }
+
+    public void setEditedVm(VM editedVm) {
+        this.editedVm = editedVm;
     }
 
     public Guid getDestStorageDomainId() {


### PR DESCRIPTION
Configuration of a cloned VM may be edited before cloning. In this case
it is passed in CloneVmParameters#vm and should be saved in editedVm
variable and passed to UpdateVmCommand that is executed after cloning.

The code that saves this configuration was incorrectly removed by change
6f143de593b2ce415e7155b8e3a1d634637afa74. This patch restores this code
with one difference: UpdateVmCommand is now executed by CoCo, so
editedVm was moved from CloneVmCommand to parameters.

Change-Id: Id77061ba6749351dcfbe832ad1c38288c6ada479
Bug-Url: https://bugzilla.redhat.com/2080758
Signed-off-by: Shmuel Melamud <smelamud@redhat.com>