### PR TITLE
core: Add memtune hard_limit for q35 VMs with many CPUs

### DIFF
--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/builder/vminfo/LibvirtVmXmlBuilder.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/builder/vminfo/LibvirtVmXmlBuilder.java
@@ -289,6 +289,7 @@ public class LibvirtVmXmlBuilder {
         }
         writeCpu(numaEnabled || vm.isHostedEngine() && !vmNumaNodesSupplier.get().isEmpty());
         writeCpuTune();
+        writeMemtune();
         writeQemuCapabilities();
         writeDevices();
         writePowerManagement();
@@ -1559,6 +1560,17 @@ public class LibvirtVmXmlBuilder {
             if (vmInfoBuildUtils.needsIommuCachingMode(vm, hostDevicesSupplier, vmDevicesSupplier)) {
                 writer.writeAttributeString("caching_mode", "on");
             }
+            writer.writeEndElement();
+            writer.writeEndElement();
+        }
+    }
+
+    private void writeMemtune() {
+        if (VmInfoBuildUtils.needsMemtune(vm)) {
+            writer.writeStartElement("memtune");
+            writer.writeStartElement("hard_limit");
+            writer.writeAttributeString("unit", "TiB");
+            writer.writeRaw("1024");
             writer.writeEndElement();
             writer.writeEndElement();
         }

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/builder/vminfo/VmInfoBuildUtils.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/builder/vminfo/VmInfoBuildUtils.java
@@ -1740,4 +1740,9 @@ public class VmInfoBuildUtils {
         }
         return cpuPinningPolicyName;
     }
+
+    public static boolean needsMemtune(VM vm) {
+        return vm.getBiosType() != null && vm.getBiosType().getChipsetType() == ChipsetType.Q35
+                && maxNumberOfVcpus(vm) >= 256;
+    }
 }


### PR DESCRIPTION
When a VM with q35 chipset has at least 256 maximum vCPUs and contains
VFIO devices, it can fail to start.  It can happen for two reasons:

1. There are multiple VFIO devices in the same IOMMU group and their
   drivers don’t handle it properly.

2. The memory locking limit needed to handle the VFIO devices is
   exceeded.

oVirt cannot do anything about 1., such a situation must be fixed in
the low level layers.  As for 2., it should be fixed in QEMU one day
but we can work around it now by specifying a sufficiently high limit
on the amount of QEMU and guest memory locked in the host
memory (i.e. not being able to swap out).  The limit should be at
least VM maximum RAM times the number of VFIO devices.  We set it
simply to an extremely high value regardless the presence and number
of VFIO devices, which should cause no trouble because we don’t want
to swap out VM memory anyway.

See https://bugzilla.redhat.com/show_bug.cgi?id=2048429#c9 for more
details.

Bug-Url: https://bugzilla.redhat.com/2081241
Bug-Url: https://bugzilla.redhat.com/2048429