### PR TITLE
core: do not remove snapshot from DB if related images were not removed

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/snapshots/CreateSnapshotCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/snapshots/CreateSnapshotCommand.java
@@ -5,7 +5,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
-import java.util.Set;
 
 import javax.inject.Inject;
 
@@ -213,7 +212,7 @@ public class CreateSnapshotCommand<T extends CreateSnapshotParameters> extends B
         List<VM> vms = vmDao.getVmsListForDisk(getDestinationDiskImage().getId(), false);
         if (getDestinationDiskImage() != null
                 && !vms.isEmpty()
-                && !isSnapshotUsed(vms.get(0))) {
+                && !imagesHandler.isSnapshotUsed(vms.get(0), getDiskImage())) {
 
             // Empty Guid, means new disk rather than snapshot, so no need to add a map to the db for new disk.
             if (!getDestinationDiskImage().getParentId().equals(Guid.Empty)) {
@@ -241,23 +240,6 @@ public class CreateSnapshotCommand<T extends CreateSnapshotParameters> extends B
             unLockImage();
         }
         setSucceeded(true);
-    }
-
-    private boolean isSnapshotUsed(VM vm) {
-        if (vm.isRunningOrPaused()) {
-            Set<Guid> volumeChain = imagesHandler.getVolumeChain(vm.getId(),
-                    vm.getRunOnVds(),
-                    getDiskImage());
-
-            if (volumeChain != null && !volumeChain.contains(getDiskImage().getImageId())) {
-                return false;
-            } else {
-                log.warn("Can not get image chain or image '{}' is still in the chain, skipping deletion",
-                        getDiskImage().getImageId());
-            }
-        }
-
-        return true;
     }
 
     protected DestroyImageParameters buildDestroyImageParameters(Guid imageGroupId, List<Guid> imageList) {

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/snapshots/CreateSnapshotForVmCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/snapshots/CreateSnapshotForVmCommand.java
@@ -481,8 +481,7 @@ public class CreateSnapshotForVmCommand<T extends CreateSnapshotForVmParameters>
 
             return null;
         });
-        setSucceeded(getParameters().getTaskGroupSuccess() &&
-                (!getParameters().isLiveSnapshotRequired() || getParameters().isLiveSnapshotSucceeded()));
+        setSucceeded(true);
         getReturnValue().setEndActionTryAgain(false);
     }
 

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/ImagesHandler.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/ImagesHandler.java
@@ -1065,6 +1065,22 @@ public class ImagesHandler {
         return images;
     }
 
+    public boolean isSnapshotUsed(VM vm, DiskImage image) {
+        if (vm.isRunningOrPaused()) {
+            Set<Guid> volumeChain = getVolumeChain(vm.getId(),
+                    vm.getRunOnVds(),
+                    image);
+
+            if (volumeChain != null && !volumeChain.contains(image.getImageId())) {
+                return false;
+            } else {
+                log.warn("Can not get image chain or image '{}' is still in the chain", image.getImageId());
+            }
+        }
+
+        return true;
+    }
+
     private Map[] getVms(Guid vdsId, Guid vmId) {
         return (Map[]) fullListAdapter.getVmFullList(
                 vdsId,

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/AuditLogType.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/AuditLogType.java
@@ -1585,6 +1585,8 @@ public enum AuditLogType {
     USER_FAILED_TO_THAW_VM(10770, AuditLogSeverity.WARNING),
     VDS_CANNOT_CONNECT_TO_GLUSTERFS(10771, AuditLogSeverity.ERROR),
 
+    SNAPSHOT_MAY_BE_INCONSISTENT(10774, AuditLogSeverity.WARNING),
+
     // Managed Block Storage
     CONNECTOR_INFO_MISSING_ON_VDS(10772, AuditLogSeverity.ERROR),
     UNDO_SNAPSHOT_FAILURE_PARTIAL(10773, AuditLogSeverity.ERROR),

--- a/backend/manager/modules/dal/src/main/resources/bundles/AuditLogMessages.properties
+++ b/backend/manager/modules/dal/src/main/resources/bundles/AuditLogMessages.properties
@@ -79,6 +79,7 @@ USER_FAILED_ATTACH_USER_TO_VM=Failed to attach User ${AdUserName} to VM ${VmName
 USER_FAILED_CHANGE_DISK_VM=Failed to change disk in VM ${VmName} (Host: ${VdsName}, User: ${UserName}).
 USER_FAILED_CREATE_SNAPSHOT=Failed to create Snapshot ${SnapshotName} for VM ${VmName} (User: ${UserName}).
 USER_CREATE_LIVE_SNAPSHOT_NO_MEMORY_FAILURE=Failed to save memory as part of Snapshot ${SnapshotName} for VM ${VmName} (User: ${UserName}).
+SNAPSHOT_MAY_BE_INCONSISTENT=Snapshot ${SnapshotName} for VM ${VmName} (User: ${UserName}), may be inconsistent as there was a failure during creation.
 USER_FAILED_REMOVE_SNAPSHOT=Failed to remove Snapshot ${SnapshotName} for VM ${VmName} (User: ${UserName}).
 USER_FAILED_PAUSE_VM=Failed to suspend VM ${VmName} (Host: ${VdsName}, User: ${UserName}).
 USER_FAILED_REMOVE_VDS=Failed to remove Host ${VdsName} (User: ${UserName}).


### PR DESCRIPTION
If we ended up not removing the new active volume from the storage
because they may be in-use, do not remove the snapshot from the database
as it may create a discrepancy between the engine DB and the storage,
leading to other issues.

Bug-Url: https://bugzilla.redhat.com/2081294
Signed-off-by: Benny Zlotnik <bzlotnik@redhat.com>