### PR TITLE
webadmin: Preselect bochs for Server VMs

### DIFF
--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/UnitVmModel.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/UnitVmModel.java
@@ -2307,6 +2307,7 @@ public class UnitVmModel extends Model implements HasValidatedTabs, ModelWithMig
                 updateResumeBehavior();
             } else if (sender == getBiosType()) {
                 updateDisplayAndGraphics();
+                behavior.assignDefaultDisplayType();
                 updateTpmEnabled();
             } else if (sender == getCpuPinningPolicy()) {
                 cpuPinningPolicyChanged();
@@ -2388,6 +2389,7 @@ public class UnitVmModel extends Model implements HasValidatedTabs, ModelWithMig
     private void compatibilityVersionChanged(Object sender, EventArgs args) {
         dataCenterWithClusterSelectedItemChanged(sender, args);
         updateDisplayAndGraphics();
+        behavior.assignDefaultDisplayType();
         behavior.updateNumOfIoThreads();
         initUsbPolicy();
         updateMultiQueues();

--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/VmModelBehaviorBase.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/VmModelBehaviorBase.java
@@ -1407,9 +1407,6 @@ public abstract class VmModelBehaviorBase<TModel extends UnitVmModel> {
 
         if (vmType == VmType.Server) {
             getModel().getIoThreadsEnabled().setEntity(true);
-            if (getModel().getDisplayType().getItems().contains(DisplayType.bochs)) {
-                getModel().getDisplayType().setSelectedItem(DisplayType.bochs);
-            }
         }
 
         // Configuration relevant only for High Performance
@@ -1441,6 +1438,8 @@ public abstract class VmModelBehaviorBase<TModel extends UnitVmModel> {
         } else {
             getModel().getHostCpu().setEntity(false);
         }
+
+        assignDefaultDisplayType();
 
         // Configuration relevant for either High Performance or VMs with pinned configuration
         if (isVmHpOrPinningConfigurationEnabled()) {
@@ -1856,4 +1855,13 @@ public abstract class VmModelBehaviorBase<TModel extends UnitVmModel> {
                  && getModel().getTemplateWithVersion().getSelectedItem() != null
                  && getModel().getTemplateWithVersion().getSelectedItem().isLatest();
      }
+
+    protected void assignDefaultDisplayType() {
+        if (getModel().getVmType() != null && getModel().getVmType().getSelectedItem() == VmType.Server
+                && getModel().getDisplayType().getItems() != null
+                && getModel().getDisplayType().getItems().contains(DisplayType.bochs)) {
+            getModel().getDisplayType().setSelectedItem(DisplayType.bochs);
+        }
+    }
+
 }


### PR DESCRIPTION
When VM type is set to Server, if bochs display type is available
according to compatibility version and BIOS type, select it
automatically.

Change-Id: I908a5a090457f8d2ceb165e4b691bd84defe0bb8
Bug-Url: https://bugzilla.redhat.com/1949004
Signed-off-by: Shmuel Melamud <smelamud@redhat.com>