### PR TITLE
Allow setting virtual NUMA nodes without host pinning

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/numa/vm/NumaValidator.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/numa/vm/NumaValidator.java
@@ -330,7 +330,7 @@ public class NumaValidator {
         }
 
         // Check if the VM is pinned to at least one host
-        if (vm.getDedicatedVmForVdsList().isEmpty() && !VmCpuCountHelper.isResizeAndPinPolicy(vm)) {
+        if (vm.getDedicatedVmForVdsList().isEmpty() && !VmCpuCountHelper.isResizeAndPinPolicy(vm) && isNumaPinning(vmNumaNodes)) {
             return new ValidationResult(EngineMessage.ACTION_TYPE_FAILED_VM_NOT_PINNED_TO_AT_LEAST_ONE_HOST);
         }
 
@@ -344,6 +344,10 @@ public class NumaValidator {
         }
 
         return validateNumaCompatibility(vm, vmNumaNodes, hostsNumaNodesMap);
+    }
+
+    private boolean isNumaPinning(final List<VmNumaNode> vmNumaNodes) {
+        return vmNumaNodes.stream().anyMatch(node -> !node.getVdsNumaNodeList().isEmpty());
     }
 
     private String formatMissingIndices(List<Integer> missingIndices) {

--- a/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/numa/vm/AddVmNumaNodesCommandTest.java
+++ b/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/numa/vm/AddVmNumaNodesCommandTest.java
@@ -100,13 +100,12 @@ public class AddVmNumaNodesCommandTest
     }
 
     @Test
-    public void canNotDoWithoutPinnedHost() {
+    public void canDoWithoutPinnedHost() {
         mockCommandWithVmFromDb();
         vm.setMigrationSupport(MigrationSupport.IMPLICITLY_NON_MIGRATABLE);
 
         vm.setDedicatedVmForVdsList(new ArrayList<>());
-        ValidateTestUtils.runAndAssertValidateFailure(command,
-                EngineMessage.ACTION_TYPE_FAILED_VM_NOT_PINNED_TO_AT_LEAST_ONE_HOST);
+        assertThat(command.validate()).isTrue();
     }
 
     @Test

--- a/frontend/webadmin/modules/gwt-common/src/main/java/org/ovirt/engine/ui/common/widget/uicommon/popup/AbstractVmPopupWidget.java
+++ b/frontend/webadmin/modules/gwt-common/src/main/java/org/ovirt/engine/ui/common/widget/uicommon/popup/AbstractVmPopupWidget.java
@@ -1707,6 +1707,7 @@ public abstract class AbstractVmPopupWidget extends AbstractModeSwitchingPopupWi
         affinityGroupSelectionWidget.init(model.getAffinityGroupList());
         affinityLabelSelectionWidget.init(model.getLabelList());
         quotaEditor.setEnabled(!model.isHostedEngine());
+        numaNodeCount.setEnabled(true);
         initTabAvailabilityListeners(model);
         initListeners(model);
         hideAlwaysHiddenFields();
@@ -1755,7 +1756,6 @@ public abstract class AbstractVmPopupWidget extends AbstractModeSwitchingPopupWi
     }
 
     private void enableNumaFields(boolean enabled) {
-        numaNodeCount.setEnabled(enabled);
         numaSupportButton.setEnabled(enabled);
     }
 

--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/ExistingVmModelBehavior.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/ExistingVmModelBehavior.java
@@ -501,7 +501,7 @@ public class ExistingVmModelBehavior extends VmModelBehaviorBase<UnitVmModel> {
     protected void updateNumaEnabled() {
         super.updateNumaEnabled();
         updateNumaEnabledHelper();
-        if (Boolean.TRUE.equals(getModel().getNumaEnabled().getEntity()) && getModel().getVmNumaNodes() != null) {
+        if (getModel().getVmNumaNodes() != null) {
             getModel().getNumaNodeCount().setEntity(getModel().getVmNumaNodes().size());
         }
 

--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/VmModelBehaviorBase.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/VmModelBehaviorBase.java
@@ -1641,6 +1641,7 @@ public abstract class VmModelBehaviorBase<TModel extends UnitVmModel> {
 
         if (getModel().getIsAutoAssign().getEntity() ||
                 getModel().getDefaultHost().getSelectedItems() == null ||
+                getModel().getDefaultHost().getSelectedItems().isEmpty() ||
                 getModel().getDefaultHost().getSelectedItems().stream().anyMatch(x -> !x.isNumaSupport())) {
             enabled = false;
         }
@@ -1648,8 +1649,6 @@ public abstract class VmModelBehaviorBase<TModel extends UnitVmModel> {
             getModel().getNumaEnabled().setMessage(constants.numaInfoMessage());
         } else {
             getModel().getNumaEnabled().setMessage(constants.numaDisabledInfoMessage());
-            getModel().getNumaNodeCount().setEntity(0);
-
         }
         getModel().getNumaEnabled().setEntity(enabled);
     }


### PR DESCRIPTION
This patch will allow setting via UI and API virtual NUMA nodes to a VM
without having the VM pinned to a host. If a `numa_node_pin` is set, the
scheduler will filter out hosts that won't fit to the NUMA pinning.
Otherwise, the VM will start with the set amount of virtual NUMA nodes.

Change-Id: Ia35a95babf3ae6b2d4713c809052be1d6ddede38
Bug-Url: https://bugzilla.redhat.com/2081410
Signed-off-by: Liran Rotenberg <lrotenbe@redhat.com>