### PR TITLE
core: block VM removal during backup

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/MigrateVmCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/MigrateVmCommand.java
@@ -146,6 +146,11 @@ public class MigrateVmCommand<T extends MigrateVmParameters> extends RunVmComman
         return lockProperties.withScope(Scope.Command);
     }
 
+    @Override
+    protected boolean shouldBlockDuringBackup() {
+        return false;
+    }
+
     /**
      * this property is used for audit log events
      */

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/RemoveVmCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/RemoveVmCommand.java
@@ -314,6 +314,10 @@ public class RemoveVmCommand<T extends RemoveVmParameters> extends VmCommand<T> 
             return false;
         }
 
+        if (isVmDuringBackup()) {
+            return failValidation(EngineMessage.ACTION_TYPE_FAILED_VM_IS_DURING_BACKUP);
+        }
+
         return true;
     }
 

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/RunVmCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/RunVmCommand.java
@@ -1152,6 +1152,11 @@ public class RunVmCommand<T extends RunVmParams> extends RunVmCommandBase<T>
         return true;
     }
 
+    @Override
+    protected boolean shouldBlockDuringBackup() {
+        return false;
+    }
+
     private void addNumaPinningForResizeAndPin() {
         // The CPU topology and CPU Pinning change happens under schedule(), when allocating CPUs
         // - VdsCpuUnitPinningHelper::updatePhysicalCpuAllocations.

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/VmCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/VmCommand.java
@@ -624,17 +624,13 @@ public abstract class VmCommand<T extends VmOperationParameterBase> extends Comm
     }
 
     public boolean isVmDuringBackup() {
-        if (!shouldBlockDuringBackup()) {
-            return false;
-        }
-
         List<VmBackup> vmBackups = vmBackupDao.getAllForVm(getVmId());
 
         // No need to block during hybrid backup
         boolean allBackupsHybrid = !CollectionUtils.isEmpty(vmBackups) && vmBackups
                 .stream()
                 .allMatch(vmBackup -> VmBackupType.Hybrid == vmBackup.getBackupType());
-        if (allBackupsHybrid) {
+        if (allBackupsHybrid && !shouldBlockDuringBackup()) {
             return false;
         }
 
@@ -643,8 +639,8 @@ public abstract class VmCommand<T extends VmOperationParameterBase> extends Comm
                 .anyMatch(vmBackup -> !vmBackup.getPhase().isBackupFinished());
     }
 
-    private boolean shouldBlockDuringBackup() {
-        return getParentParameters() == null || getParentParameters().getCommandType() != ActionType.HybridBackup;
+    protected boolean shouldBlockDuringBackup() {
+        return true;
     }
 
     protected VdsManager getVdsManager(Guid vdsId) {

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/VmOperationCommandBase.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/VmOperationCommandBase.java
@@ -28,6 +28,11 @@ public abstract class VmOperationCommandBase<T extends VmOperationParameterBase>
         setActionReturnValue((getVm() != null) ? getVm().getStatus() : VMStatus.Down);
     }
 
+    @Override
+    protected boolean shouldBlockDuringBackup() {
+        return false;
+    }
+
     /**
      * This method checks if the virtual machine is running in some host. It also
      * has the side effect of storing the reference to the host inside the command.


### PR DESCRIPTION
It was possible to remove a VM during backup, this patch rearranges isDuringBackup() validation method and explictly sets which operations should be blocked or not.

Not blocking:
RunVmCommand
StopVmCommand
MigrateVmCommand
CreateSnapshotForVmCommand

Bug-Url: https://bugzilla.redhat.com/2080718
