### PR TITLE
Replace SpringFramework's StringUtils with Apache

### DIFF
--- a/backend/manager/modules/dal/src/test/java/org/ovirt/engine/core/dao/UnregisteredDisksDaoTest.java
+++ b/backend/manager/modules/dal/src/test/java/org/ovirt/engine/core/dao/UnregisteredDisksDaoTest.java
@@ -8,13 +8,13 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.commons.lang.StringUtils;
 import org.junit.jupiter.api.Test;
 import org.ovirt.engine.core.common.businessentities.VmBase;
 import org.ovirt.engine.core.common.businessentities.storage.DiskImage;
 import org.ovirt.engine.core.common.businessentities.storage.UnregisteredDisk;
 import org.ovirt.engine.core.common.businessentities.storage.UnregisteredDiskId;
 import org.ovirt.engine.core.compat.Guid;
-import org.springframework.util.StringUtils;
 
 public class UnregisteredDisksDaoTest extends BaseDaoTestCase<UnregisteredDisksDao> {
     @Test

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/VmReplicateDiskVDSCommand.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/VmReplicateDiskVDSCommand.java
@@ -3,8 +3,8 @@ package org.ovirt.engine.core.vdsbroker.vdsbroker;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.lang.StringUtils;
 import org.ovirt.engine.core.common.vdscommands.VmReplicateDiskParameters;
-import org.springframework.util.StringUtils;
 
 public abstract class VmReplicateDiskVDSCommand<P extends VmReplicateDiskParameters> extends VdsBrokerCommand<P> {
 


### PR DESCRIPTION
Remove SpringFrameworks's StringUtils implementation with Apache.

Bug-Url: https://bugzilla.redhat.com/2092010
Signed-off-by: Martin Perina <mperina@redhat.com>
