### PR TITLE
core: add new configuration for volume chunk size

### DIFF
--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/config/ConfigValues.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/config/ConfigValues.java
@@ -1584,6 +1584,9 @@ public enum ConfigValues {
     @TypeConverterAttribute(Integer.class)
     LiveSnapshotFreezeTimeout,
 
+    @TypeConverterAttribute(Integer.class)
+    VolumeUtilizationChunkInMB,
+
     @TypeConverterAttribute(Boolean.class)
     IsIncrementalBackupSupported,
 

--- a/packaging/dbscripts/upgrade/pre_upgrade/0000_config.sql
+++ b/packaging/dbscripts/upgrade/pre_upgrade/0000_config.sql
@@ -824,6 +824,7 @@ select fn_db_add_config_value_for_versions_up_to('BiosTypeSupported', 'true', '4
 select fn_db_add_config_value('LiveSnapshotTimeoutInMinutes', '30', 'general');
 select fn_db_add_config_value('LiveSnapshotAllowInconsistent', 'true', 'general');
 select fn_db_add_config_value('LiveSnapshotFreezeTimeout', '8', 'general');
+select fn_db_add_config_value('VolumeUtilizationChunkInMB', '2560', 'general'); -- Cluster level 4.7 and above.
 
 -- VirtIO-Win drivers path
 select fn_db_add_config_value('VirtioWinIsoPath','/usr/share/virtio-win','general');

--- a/packaging/etc/engine-config/engine-config.properties
+++ b/packaging/etc/engine-config/engine-config.properties
@@ -550,6 +550,9 @@ LiveSnapshotPerformFreezeInEngine.type=Boolean
 LiveSnapshotFreezeTimeout.description=The live snapshot command without memory timeout in minutes
 LiveSnapshotFreezeTimeout.type=Integer
 LiveSnapshotFreezeTimeout.validValues=1..3000
+VolumeUtilizationChunkInMB.description="Size of extension chunk in megabytes. Use higher values to extend in bigger chunks. WARNING: If it's changed, please make sure to change the corresponding value in VDSM (see: https://github.com/oVirt/vdsm/blob/v4.50.1/lib/vdsm/common/config.py.in#L325)!"
+VolumeUtilizationChunkInMB.type=Integer
+VolumeUtilizationChunkInMB.validValues=1024..4096
 # Incremental backup
 IsIncrementalBackupSupported.description=Enable incremental backup operations for a VM.
 IsIncrementalBackupSupported.type=Boolean


### PR DESCRIPTION
Adding new configuration for volume chunk size.
This duplicates VDSM `irs:volume_utilization_chunk_mb` configuration.
https://github.com/oVirt/vdsm/blob/v4.50.1/lib/vdsm/common/config.py.in#L325

Duplicating the configuration is bad.
But until the configuration is totally moved to engine, we have no other way to use the right size for creating new volumes.
This commit was part of https://github.com/oVirt/ovirt-engine/pull/305, but in order to enable faster merging and using this new parameter extracting it out.

Bug-Url: https://bugzilla.redhat.com/1958032