### PR TITLE
Leverage the VM-lock in SetVmTicket

### DIFF
--- a/backend/manager/modules/dal/src/main/java/org/ovirt/engine/core/dao/VmDynamicDao.java
+++ b/backend/manager/modules/dal/src/main/java/org/ovirt/engine/core/dao/VmDynamicDao.java
@@ -67,16 +67,6 @@ public interface VmDynamicDao extends GenericDao<VmDynamic, Guid>, StatusAwareDa
     @Override
     void save(VmDynamic vm);
 
-    /**
-     * Update the console user name and id, but only if it was empty before. This
-     * method is needed in order to implement optimistic locking for the functionality
-     * that allows reconnection to the console without rebooting the virtual machine.
-     *
-     * @param vm the dynamic data of the virtual machine
-     * @return {@code true} if at least one row was updated, {@code false} otherwise
-     */
-    boolean updateConsoleUserWithOptimisticLocking(VmDynamic vm);
-
     void clearMigratingToVds(Guid id);
 
     void clearMigratingToVdsAndSetDynamicPinning(Guid id, String cpuPinning, String numaPinning);

--- a/backend/manager/modules/dal/src/main/java/org/ovirt/engine/core/dao/VmDynamicDaoImpl.java
+++ b/backend/manager/modules/dal/src/main/java/org/ovirt/engine/core/dao/VmDynamicDaoImpl.java
@@ -2,7 +2,6 @@ package org.ovirt.engine.core.dao;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Types;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -90,22 +89,6 @@ public class VmDynamicDaoImpl extends MassOperationsGenericDao<VmDynamic, Guid>
                 .addValue("current_numa_pinning", currentNumaPinning);
 
         getCallsHandler().executeModification("ClearMigratingToVdsAndSetDynamicPinning", parameterSource);
-    }
-
-    @Override
-    public boolean updateConsoleUserWithOptimisticLocking(VmDynamic vm) {
-        MapSqlParameterSource parameterSource = getCustomMapSqlParameterSource()
-                .addValue("vm_guid", vm.getId())
-                .addValue("console_user_id", vm.getConsoleUserId())
-                .addValue("guest_cur_user_name", vm.getGuestCurrentUserName())
-                .addValue("console_cur_user_name", vm.getConsoleCurrentUserName());
-
-        Map<String, Object> results = getCallsHandler().executeModification("UpdateConsoleUserWithOptimisticLocking",
-                parameterSource,
-                "updated",
-                Types.BIT);
-
-        return (Boolean) results.get("updated");
     }
 
     @Override

--- a/backend/manager/modules/dal/src/test/java/org/ovirt/engine/core/dao/VmDynamicDaoTest.java
+++ b/backend/manager/modules/dal/src/test/java/org/ovirt/engine/core/dao/VmDynamicDaoTest.java
@@ -97,34 +97,6 @@ public class VmDynamicDaoTest extends BaseGenericDaoTestCase<Guid, VmDynamic, Vm
         assertEquals(existingVm2, dao.get(existingVm2.getId()));
     }
 
-    /**
-     * Make sure that saving a new console user id and console user name to a virtual machine
-     * without a previous console user succeeds and returns {@code true}.
-     */
-    @Test
-    public void testUpdateConsoleUserWithOptimisticLockingSuccess() {
-        VmDynamic vmWithoutConsoleUser = dao.get(FixturesTool.VM_RHEL5_POOL_51);
-        vmWithoutConsoleUser.setConsoleUserId(new Guid("9bf7c640-b620-456f-a550-0348f366544b"));
-
-        boolean result = dao.updateConsoleUserWithOptimisticLocking(vmWithoutConsoleUser);
-
-        assertTrue(result);
-    }
-
-    /**
-     * Make sure that saving a new console user id and console user name to a virtual machine
-     * that already as a previous console user fails and returns {@code false}.
-     */
-    @Test
-    public void testUpdateConsoleUserWithOptimisticLockingFailure() {
-        VmDynamic vmWithoutConsoleUser = dao.get(FixturesTool.VM_RHEL5_POOL_57);
-        vmWithoutConsoleUser.setConsoleUserId(new Guid("9bf7c640-b620-456f-a550-0348f366544b"));
-
-        boolean result = dao.updateConsoleUserWithOptimisticLocking(vmWithoutConsoleUser);
-
-        assertFalse(result);
-    }
-
     @Test
     public void testClearMigratingToVds() {
         VmDynamic vmDynamic = dao.get(FixturesTool.VM_RHEL5_POOL_51);

--- a/packaging/dbscripts/vms_sp.sql
+++ b/packaging/dbscripts/vms_sp.sql
@@ -576,28 +576,6 @@ BEGIN
 END;$PROCEDURE$
 LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION UpdateConsoleUserWithOptimisticLocking (
-    v_vm_guid UUID,
-    v_console_user_id UUID,
-    v_guest_cur_user_name TEXT,
-    v_console_cur_user_name VARCHAR(255),
-    OUT v_updated BOOLEAN
-    ) AS $PROCEDURE$
-BEGIN
-    UPDATE vm_dynamic
-    SET console_user_id = v_console_user_id,
-        guest_cur_user_name = v_guest_cur_user_name,
-        console_cur_user_name = v_console_cur_user_name
-    WHERE vm_guid = v_vm_guid
-        AND (
-            console_user_id = v_console_user_id
-            OR console_user_id IS NULL
-            );
-
-    v_updated := FOUND;
-END;$PROCEDURE$
-LANGUAGE plpgsql;
-
 CREATE OR REPLACE FUNCTION UpdateVmDynamicStatus (
     v_vm_guid UUID,
     v_status INT


### PR DESCRIPTION
Previously, we used optimisic locking to see if the user that tries to
connect to the VM can do that or not. However, now that we lock the VM
using VmManager's lock, we don't need that anymore - we can rather
inspect VmDynamic in the command itself to discover it.

Signed-off-by: Arik Hadas <ahadas@redhat.com>