### PR TITLE
Initialize RFB with wsProtocols in novnc-main.jsp

### DIFF
--- a/backend/manager/modules/services/src/main/webapp/novnc-main.jsp
+++ b/backend/manager/modules/services/src/main/webapp/novnc-main.jsp
@@ -192,7 +192,8 @@
 
             // Creating a new RFB object will start a new connection
             rfb = new RFB(document.getElementById('screen'), url,
-                          { credentials: { password: password } });
+                          { credentials: { password: password },
+                            wsProtocols: ['binary'] });
 
             // Add listeners to important events from the RFB module
             rfb.addEventListener("connect",  connectedToServer);


### PR DESCRIPTION
Because of commit https://github.com/novnc/noVNC/commit/c912230309806aacbae4295faf7ad6406da97617, it's needed to initialize RFB with certain protocol, otherwise the ovirt-websocket-proxy report the error "code 400, message Client must support 'binary' or 'base64' protocol", when trying connecting to noVNC console.