### PR TITLE
core: copy disk will set the correct allocation policy for the new copied disk

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/CopyImageGroupWithDataCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/CopyImageGroupWithDataCommand.java
@@ -156,6 +156,7 @@ public class CopyImageGroupWithDataCommand<T extends CopyImageGroupWithDataComma
         parameters.setParentCommand(getActionType());
         parameters.setParentParameters(getParameters());
         parameters.setEndProcedure(EndProcedure.COMMAND_MANAGED);
+        parameters.setBackup(getDiskImage().getBackup());
         runInternalAction(ActionType.CreateVolumeContainer, parameters);
     }
 

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/CreateVolumeContainerCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/CreateVolumeContainerCommand.java
@@ -13,9 +13,9 @@ import org.ovirt.engine.core.bll.NonTransactiveCommandAttribute;
 import org.ovirt.engine.core.bll.context.CommandContext;
 import org.ovirt.engine.core.bll.utils.PermissionSubject;
 import org.ovirt.engine.core.common.VdcObjectType;
-import org.ovirt.engine.core.common.action.ActionType;
 import org.ovirt.engine.core.common.action.CreateVolumeContainerCommandParameters;
 import org.ovirt.engine.core.common.asynctasks.AsyncTaskType;
+import org.ovirt.engine.core.common.businessentities.storage.DiskBackup;
 import org.ovirt.engine.core.common.businessentities.storage.DiskContentType;
 import org.ovirt.engine.core.common.businessentities.storage.DiskImage;
 import org.ovirt.engine.core.common.businessentities.storage.VolumeFormat;
@@ -81,7 +81,8 @@ public class CreateVolumeContainerCommand<T extends CreateVolumeContainerCommand
     }
 
     private VolumeType getType() {
-        if (getParentParameters() != null && getParentParameters().getParentCommand() == ActionType.ConvertDisk) {
+        // When the incremental backup flag is set, we have no limitation on the format/allocation policy combination
+        if (getParameters().getBackup() == DiskBackup.Incremental) {
             return getParameters().getVolumeType();
         }
 

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/CreateVolumeContainerCommandParameters.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/CreateVolumeContainerCommandParameters.java
@@ -1,5 +1,6 @@
 package org.ovirt.engine.core.common.action;
 
+import org.ovirt.engine.core.common.businessentities.storage.DiskBackup;
 import org.ovirt.engine.core.common.businessentities.storage.VolumeFormat;
 import org.ovirt.engine.core.common.businessentities.storage.VolumeType;
 import org.ovirt.engine.core.compat.Guid;
@@ -14,6 +15,8 @@ public class CreateVolumeContainerCommandParameters extends StorageJobCommandPar
     private boolean legal = true;
 
     private Integer sequenceNumber;
+
+    private DiskBackup backup;
 
     public CreateVolumeContainerCommandParameters() {
     }
@@ -99,5 +102,13 @@ public class CreateVolumeContainerCommandParameters extends StorageJobCommandPar
 
     public void setSequenceNumber(Integer sequenceNumber) {
         this.sequenceNumber = sequenceNumber;
+    }
+
+    public DiskBackup getBackup() {
+        return backup;
+    }
+
+    public void setBackup(DiskBackup backup) {
+        this.backup = backup;
     }
 }


### PR DESCRIPTION
while coping disk that has incremental backup flag up and set to be preallocated
the new copied disk will change the allocation policy to thin provision.
now it will change the allocation policy to be the same as it was set on the original disk

Bug-Url: https://bugzilla.redhat.com/2072423
Signed-off-by: Artiom Divak <adivak@redhat.com>