### PR TITLE
don't throw an exception when canceling playbook if play execution was already completed

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/hostdeploy/InstallVdsInternalCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/hostdeploy/InstallVdsInternalCommand.java
@@ -356,7 +356,7 @@ public class InstallVdsInternalCommand<T extends InstallVdsParameters> extends V
                 throw new VdsInstallException(
                     VDSStatus.InstallFailed,
                     String.format(
-                        "Failed to execute Ansible host-deploy role: %1$s. Please check logs for more details: %2$s",
+                        "Failed to execute Ansible host-deploy: %1$s. Please check logs for more details: %2$s",
                         ansibleReturnValue.getStderr(),
                         ansibleReturnValue.getLogFile()
                     )

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleRunnerHttpClient.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleRunnerHttpClient.java
@@ -213,7 +213,14 @@ public class AnsibleRunnerHttpClient {
         File output = File.createTempFile("output", ".log");
         String command = String.format("ansible-runner stop %1$s", uuid);
         ProcessBuilder ansibleProcessBuilder = new ProcessBuilder(command).redirectErrorStream(true).redirectOutput(output);
-        ansibleProcess = ansibleProcessBuilder.start();
+        try {
+            ansibleProcess = ansibleProcessBuilder.start();
+            // if play execution was already completed, the command fails.
+        } catch (IOException e) {
+            log.error(String.format("Failed to execute call to cancel playbook. %1$s, %2$s ",
+                    output.toString(), Paths.get(this.getJobEventsDir(uuid.toString()) + "../stdout")));
+            return;
+        }
         if (!ansibleProcess.waitFor(timeout, TimeUnit.MINUTES)) {
             throw new Exception("Timeout occurred while canceling Ansible playbook.");
         }

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleRunnerHttpClient.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleRunnerHttpClient.java
@@ -217,8 +217,10 @@ public class AnsibleRunnerHttpClient {
             ansibleProcess = ansibleProcessBuilder.start();
             // if play execution was already completed, the command fails.
         } catch (IOException e) {
-            log.error(String.format("Failed to execute call to cancel playbook. %1$s, %2$s ",
-                    output.toString(), Paths.get(this.getJobEventsDir(uuid.toString()) + "../stdout")));
+            log.error(String.format("Failed to execute call to cancel playbook. %1$s, %2$s../stdout ",
+                    output.toString(),
+                    Paths.get(this.getJobEventsDir(uuid.toString()))));
+            log.debug("Exception: ", e);
             return;
         }
         if (!ansibleProcess.waitFor(timeout, TimeUnit.MINUTES)) {


### PR DESCRIPTION
In some cases play execution is completed, but host deploy process is still running and parsing events.
In such case if the timeout was reached, an attempt to cancel the playbook will fail because the play process
no longer exists.
In cases where the command to cancel the playbook fails, an error will be logged with both host-deploy and
stdout logs.

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=2087738
