### PR TITLE
Add NUMA nodes to OVA

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/AddVmCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/AddVmCommand.java
@@ -67,7 +67,6 @@ import org.ovirt.engine.core.common.action.LockProperties;
 import org.ovirt.engine.core.common.action.LockProperties.Scope;
 import org.ovirt.engine.core.common.action.RngDeviceParameters;
 import org.ovirt.engine.core.common.action.SealVmParameters;
-import org.ovirt.engine.core.common.action.VmNumaNodeOperationParameters;
 import org.ovirt.engine.core.common.action.WatchdogParameters;
 import org.ovirt.engine.core.common.asynctasks.EntityInfo;
 import org.ovirt.engine.core.common.businessentities.ActionGroup;
@@ -93,7 +92,6 @@ import org.ovirt.engine.core.common.businessentities.VmDeviceGeneralType;
 import org.ovirt.engine.core.common.businessentities.VmDeviceId;
 import org.ovirt.engine.core.common.businessentities.VmDynamic;
 import org.ovirt.engine.core.common.businessentities.VmInit;
-import org.ovirt.engine.core.common.businessentities.VmNumaNode;
 import org.ovirt.engine.core.common.businessentities.VmPayload;
 import org.ovirt.engine.core.common.businessentities.VmRngDevice;
 import org.ovirt.engine.core.common.businessentities.VmStatic;
@@ -1290,16 +1288,7 @@ public class AddVmCommand<T extends AddVmParameters> extends VmManagementCommand
     }
 
     private void addVmNumaNodes() {
-        List<VmNumaNode> numaNodes = getParameters().getVm().getvNumaNodeList();
-        if (numaNodes.isEmpty()) {
-            return;
-        }
-        VmNumaNodeOperationParameters params = new VmNumaNodeOperationParameters(getParameters().getVm(), numaNodes);
-
-        ActionReturnValue returnValueBase = backend.runInternalAction(ActionType.AddVmNumaNodes, params);
-        if (!returnValueBase.getSucceeded()) {
-            auditLogDirector.log(this, AuditLogType.NUMA_ADD_VM_NUMA_NODE_FAILED);
-        }
+        vmHandler.addVmNumaNodes(getParameters().getVm());
     }
 
     private void addVmInit() {

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/CreateOvaCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/CreateOvaCommand.java
@@ -114,6 +114,7 @@ public class CreateOvaCommand<T extends CreateOvaParameters> extends CommandBase
         default:
             VM vm = vmDao.get(getParameters().getEntityId());
             vmHandler.updateVmInitFromDB(vm.getStaticData(), true);
+            vmHandler.updateNumaNodesFromDb(vm);
             vm.setVmExternalData(getVmExternalData());
             interfaces = vmNetworkInterfaceDao.getAllForVm(vm.getId());
             vm.setInterfaces(interfaces);

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/VmHandler.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/VmHandler.java
@@ -45,8 +45,10 @@ import org.ovirt.engine.core.common.AuditLogType;
 import org.ovirt.engine.core.common.BackendService;
 import org.ovirt.engine.core.common.FeatureSupported;
 import org.ovirt.engine.core.common.VdcObjectType;
+import org.ovirt.engine.core.common.action.ActionReturnValue;
 import org.ovirt.engine.core.common.action.ActionType;
 import org.ovirt.engine.core.common.action.VmManagementParametersBase;
+import org.ovirt.engine.core.common.action.VmNumaNodeOperationParameters;
 import org.ovirt.engine.core.common.backendinterfaces.BaseHandler;
 import org.ovirt.engine.core.common.businessentities.ActionGroup;
 import org.ovirt.engine.core.common.businessentities.ArchitectureType;
@@ -1039,6 +1041,19 @@ public class VmHandler implements BackendService {
         List<VmNumaNode> nodes = vmNumaNodeDao.getAllVmNumaNodeByVmId(vm.getId());
 
         vm.setvNumaNodeList(nodes);
+    }
+
+    public void addVmNumaNodes(VM vm) {
+        List<VmNumaNode> numaNodes = vm.getvNumaNodeList();
+        if (numaNodes.isEmpty()) {
+            return;
+        }
+        VmNumaNodeOperationParameters params = new VmNumaNodeOperationParameters(vm, numaNodes);
+
+        ActionReturnValue returnValueBase = backend.runInternalAction(ActionType.AddVmNumaNodes, params);
+        if (!returnValueBase.getSucceeded()) {
+            auditLogDirector.log(new AuditLogableImpl(), AuditLogType.NUMA_ADD_VM_NUMA_NODE_FAILED);
+        }
     }
 
     public static List<PermissionSubject> getPermissionsNeededToChangeCluster(Guid vmId, Guid clusterId) {

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ImportVmCommandBase.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ImportVmCommandBase.java
@@ -568,6 +568,7 @@ public abstract class ImportVmCommandBase<T extends ImportVmParameters> extends 
             addVmStatistics();
             addVmInterfaces();
             addVmPermission();
+            addVmNuma();
             getCompensationContext().stateChanged();
             return null;
         });
@@ -596,6 +597,10 @@ public abstract class ImportVmCommandBase<T extends ImportVmParameters> extends 
                 ActionGroup.MANIPULATE_PERMISSIONS,
                 getVmId(),
                 VdcObjectType.VM);
+    }
+
+    private void addVmNuma() {
+        vmHandler.addVmNumaNodes(getVm());
     }
 
     protected void addVmStatic() {

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/snapshots/SnapshotsManager.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/snapshots/SnapshotsManager.java
@@ -323,6 +323,7 @@ public class SnapshotsManager {
         if (vm.getStaticData().getVmInit() == null) {
             vmHandler.updateVmInitFromDB(vm.getStaticData(), true);
         }
+        vmHandler.updateNumaNodesFromDb(vm);
         return ovfManager.exportVm(vm,
                 fullEntityOvfData,
                 clusterUtils.getCompatibilityVersion(vm));

--- a/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfOvaVmReader.java
+++ b/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfOvaVmReader.java
@@ -27,7 +27,7 @@ public class OvfOvaVmReader extends OvfOvaReader {
         }
         XmlNode node = selectSingleNode(content, "NumaNodeSection");
         if (node != null) {
-            readNumaNodeListSection(node, true);
+            readNumaNodeListSection(node, false);
         }
     }
 

--- a/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfOvaVmReader.java
+++ b/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfOvaVmReader.java
@@ -25,6 +25,10 @@ public class OvfOvaVmReader extends OvfOvaReader {
         if (!StringUtils.isBlank(vm.getCpuPinning())) {
             vm.setCpuPinningPolicy(CpuPinningPolicy.MANUAL);
         }
+        XmlNode node = selectSingleNode(content, "NumaNodeSection");
+        if (node != null) {
+            readNumaNodeListSection(node, true);
+        }
     }
 
     @Override

--- a/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfOvaVmWriter.java
+++ b/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfOvaVmWriter.java
@@ -1,7 +1,10 @@
 package org.ovirt.engine.core.utils.ovf;
 
+import java.util.List;
+
 import org.apache.commons.lang.StringUtils;
 import org.ovirt.engine.core.common.businessentities.VM;
+import org.ovirt.engine.core.common.businessentities.VmNumaNode;
 import org.ovirt.engine.core.common.businessentities.storage.FullEntityOvfData;
 import org.ovirt.engine.core.common.osinfo.OsRepository;
 import org.ovirt.engine.core.common.utils.VmCpuCountHelper;
@@ -60,6 +63,18 @@ public class OvfOvaVmWriter extends OvfOvaWriter {
         if (vm.getCpuPinning() != null) {
             _writer.writeElement(CPU_PINNING, vm.getCpuPinning());
         }
+        writeNumaNodeList();
+    }
+
+    @Override
+    protected void writeNumaNodeList() {
+        List<VmNumaNode> vmNumaNodes = vm.getvNumaNodeList();
+
+        if (vmNumaNodes == null || vmNumaNodes.isEmpty()) {
+            return;
+        }
+        _writer.writeStartElement("NumaNodeSection");
+        super.writeNumaNodeList();
     }
 
     @Override

--- a/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfOvaVmWriter.java
+++ b/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfOvaVmWriter.java
@@ -63,7 +63,6 @@ public class OvfOvaVmWriter extends OvfOvaWriter {
         if (vm.getCpuPinning() != null) {
             _writer.writeElement(CPU_PINNING, vm.getCpuPinning());
         }
-        writeNumaNodeList();
     }
 
     @Override
@@ -82,4 +81,9 @@ public class OvfOvaVmWriter extends OvfOvaWriter {
         return VmCpuCountHelper.calcMaxVCpu(vm, getVersion());
     }
 
+    @Override
+    protected void writeHardware() {
+        super.writeHardware();
+        writeNumaNodeList();
+    }
 }

--- a/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfOvaVmWriter.java
+++ b/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfOvaVmWriter.java
@@ -66,14 +66,8 @@ public class OvfOvaVmWriter extends OvfOvaWriter {
     }
 
     @Override
-    protected void writeNumaNodeList() {
-        List<VmNumaNode> vmNumaNodes = vm.getvNumaNodeList();
-
-        if (vmNumaNodes == null || vmNumaNodes.isEmpty()) {
-            return;
-        }
+    protected void startNUMASection() {
         _writer.writeStartElement("NumaNodeSection");
-        super.writeNumaNodeList();
     }
 
     @Override

--- a/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfOvaVmWriter.java
+++ b/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfOvaVmWriter.java
@@ -78,6 +78,6 @@ public class OvfOvaVmWriter extends OvfOvaWriter {
     @Override
     protected void writeHardware() {
         super.writeHardware();
-        writeNumaNodeList();
+        writeNumaSection();
     }
 }

--- a/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfOvaVmWriter.java
+++ b/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfOvaVmWriter.java
@@ -1,10 +1,7 @@
 package org.ovirt.engine.core.utils.ovf;
 
-import java.util.List;
-
 import org.apache.commons.lang.StringUtils;
 import org.ovirt.engine.core.common.businessentities.VM;
-import org.ovirt.engine.core.common.businessentities.VmNumaNode;
 import org.ovirt.engine.core.common.businessentities.storage.FullEntityOvfData;
 import org.ovirt.engine.core.common.osinfo.OsRepository;
 import org.ovirt.engine.core.common.utils.VmCpuCountHelper;

--- a/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfOvirtReader.java
+++ b/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfOvirtReader.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -100,7 +99,7 @@ public abstract class OvfOvirtReader extends OvfReader {
 
             node = getNode(list, "xsi:type", "ovf:NumaNodeSection_Type");
             if (node != null) {
-                readNumaNodeListSection(node);
+                readNumaNodeListSection(node, false);
             }
         }
 
@@ -111,22 +110,6 @@ public abstract class OvfOvirtReader extends OvfReader {
         super.readGeneralData(content);
         consumeReadProperty(content, CLUSTER_NAME, val -> fullEntityOvfData.setClusterName(val));
     }
-
-    protected List<Integer> readIntegerList(XmlNode node, String label) {
-        List<Integer> integerList = new ArrayList<>();
-        XmlNode xmlNode = selectSingleNode(node, label, _xmlNS);
-        if (xmlNode != null) {
-            String valueList = xmlNode.innerText;
-            if (valueList != null && !valueList.isEmpty()) {
-                String[] values = valueList.split(",");
-                for (String value : values) {
-                    integerList.add(Integer.valueOf(value));
-                }
-            }
-        }
-        return integerList;
-    }
-
 
     @Override
     protected void readLunDisk(XmlNode node, LunDisk lun) {

--- a/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfOvirtReader.java
+++ b/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfOvirtReader.java
@@ -99,7 +99,7 @@ public abstract class OvfOvirtReader extends OvfReader {
 
             node = getNode(list, "xsi:type", "ovf:NumaNodeSection_Type");
             if (node != null) {
-                readNumaNodeListSection(node, false);
+                readNumaNodeListSection(node, true);
             }
         }
 

--- a/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfOvirtWriter.java
+++ b/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfOvirtWriter.java
@@ -4,7 +4,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.apache.commons.lang.StringUtils;
 import org.ovirt.engine.core.common.action.VmExternalDataKind;
@@ -252,14 +251,5 @@ public abstract class OvfOvirtWriter extends OvfWriter {
     @Override
     protected String getInstaceIdTag() {
         return "InstanceId";
-    }
-
-    protected void writeIntegerList(String label, List<Integer> list) {
-        if (list != null && !list.isEmpty()) {
-            String writeList = list.stream().map(i -> i.toString()).collect(Collectors.joining(","));
-            _writer.writeElement(label, writeList);
-        } else {
-            _writer.writeElement(label, "");
-        }
     }
 }

--- a/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfProperties.java
+++ b/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfProperties.java
@@ -101,7 +101,6 @@ public interface OvfProperties {
     String CPU_PINNING = "CpuPinning";
     String MULTI_QUEUES_ENABLED = "MultiQueuesEnabled";
     String VIRTIO_SCSI_MULTI_QUEUES_ENABLED = "VirtioScsiMultiQueuesEnabled";
-    String NUMA_TUNE_MODE = "NumaTuneMode";
     String BALLOON_ENABLED = "BalloonEnabled";
     String CPU_PINNING_POLICY = "CpuPinningPolicy";
 
@@ -128,4 +127,12 @@ public interface OvfProperties {
     String VM_EXTERNAL_DATA_ITEM = "VmExternalDataItem";
     String VM_EXTERNAL_DATA_KIND = "kind";
     String VM_EXTERNAL_DATA_CONTENT = "VmExternalDataContent";
+
+    // NUMA
+    String NUMA_NODE = "NumaNode";
+    String NUMA_INDEX = "Index";
+    String NUMA_CPU_ID_LIST = "cpuIdList";
+    String NUMA_VDS_NUMA_LIST = "vdsNumaNodeList";
+    String NUMA_TOTAL_MEMORY = "MemTotal";
+    String NUMA_TUNE_MODE = "NumaTuneMode";
 }

--- a/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfReader.java
+++ b/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfReader.java
@@ -972,7 +972,7 @@ public abstract class OvfReader implements IOvfBuilder {
         }
     }
 
-    protected void readNumaNodeListSection(XmlNode section, boolean ova) {
+    protected void readNumaNodeListSection(XmlNode section, boolean readNUMAPinning) {
         XmlNodeList list = selectNodes(section, NUMA_NODE);
         List<VmNumaNode> vmNumaNodes = new ArrayList<>();
 
@@ -984,7 +984,7 @@ public abstract class OvfReader implements IOvfBuilder {
             }
             vmNumaNode.setIndex(Integer.valueOf(selectSingleNode(node, NUMA_INDEX, _xmlNS).innerText));
             vmNumaNode.setCpuIds(readIntegerList(node, NUMA_CPU_ID_LIST));
-            vmNumaNode.setVdsNumaNodeList(ova ? new ArrayList<>() : readIntegerList(node, NUMA_VDS_NUMA_LIST));
+            vmNumaNode.setVdsNumaNodeList(readNUMAPinning ? readIntegerList(node, NUMA_VDS_NUMA_LIST) : new ArrayList<>());
             vmNumaNode.setMemTotal(Long.valueOf(selectSingleNode(node, NUMA_TOTAL_MEMORY, _xmlNS).innerText));
             XmlNode numaTuneMode = selectSingleNode(node, NUMA_TUNE_MODE, _xmlNS);
             if (numaTuneMode != null) {

--- a/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfVmReader.java
+++ b/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfVmReader.java
@@ -12,12 +12,10 @@ import org.ovirt.engine.core.common.businessentities.ArchitectureType;
 import org.ovirt.engine.core.common.businessentities.CpuPinningPolicy;
 import org.ovirt.engine.core.common.businessentities.Label;
 import org.ovirt.engine.core.common.businessentities.LabelBuilder;
-import org.ovirt.engine.core.common.businessentities.NumaTuneMode;
 import org.ovirt.engine.core.common.businessentities.Snapshot;
 import org.ovirt.engine.core.common.businessentities.Snapshot.SnapshotStatus;
 import org.ovirt.engine.core.common.businessentities.Snapshot.SnapshotType;
 import org.ovirt.engine.core.common.businessentities.VM;
-import org.ovirt.engine.core.common.businessentities.VmNumaNode;
 import org.ovirt.engine.core.common.businessentities.VmStatic;
 import org.ovirt.engine.core.common.businessentities.network.VmNetworkInterface;
 import org.ovirt.engine.core.common.businessentities.storage.DiskImage;
@@ -148,31 +146,6 @@ public class OvfVmReader extends OvfOvirtReader {
         }
         return null;
     }
-
-
-    protected void readNumaNodeListSection(XmlNode section) {
-        XmlNodeList list = selectNodes(section, "NumaNode");
-        List<VmNumaNode> vmNumaNodes = new ArrayList<>();
-        _vm.setvNumaNodeList(vmNumaNodes);
-
-        for (XmlNode node : list) {
-            VmNumaNode vmNumaNode = new VmNumaNode();
-            XmlNode id = selectSingleNode(node, "id", _xmlNS);
-            if (id != null) {
-                vmNumaNode.setId(new Guid(id.innerText));
-            }
-            vmNumaNode.setIndex(Integer.valueOf(selectSingleNode(node, "Index", _xmlNS).innerText));
-            vmNumaNode.setCpuIds(readIntegerList(node, "cpuIdList"));
-            vmNumaNode.setVdsNumaNodeList(readIntegerList(node, "vdsNumaNodeList"));
-            vmNumaNode.setMemTotal(Long.valueOf(selectSingleNode(node, "MemTotal", _xmlNS).innerText));
-            XmlNode numaTuneMode = selectSingleNode(node, NUMA_TUNE_MODE, _xmlNS);
-            if (numaTuneMode != null) {
-                vmNumaNode.setNumaTuneMode(NumaTuneMode.forValue(numaTuneMode.innerText));
-            }
-            vmNumaNodes.add(vmNumaNode);
-        }
-    }
-
 
     @Override
     protected void readSnapshotsSection(XmlNode section) {

--- a/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfVmWriter.java
+++ b/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfVmWriter.java
@@ -119,7 +119,8 @@ public class OvfVmWriter extends OvfOvirtWriter {
      * Write the numa nodes of the VM.<br>
      * If no numa nodes were set to be written, this section will not be written.
      */
-    private void writeNumaNodeList() {
+    @Override
+    protected void writeNumaNodeList() {
         List<VmNumaNode> vmNumaNodes = vm.getvNumaNodeList();
 
         if (vmNumaNodes == null || vmNumaNodes.isEmpty()) {
@@ -127,20 +128,7 @@ public class OvfVmWriter extends OvfOvirtWriter {
         }
         _writer.writeStartElement("Section");
         _writer.writeAttributeString(XSI_URI, "type", "ovf:NumaNodeSection_Type");
-
-        for (VmNumaNode vmNumaNode : vmNumaNodes) {
-            _writer.writeStartElement("NumaNode");
-            if (vmNumaNode.getId() != null) {
-                _writer.writeElement("id", String.valueOf(vmNumaNode.getId()));
-            }
-            _writer.writeElement("Index", String.valueOf(vmNumaNode.getIndex()));
-            writeIntegerList("cpuIdList", vmNumaNode.getCpuIds());
-            writeIntegerList("vdsNumaNodeList", vmNumaNode.getVdsNumaNodeList());
-            _writer.writeElement("MemTotal", String.valueOf(vmNumaNode.getMemTotal()));
-            _writer.writeElement(NUMA_TUNE_MODE, vmNumaNode.getNumaTuneMode().getValue());
-            _writer.writeEndElement();
-        }
-        _writer.writeEndElement();
+        super.writeNumaNodeList();
     }
 
     /**

--- a/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfVmWriter.java
+++ b/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfVmWriter.java
@@ -9,7 +9,6 @@ import org.ovirt.engine.core.common.businessentities.Label;
 import org.ovirt.engine.core.common.businessentities.Snapshot;
 import org.ovirt.engine.core.common.businessentities.VM;
 import org.ovirt.engine.core.common.businessentities.VmDevice;
-import org.ovirt.engine.core.common.businessentities.VmNumaNode;
 import org.ovirt.engine.core.common.businessentities.VmStatic;
 import org.ovirt.engine.core.common.businessentities.storage.DiskImage;
 import org.ovirt.engine.core.common.businessentities.storage.FullEntityOvfData;

--- a/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfVmWriter.java
+++ b/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfVmWriter.java
@@ -108,7 +108,7 @@ public class OvfVmWriter extends OvfOvirtWriter {
     protected void writeHardware() {
         super.writeHardware();
         writeSnapshotsSection();
-        writeNumaNodeList();
+        writeNumaSection();
     }
 
     protected boolean isSpecialDevice(VmDevice vmDevice) {

--- a/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfVmWriter.java
+++ b/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfVmWriter.java
@@ -91,7 +91,6 @@ public class OvfVmWriter extends OvfOvirtWriter {
 
         writeAffinityGroups();
         writeAffinityLabels();
-        writeNumaNodeList();
     }
 
     private void writeLogEvent(String name, String value) {
@@ -109,26 +108,17 @@ public class OvfVmWriter extends OvfOvirtWriter {
     protected void writeHardware() {
         super.writeHardware();
         writeSnapshotsSection();
+        writeNumaNodeList();
     }
 
     protected boolean isSpecialDevice(VmDevice vmDevice) {
         return VmDeviceCommonUtils.isSpecialDevice(vmDevice.getDevice(), vmDevice.getType(), true);
     }
 
-    /**
-     * Write the numa nodes of the VM.<br>
-     * If no numa nodes were set to be written, this section will not be written.
-     */
     @Override
-    protected void writeNumaNodeList() {
-        List<VmNumaNode> vmNumaNodes = vm.getvNumaNodeList();
-
-        if (vmNumaNodes == null || vmNumaNodes.isEmpty()) {
-            return;
-        }
+    protected void startNUMASection() {
         _writer.writeStartElement("Section");
         _writer.writeAttributeString(XSI_URI, "type", "ovf:NumaNodeSection_Type");
-        super.writeNumaNodeList();
     }
 
     /**

--- a/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfWriter.java
+++ b/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfWriter.java
@@ -793,7 +793,8 @@ public abstract class OvfWriter implements IOvfBuilder {
         _writer.writeEndElement();
     }
 
-    protected abstract void startNUMASection();
+    protected void startNUMASection() {
+    }
 
     private void writeIntegerList(String label, List<Integer> list) {
         if (list != null && !list.isEmpty()) {

--- a/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfWriter.java
+++ b/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfWriter.java
@@ -770,7 +770,7 @@ public abstract class OvfWriter implements IOvfBuilder {
      * Write the numa nodes of the VM.<br>
      * If no numa nodes were set to be written, this section will not be written.
      */
-    protected void writeNumaNodeList() {
+    protected void writeNumaSection() {
         List<VmNumaNode> vmNumaNodes = vmBase.getvNumaNodeList();
 
         if (vmNumaNodes == null || vmNumaNodes.isEmpty()) {

--- a/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfWriter.java
+++ b/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfWriter.java
@@ -777,6 +777,7 @@ public abstract class OvfWriter implements IOvfBuilder {
             return;
         }
 
+        startNUMASection();
         for (VmNumaNode vmNumaNode : vmNumaNodes) {
             _writer.writeStartElement(NUMA_NODE);
             if (vmNumaNode.getId() != null) {
@@ -791,6 +792,8 @@ public abstract class OvfWriter implements IOvfBuilder {
         }
         _writer.writeEndElement();
     }
+
+    protected abstract void startNUMASection();
 
     private void writeIntegerList(String label, List<Integer> list) {
         if (list != null && !list.isEmpty()) {


### PR DESCRIPTION
This patch adds the NUMA nodes list of a VM to the OVA's OVF. It allows
exporting and importing the current VM configuration of virtual NUMA
nodes.

Change-Id: I7cba56cb63020b061e3554805f58f9db653f40fa
Bug-Url: https://bugzilla.redhat.com/2079605
Signed-off-by: Liran Rotenberg <lrotenbe@redhat.com>