### PR TITLE
engine: Change the memory usage calculation 

### DIFF
--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/utils/HugePageUtils.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/utils/HugePageUtils.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import org.ovirt.engine.core.common.businessentities.HugePage;
+import org.ovirt.engine.core.common.businessentities.VDS;
 import org.ovirt.engine.core.common.businessentities.VmBase;
 import org.ovirt.engine.core.common.utils.customprop.SimpleCustomPropertiesUtil;
 
@@ -86,6 +87,30 @@ public class HugePageUtils {
     public static int totalHugePageMemMb(Map<Integer, Integer> hugepages) {
         long hugePageMemKb = hugepages.entrySet().stream()
                 .mapToLong(entry -> entry.getKey() * entry.getValue())
+                .sum();
+
+        return (int)((hugePageMemKb + KIB_IN_MIB - 1) / KIB_IN_MIB);
+    }
+
+    public static int totalHugePageMemMb(VDS vds) {
+        if (vds.getHugePages() == null) {
+            return 0;
+        }
+
+        long hugePageMemKb = vds.getHugePages().stream()
+                .mapToLong(hugePage -> hugePage.getTotal() * hugePage.getSizeKB())
+                .sum();
+
+        return (int)((hugePageMemKb + KIB_IN_MIB - 1) / KIB_IN_MIB);
+    }
+
+    public static int totalHugePageFreeMemMb(VDS vds) {
+        if (vds.getHugePages() == null) {
+            return 0;
+        }
+
+        long hugePageMemKb = vds.getHugePages().stream()
+                .mapToLong(hugePage -> hugePage.getFree() * hugePage.getSizeKB())
                 .sum();
 
         return (int)((hugePageMemKb + KIB_IN_MIB - 1) / KIB_IN_MIB);


### PR DESCRIPTION
So far, the memory usage was calculated in VDSM and the calculation considered hugepages as used memory. As a result, the host with hugepages had high memory usage even though the hugepages were not used.

This patch moves the calculation from VDSM to the engine. This allows to calculate the memory usage differently in various scenarios.

- In the UI, the memory usage calculation includes hugepages so that the user has the full overview of the host memory
- In host monitoring, we issue VDS_HIGH_MEM_USE only for the normal memory and calculation does NOT include hugepages

Bug-Url: https://bugzilla.redhat.com/2006625