### PR TITLE
core: vnic hot un\plug - avoid race

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/network/vm/ActivateDeactivateVmNicCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/network/vm/ActivateDeactivateVmNicCommand.java
@@ -473,15 +473,8 @@ public class ActivateDeactivateVmNicCommand<T extends ActivateDeactivateVmNicPar
     }
 
     private void updateDevice() {
-        if (getParameters().getAction() == PlugAction.PLUG
-                && hotPlugVmNicRequired(getVm().getStatus())) {
-            VmDevicesMonitoring.Change change = vmDevicesMonitoring.createChange(getVdsId(), System.nanoTime());
-            change.updateVm(getVmId(), VmDevicesMonitoring.UPDATE_HASH);
-            change.flush();
-        } else {
-            vmDevice.setPlugged(getParameters().getAction() == PlugAction.PLUG);
-            vmDeviceDao.update(vmDevice);
-        }
+        vmDevice.setPlugged(getParameters().getAction() == PlugAction.PLUG);
+        vmDeviceDao.update(vmDevice);
     }
 
     private boolean handleFailoverIfNeeded() {


### PR DESCRIPTION
Lack of a lock in ActivateDeactivateVmNicCommand allows several
instances of hot plug and unplug requests to run in parallel causing an
inconsistent in vNIC status as well as libvirt failing the requests due
to non-unique aliases. This patch adds a lock to the command so that
each instance of the command has to finish before the next one starts.

Bug-Url: https://bugzilla.redhat.com/2084530
Change-Id: I93ac9f1f12f34526ad10b9a49790c3a2689e8c4d
Signed-off-by: Eitan Raviv <eraviv@redhat.com>