### PR TITLE
certificates: fix confirmation question

### DIFF
--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/pki/ca.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/pki/ca.py
@@ -519,10 +519,9 @@ class Plugin(plugin.PluginBase):
                     note=_(
                         'One or more of the certificates should be renewed, '
                         'because they expire soon, or include an invalid '
-                        'expiry date, or they were created with validity '
-                        'period longer than 398 days, or do not include the '
-                        'subjectAltName extension, which can cause them to be '
-                        'rejected by recent browsers and up to date hosts.\n'
+                        'expiry date, or do not include the subjectAltName '
+                        'extension, which can cause them to be rejected by '
+                        'recent browsers and up to date hosts.\n'
                         'See {url} for more details.\n'
                         'Renew certificates? '
                         '(@VALUES@) [@DEFAULT@]: '


### PR DESCRIPTION
In 67e77630f00ea4ff83a4002fac3aa68c1ce61bff we dropped the cehck for 398
validity in certificates. Let's make sure the engine-setup text reflects
the change.
