### PR TITLE
Set limit the unknown status in ansible callback

### DIFF
--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/AnsibleCommandParameters.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/AnsibleCommandParameters.java
@@ -14,10 +14,12 @@ public class AnsibleCommandParameters extends ActionParametersBase {
     private Guid hostId;
     private String playAction;
     private Map<String, Object> variables;
+    private long commandStartTime;
 
     public AnsibleCommandParameters() {
         super();
         this.playUuid = UUID.randomUUID().toString();
+        this.commandStartTime = System.currentTimeMillis();
     }
 
     public int getLastEventId() {
@@ -74,5 +76,13 @@ public class AnsibleCommandParameters extends ActionParametersBase {
 
     public Map<String, Object> getVariables() {
         return variables;
+    }
+
+    public long getCommandStartTime() {
+        return commandStartTime;
+    }
+
+    public void setCommandStartTime(long commandStartTime) {
+        this.commandStartTime = commandStartTime;
     }
 }

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/config/ConfigValues.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/config/ConfigValues.java
@@ -1628,6 +1628,12 @@ public enum ConfigValues {
     @TypeConverterAttribute(Boolean.class)
     IsDedicatedSupported,
 
+    /**
+     * Defines max timeout in seconds for async ansible callback when status is unknown.
+     */
+    @TypeConverterAttribute(Integer.class)
+    AsyncAnsibleTimeout,
+
     Invalid;
 
     private ClientAccessLevel accessLevel;

--- a/packaging/dbscripts/upgrade/pre_upgrade/0000_config.sql
+++ b/packaging/dbscripts/upgrade/pre_upgrade/0000_config.sql
@@ -210,6 +210,8 @@ select fn_db_add_config_value('AnsibleRunnerArtifactsCleanupCheckTimeInHours','2
 
 select fn_db_add_config_value('AnsibleRunnerArtifactsLifetimeInDays', '14', 'general');
 
+select fn_db_add_config_value('AsyncAnsibleTimeout','180','general');
+
 select fn_db_add_config_value('MaxIoThreadsPerVm','127','general');
 
 select fn_db_add_config_value('DisplayUncaughtUIExceptions', 'true', 'general');

--- a/packaging/etc/engine-config/engine-config.properties
+++ b/packaging/etc/engine-config/engine-config.properties
@@ -490,6 +490,8 @@ AnsibleRunnerArtifactsCleanupCheckTimeInHours.description=Refresh rate (in hours
 AnsibleRunnerArtifactsCleanupCheckTimeInHours.type=Double
 AnsibleRunnerArtifactsLifetimeInDays.description=Artifacts lifetime (in days)
 AnsibleRunnerArtifactsLifetimeInDays.type=Integer
+AsyncAnsibleTimeout.type=Integer
+AsyncAnsibleTimeout.description=Defines max timeout in seconds for async ansible call, when status is unknown.
 # Hosted Engine
 HostedEngineVmName.description=The name of the Hosted Engine VM. That name will be used to perform exclusive operation by ovirt-engine on that VM.
 AutoImportHostedEngine.description="Try to automatically import the hosted engine VM and its storage domain"


### PR DESCRIPTION
When calling ansible callback, we check the event and see the command
status. Initially the command status is `unknown`. Until now the async
ansible callback had no limitations, but if the ansible runner service
and the artifacts are gone, it will keep being on `unknown` state or
move to this state again, running for unlimited time.

Change-Id: I31c7c4a1bc17721806c70769377fe1a1cf059b57
Bug-Url: https://bugzilla.redhat.com/2030293
Signed-off-by: Liran Rotenberg <lrotenbe@redhat.com>