### PR TITLE
core: Replace all illegal chars in disk aliases

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ImportVmFromExternalProviderCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ImportVmFromExternalProviderCommand.java
@@ -75,6 +75,7 @@ implements SerialChildExecutingCommand, QuotaStorageDependent {
 
     private static final Pattern VMWARE_DISK_NAME_PATTERN = Pattern.compile("\\[.*?\\] .*/(.*).vmdk");
     private static final Pattern DISK_NAME_PATTERN = Pattern.compile(".*/([^.]+).*");
+    private static final Pattern DISK_ALIAS_ILLEGAL_CHARS_PATTERN = Pattern.compile("[^\\w.-]");
 
     private static final String VDSM_COMPAT_VERSION_1_1 = "1.1";
 
@@ -369,7 +370,7 @@ implements SerialChildExecutingCommand, QuotaStorageDependent {
     }
 
     private static String replaceInvalidDiskAliasChars(String alias) {
-        return alias.replace(' ', '_');
+        return DISK_ALIAS_ILLEGAL_CHARS_PATTERN.matcher(alias).replaceAll("_");
     }
 
     protected static String renameDiskAlias(OriginType originType, String alias) {

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ImportVmFromExternalProviderCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ImportVmFromExternalProviderCommand.java
@@ -60,6 +60,7 @@ import org.ovirt.engine.core.common.job.Step;
 import org.ovirt.engine.core.common.job.StepEnum;
 import org.ovirt.engine.core.common.queries.IdQueryParameters;
 import org.ovirt.engine.core.common.queries.QueryType;
+import org.ovirt.engine.core.common.utils.ValidationUtils;
 import org.ovirt.engine.core.common.vdscommands.VDSCommandType;
 import org.ovirt.engine.core.common.vdscommands.VdsAndVmIDVDSParametersBase;
 import org.ovirt.engine.core.compat.Guid;
@@ -75,7 +76,8 @@ implements SerialChildExecutingCommand, QuotaStorageDependent {
 
     private static final Pattern VMWARE_DISK_NAME_PATTERN = Pattern.compile("\\[.*?\\] .*/(.*).vmdk");
     private static final Pattern DISK_NAME_PATTERN = Pattern.compile(".*/([^.]+).*");
-    private static final Pattern DISK_ALIAS_ILLEGAL_CHARS_PATTERN = Pattern.compile("[^\\w.-]");
+    private static final Pattern DISK_ALIAS_ILLEGAL_CHARS_PATTERN =
+            Pattern.compile("[^" + ValidationUtils.NO_SPECIAL_CHARACTER_CLASS_I18N + "]");
 
     private static final String VDSM_COMPAT_VERSION_1_1 = "1.1";
 

--- a/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/exportimport/ImportVmFromExternalProviderCommandTest.java
+++ b/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/exportimport/ImportVmFromExternalProviderCommandTest.java
@@ -18,4 +18,11 @@ public class ImportVmFromExternalProviderCommandTest {
         String alias = ImportVmFromExternalProviderCommand.renameDiskAlias(OriginType.XEN, "/home/vdsm/Fedora22.img");
         assertEquals("Fedora22", alias);
     }
+
+    @Test
+    public void renameImageWithSpecialChars() {
+        String alias = ImportVmFromExternalProviderCommand.renameDiskAlias(OriginType.VMWARE, "[datastore] Fedora21/Fedora 21-yy%2fmm.vmdk");
+        assertEquals("Fedora_21-yy_2fmm", alias);
+    }
+
 }

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/utils/ValidationUtils.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/utils/ValidationUtils.java
@@ -22,7 +22,8 @@ public class ValidationUtils {
 
     public static final String NO_SPECIAL_CHARACTERS_EXTRA_I18N = "^[\\p{L}0-9._\\+-]*$";
     public static final String CUSTOM_CPU_NAME = "^[\\p{L}0-9._\\+\\-,]*$";
-    public static final String NO_SPECIAL_CHARACTERS_I18N = "^[\\p{L}0-9._-]*$";
+    public static final String NO_SPECIAL_CHARACTER_CLASS_I18N = "\\p{L}0-9._-";
+    public static final String NO_SPECIAL_CHARACTERS_I18N = "^["+ NO_SPECIAL_CHARACTER_CLASS_I18N + "]*$";
     public static final String NO_SPECIAL_CHARACTERS = "[0-9a-zA-Z_-]+";
     public static final String ONLY_I18N_ASCII_OR_NONE = "[\\p{ASCII}\\p{L}]*";
     public static final String ONLY_ASCII_OR_NONE = "[\\p{ASCII}]*";


### PR DESCRIPTION
When importing a VM, aliases are generated for all imported disks. To
comply with oVirt naming convention for disk aliases, we need to replace
all illegal characters that may appear in imported disk names.

Change-Id: I4f54a3fd8e31799d8ca33d2f4413e82f452ebabd
Bug-Url: https://bugzilla.redhat.com/1904962
Signed-off-by: Shmuel Melamud <smelamud@redhat.com>