### PR TITLE
persist event notifier service boots

### DIFF
--- a/backend/manager/tools/src/main/java/org/ovirt/engine/core/notifier/NotificationService.java
+++ b/backend/manager/tools/src/main/java/org/ovirt/engine/core/notifier/NotificationService.java
@@ -86,6 +86,12 @@ public class NotificationService implements Runnable {
                         TimeUnit.SECONDS
                 )
         );
+        try {
+            int boots = eventsManager.getNotificationServiceBoots();
+            eventsManager.setNotificationServiceBoots(++boots);
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
     }
 
     /**

--- a/backend/manager/tools/src/main/java/org/ovirt/engine/core/notifier/dao/EventsManager.java
+++ b/backend/manager/tools/src/main/java/org/ovirt/engine/core/notifier/dao/EventsManager.java
@@ -234,4 +234,33 @@ public class EventsManager implements Observer {
             log.error("Could not insert event notification history event", e);
         }
     }
+
+    public void setNotificationServiceBoots(int bootsValue)
+            throws SQLException {
+        try (Connection connection = ds.getConnection();
+             PreparedStatement ps = connection.prepareStatement(
+                     "UPDATE vdc_options " +
+                             "SET option_value = '" + Integer.toString(bootsValue) + "' " +
+                             "WHERE option_name = 'NotificationServiceBoots';")) {
+            int updated = ps.executeUpdate();
+            if (updated != 1) {
+                log.error("Failed to update vdc_options:NotificationServiceBoots to : {}",
+                        bootsValue);
+            }
+        }
+    }
+
+    public int getNotificationServiceBoots()
+            throws SQLException {
+        try (Connection connection = ds.getConnection();
+             PreparedStatement ps = connection.prepareStatement(
+                     "SELECT option_value from  vdc_options " +
+                             "WHERE option_name = 'NotificationServiceBoots';")) {
+            ResultSet rs = ps.executeQuery();
+            while (rs.next()) {
+                return Integer.parseInt(rs.getString("option_value"));
+            }
+        }
+        return 0;
+    }
 }

--- a/packaging/dbscripts/upgrade/pre_upgrade/0000_config.sql
+++ b/packaging/dbscripts/upgrade/pre_upgrade/0000_config.sql
@@ -966,6 +966,11 @@ select fn_db_add_config_value('InstanceId', uuid_generate_v1()::varchar, 'genera
 -- Number of MAC address left in pool to invoke audit warning
 select fn_db_add_config_value('RemainingMacsInPoolWarningThreshold', '10', 'general');
 
+-- Number of times that the Notification Service was rebooted, this is needed for
+-- SNMP V3 security requirements and should not be modified manually.
+
+select fn_db_add_config_value('NotificationServiceBoots', '0', 'general');
+
 ------------------------------------------------------------------------------------
 --                  Update with override section
 ------------------------------------------------------------------------------------


### PR DESCRIPTION
This bug is a result of applying level 3 security of the new USM
introduced on SNMP V3.
When the Event Notification Service is restarts , it creates a new USM
object but does not update the number of time its was rebooted.
This makes the service suspected by SNMP V3 and it stops getting traps
from it in snmptrapd.
The solution is to add a new configuration value
NotificationServiceBoots which is set by default to 0.
Each time the Event Notification Service is rebooted, this value is
incremented by 1 and stored in the configuration table (vdc_options)

When a new USM object is created on Event Notification Service run
method, it set the number of boots accordint to the persisted value.

This solves the problem and Event Notification Service can be restated
several times and still keep getting traps on which it is listening
according to its "FILTER" settings.

Signed-off-by: Eli Mesika <emesika@redhat.com>
Bug-Url: https://bugzilla.redhat.com/2072626