### PR TITLE
core: avoid null value so the ${DiskName} will be injected

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/MoveDiskCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/MoveDiskCommand.java
@@ -170,11 +170,19 @@ public class MoveDiskCommand<T extends MoveDiskParameters> extends CommandBase<T
 
     private String getDiskIsBeingMigratedMessage() {
         if (cachedDiskIsBeingMigratedMessage == null) {
+            String diskName = "";
+            if (getParameters().getNewAlias() != null) {
+                diskName = getParameters().getNewAlias();
+            } else {
+                DiskImage diskImage = diskImageDao.get(getParameters().getImageId());
+                if (diskImage != null && diskImage.getDiskAlias() != null) {
+                    diskName = diskImage.getDiskAlias();
+                }
+            }
             cachedDiskIsBeingMigratedMessage = new LockMessage(EngineMessage.ACTION_TYPE_FAILED_DISK_IS_BEING_MIGRATED)
-                    .withOptional("DiskName", getParameters().getNewAlias())
+                    .with("DiskName", diskName)
                     .toString();
         }
-
         return cachedDiskIsBeingMigratedMessage;
     }
 }


### PR DESCRIPTION
if somehow withoption function get null as variablevalue it will not
try to inject variablevalue instead of variableName so this cause the message to
look like this:
Cannot remove Virtual Disk. Disk ${DiskName} is being moved or copied.
so I added validation of getParameters().getNewAlias() and getParameters().getDiskAlias()
and if both are null the LockMessage will be somthing more genaric and will look like this:
Cannot remove Virtual Disk. Related operation is currently in progress. Please try again later.
and if at list one of them is not null I can inject into the message so the message will look like this:
Cannot remove Virtual Disk. Disk vm_disk is being moved or copied.

Bug-Url: https://bugzilla.redhat.com/2039746
Signed-off-by: Artiom Divak <adivak@redhat.com>