### PR TITLE
Reduce CPU pinning fragmentation

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/SchedulingManager.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/SchedulingManager.java
@@ -67,6 +67,7 @@ import org.ovirt.engine.core.common.businessentities.VdsCpuUnit;
 import org.ovirt.engine.core.common.businessentities.VdsNumaNode;
 import org.ovirt.engine.core.common.businessentities.VmNumaNode;
 import org.ovirt.engine.core.common.businessentities.VmStatic;
+import org.ovirt.engine.core.common.businessentities.comparators.VmsCpuPinningPolicyComparator;
 import org.ovirt.engine.core.common.config.Config;
 import org.ovirt.engine.core.common.config.ConfigValues;
 import org.ovirt.engine.core.common.errors.EngineMessage;
@@ -432,7 +433,6 @@ public class SchedulingManager implements BackendService {
                         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, NumaNodeMemoryConsumption::merge));
                 updateHostNumaNodes(host, numaConsumption);
 
-
                 for (VM vm : vmsNotOnHost) {
                     vmHandler.updateCpuAndNumaPinning(vm, host.getId());
                     vmHandler.setCpuPinningByNumaPinning(vm, host.getId());
@@ -701,6 +701,7 @@ public class SchedulingManager implements BackendService {
         if (vms.size() < 2) {
             return Collections.singletonList(vms);
         }
+        vms.sort(new VmsCpuPinningPolicyComparator().reversed());
 
         if (context.isDoNotGroupVms() || context.isIgnoreHardVmToVmAffinity()) {
             return vms.stream()

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/CpuPinningPolicy.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/CpuPinningPolicy.java
@@ -43,4 +43,38 @@ public enum CpuPinningPolicy {
     public boolean isExclusive() {
         return this == DEDICATED || this == ISOLATE_THREADS;
     }
+
+    public static int compare(CpuPinningPolicy policy, CpuPinningPolicy other) {
+        if (policy == other) {
+            return 0;
+        }
+        if (policy == CpuPinningPolicy.NONE) {
+            return -1;
+        }
+        if (other == CpuPinningPolicy.NONE) {
+            return 1;
+        }
+        // both not none
+        if (policy == CpuPinningPolicy.MANUAL) {
+            return 1;
+        }
+        if (other == CpuPinningPolicy.MANUAL) {
+            return -1;
+        }
+        // not none, not manual
+        if (policy == CpuPinningPolicy.RESIZE_AND_PIN_NUMA) {
+            // automatically vm2 is exclusive
+            return 1;
+        }
+        if (other == CpuPinningPolicy.RESIZE_AND_PIN_NUMA) {
+            // automatically vm1 is exclusive
+            return -1;
+        }
+        if (policy == CpuPinningPolicy.ISOLATE_THREADS) {
+            // automatically vm2 is dedicated
+            return 1;
+        }
+        // vm1 is dedicated and vm2 is isolate-threads
+        return -1;
+    }
 }

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/comparators/VmsCpuPinningPolicyComparator.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/comparators/VmsCpuPinningPolicyComparator.java
@@ -1,0 +1,35 @@
+package org.ovirt.engine.core.common.businessentities.comparators;
+
+import java.io.Serializable;
+import java.util.Comparator;
+
+import org.ovirt.engine.core.common.businessentities.CpuPinningPolicy;
+import org.ovirt.engine.core.common.businessentities.VM;
+
+/**
+ * Comparing VMs based on the CPU pinning policy and if needed, their CPU topology.
+ */
+public class VmsCpuPinningPolicyComparator implements Comparator<VM>, Serializable {
+
+    @Override
+    public int compare(VM vm1, VM vm2) {
+        int diff = CpuPinningPolicy.compare(vm1.getCpuPinningPolicy(), vm2.getCpuPinningPolicy());
+        if (diff != 0) {
+            return diff;
+        }
+        diff = vm1.getNumOfCpus() - vm2.getNumOfCpus();
+        if (diff != 0) {
+            return diff;
+        }
+        // The policies are equal, numOfCpus is equal, compare based on CPU topology - bottom up.
+        diff = vm1.getThreadsPerCpu() - vm2.getThreadsPerCpu();
+        if (diff != 0) {
+            return diff;
+        }
+        diff = vm1.getCpuPerSocket() - vm2.getCpuPerSocket();
+        if (diff != 0) {
+            return diff;
+        }
+        return vm1.getNumOfSockets() - vm2.getNumOfSockets();
+    }
+}

--- a/backend/manager/modules/common/src/test/java/org/ovirt/engine/core/common/businessentities/comparators/VmsCpuPinningPolicyComparatorTest.java
+++ b/backend/manager/modules/common/src/test/java/org/ovirt/engine/core/common/businessentities/comparators/VmsCpuPinningPolicyComparatorTest.java
@@ -1,0 +1,137 @@
+package org.ovirt.engine.core.common.businessentities.comparators;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.ovirt.engine.core.common.businessentities.CpuPinningPolicy;
+import org.ovirt.engine.core.common.businessentities.VM;
+
+public class VmsCpuPinningPolicyComparatorTest {
+
+    private VM vm1;
+    private VM vm2;
+    VmsCpuPinningPolicyComparator comparator = new VmsCpuPinningPolicyComparator();
+
+    private void verifyResult(VM vm1, VM vm2, int expectedResult) {
+        assertEquals(expectedResult, comparator.compare(vm1, vm2),
+                String.format("Expected %1$s to be %3$s %2$s, but it wasn't.",
+                        vm1.getName(),
+                        vm2.getName(),
+                        expectedResult == -1 ? "less than" : expectedResult == 1 ? "greater than" : "equal to"));
+    }
+
+    @BeforeEach
+    public void setUp() {
+        vm1 = new VM();
+        vm1.setName("vm1");
+        vm2 = new VM();
+        vm2.setName("vm2");
+    }
+
+    @Test
+    public void testEqualNone() {
+        verifyResult(vm1, vm2, 0);
+    }
+
+    @Test
+    public void testManual() {
+        vm1.setCpuPinningPolicy(CpuPinningPolicy.MANUAL);
+        // vm2 is none
+        verifyResult(vm1, vm2, 1);
+        vm2.setCpuPinningPolicy(CpuPinningPolicy.RESIZE_AND_PIN_NUMA);
+        verifyResult(vm1, vm2, 1);
+        vm2.setCpuPinningPolicy(CpuPinningPolicy.ISOLATE_THREADS);
+        verifyResult(vm1, vm2, 1);
+        vm2.setCpuPinningPolicy(CpuPinningPolicy.DEDICATED);
+        verifyResult(vm1, vm2, 1);
+    }
+
+    @Test
+    public void testResize() {
+        vm1.setCpuPinningPolicy(CpuPinningPolicy.RESIZE_AND_PIN_NUMA);
+        // vm2 is none
+        verifyResult(vm1, vm2, 1);
+        vm2.setCpuPinningPolicy(CpuPinningPolicy.MANUAL);
+        verifyResult(vm1, vm2, -1);
+        vm2.setCpuPinningPolicy(CpuPinningPolicy.RESIZE_AND_PIN_NUMA);
+        verifyResult(vm1, vm2, 0);
+        vm2.setCpuPinningPolicy(CpuPinningPolicy.ISOLATE_THREADS);
+        verifyResult(vm1, vm2, 1);
+        vm2.setCpuPinningPolicy(CpuPinningPolicy.DEDICATED);
+        verifyResult(vm1, vm2, 1);
+    }
+
+    @Test
+    public void testIsolateThreads() {
+        vm1.setCpuPinningPolicy(CpuPinningPolicy.ISOLATE_THREADS);
+        // vm2 is none
+        verifyResult(vm1, vm2, 1);
+        vm2.setCpuPinningPolicy(CpuPinningPolicy.MANUAL);
+        verifyResult(vm1, vm2, -1);
+        vm2.setCpuPinningPolicy(CpuPinningPolicy.RESIZE_AND_PIN_NUMA);
+        verifyResult(vm1, vm2, -1);
+        vm2.setCpuPinningPolicy(CpuPinningPolicy.ISOLATE_THREADS);
+        verifyResult(vm1, vm2, 0);
+        vm2.setCpuPinningPolicy(CpuPinningPolicy.DEDICATED);
+        verifyResult(vm1, vm2, 1);
+    }
+
+    @Test
+    public void testDedicated() {
+        vm1.setCpuPinningPolicy(CpuPinningPolicy.DEDICATED);
+        // vm2 is none
+        verifyResult(vm1, vm2, 1);
+        vm2.setCpuPinningPolicy(CpuPinningPolicy.MANUAL);
+        verifyResult(vm1, vm2, -1);
+        vm2.setCpuPinningPolicy(CpuPinningPolicy.RESIZE_AND_PIN_NUMA);
+        verifyResult(vm1, vm2, -1);
+        vm2.setCpuPinningPolicy(CpuPinningPolicy.ISOLATE_THREADS);
+        verifyResult(vm1, vm2, -1);
+        vm2.setCpuPinningPolicy(CpuPinningPolicy.DEDICATED);
+        verifyResult(vm1, vm2, 0);
+    }
+
+    @Test
+    public void testNumOfCpus() {
+        vm1.setCpuPinningPolicy(CpuPinningPolicy.MANUAL);
+        vm2.setCpuPinningPolicy(CpuPinningPolicy.MANUAL);
+        vm2.setNumOfSockets(2);
+        verifyResult(vm1, vm2, -1);
+    }
+
+    @Test
+    public void testCpuTopologyThreads() {
+        vm1.setThreadsPerCpu(2);
+        vm2.setCpuPerSocket(2);
+        verifyResult(vm1, vm2, 1);
+    }
+
+    @Test
+    public void testCpuTopologyCores() {
+        vm1.setCpuPerSocket(2);
+        vm2.setNumOfSockets(2);
+        verifyResult(vm1, vm2, 1);
+    }
+
+    @Test
+    public void testCpuTopologySockets() {
+        vm1.setNumOfSockets(3);
+        vm2.setNumOfSockets(2);
+        verifyResult(vm1, vm2, 1);
+    }
+
+    @Test
+    public void vmSort() {
+        ArrayList<VM> vms = new ArrayList<>();
+        vms.add(vm1);
+        vms.add(vm2);
+        vm2.setCpuPinningPolicy(CpuPinningPolicy.MANUAL);
+        vms.sort(comparator.reversed());
+        assertEquals(vms.get(0), vm2);
+        assertEquals(vms.get(1), vm1);
+    }
+
+}


### PR DESCRIPTION
This patch sorts the VM list on schedule phase before doing the
dedicated CPU pinning.
This change tries to reduce the fragmentation that may be caused when
allocating a smaller VM in terms of the policy and CPU topology (a less
restricted) when having a bigger one. Scheduling the smaller VM first
may cause less physical resources needed by the larger VM because we try
to enhance performance in the allocation logic.
Now, the VMs will be sorted based on the policy first and if needed by
the CPU topology, letting the more restricted VM to be scheduled first.

Change-Id: Ia3fc28511c147d43da9cf8d86d50ca17f1e3f0e1
Signed-off-by: Liran Rotenberg <lrotenbe@redhat.com>