### PR TITLE
Require postgresql-jdbc >= 42.2.14

### DIFF
--- a/ovirt-engine.spec.in
+++ b/ovirt-engine.spec.in
@@ -362,7 +362,7 @@ Requires:	libfastjson
 Requires:	liblognorm
 Requires:	libestr
 
-Requires:	postgresql-jdbc >= 42.2.3
+Requires:	postgresql-jdbc >= 42.2.14
 
 Requires:	postgresql-server >= 12.0
 Requires:	postgresql-contrib >= 12.0


### PR DESCRIPTION
As a part of https://github.com/oVirt/ovirt-engine/pull/322 ovirt-engine
now requires postgresql-jdbc >= 42.2.14, whih should be the latest
version available. But unfortunately we forgot to add RPM requires for
this version, which caused issues around upgrade.

Bug-Url: https://bugzilla.redhat.com/2077794
Signed-off-by: Martin Perina <mperina@redhat.com>
