### PR TITLE
Block snapshot removal when VM in backup

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/snapshots/RemoveSnapshotCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/snapshots/RemoveSnapshotCommand.java
@@ -389,6 +389,10 @@ public class RemoveSnapshotCommand<T extends RemoveSnapshotParameters> extends V
             return false;
         }
 
+        if (getParameters().getParentCommand() != ActionType.HybridBackup && isVmDuringBackup()) {
+            return failValidation(EngineMessage.ACTION_TYPE_FAILED_VM_IS_DURING_BACKUP);
+        }
+
         VmValidator vmValidator = createVmValidator(getVm());
         if (!validate(new StoragePoolValidator(getStoragePool()).existsAndUp()) ||
                 !validateVmSnapshotDisksNotDuringMerge() ||


### PR DESCRIPTION
Currently removing snapshots on VM during Hybrid backup is not blocked
which allows user to remove the parent snapshot of the auto-generated
snapshot. As a result, the user cannot initiate an image transfer.

Blocking any snapshot removal during active backup fixes this issue,
and also prevents other conflicts. This validation is skipped for
snapshot removal done as part of Hybrid Backup finalization

This PR depends on:
https://github.com/oVirt/ovirt-engine/pull/375

Bug-Url: https://bugzilla.redhat.com/1954427