### PR TITLE
db: fix fn_db_change_column_null

### DIFF
--- a/packaging/dbscripts/upgrade/04_05_0100_fix_04_04_0050_set_to_not_null.sql
+++ b/packaging/dbscripts/upgrade/04_05_0100_fix_04_04_0050_set_to_not_null.sql
@@ -1,21 +1,2 @@
--- Make sure that forgotten options from ancient releases have default value
-UPDATE vdc_options
-  SET default_value = option_value
-  WHERE
-    default_value IS NULL
-    AND option_value IS NOT NULL;
-
--- If there are still some crappy options, let's set default value to empty string
-UPDATE vdc_options
-  SET default_value = ''
-  WHERE
-    default_value IS NULL
-    AND option_value IS NULL;
-
--- We shouldn't have any options with NULL values by now, but let's make sure
-UPDATE vdc_options
-  SET option_value = ''
-  WHERE option_value IS NULL;
-
-SELECT fn_db_change_column_null('vdc_options', 'default_value', false);
-SELECT fn_db_change_column_null('vdc_options', 'option_value', false);
+SELECT fn_db_change_column_null('vdc_options', 'default_value', false, 'text');
+SELECT fn_db_change_column_null('vdc_options', 'option_value', false, 'text');

--- a/packaging/dbscripts/upgrade/pre_upgrade/0000_config.sql
+++ b/packaging/dbscripts/upgrade/pre_upgrade/0000_config.sql
@@ -1456,4 +1456,4 @@ select fn_db_split_config_value('LiveSnapshotPerformFreezeInEngine', 'false', 'f
 --
 -- This must be the last section of the file!
 ------------------------------------------------------------------------------------
-select fn_db_change_column_null('vdc_options', 'default_value', false);
+select fn_db_change_column_null('vdc_options', 'default_value', false, 'text');


### PR DESCRIPTION
Changing the function that sets a column in the part that turns from
NULL to not NULL to set any found NULL values on the changed column
values to a default value according to the column type.

This script changes also upgrade scripts to pass the v_type new
parameter.

In case that unsupported type is passed, an error is thrown.

Signed-off-by: Eli Mesika <emesika@redhat.com>
Bug-Url: https://bugzilla.redhat.com/2077387
Allow-db-upgrade-script-changes: Yes