### PR TITLE
packaging: Fix KeyError in ovirt-engine-rename certificate handling

### DIFF
--- a/packaging/setup/plugins/ovirt-engine-rename/ovirt-engine/ovn.py
+++ b/packaging/setup/plugins/ovirt-engine-rename/ovirt-engine/ovn.py
@@ -53,6 +53,7 @@ class Plugin(plugin.PluginBase):
                 'ca_cert': None,
                 'extract_key': True,
                 'extra_action': None,
+                'shortLife': False,
             }
         )
 

--- a/packaging/setup/plugins/ovirt-engine-rename/ovirt-engine/pki.py
+++ b/packaging/setup/plugins/ovirt-engine-rename/ovirt-engine/pki.py
@@ -81,6 +81,7 @@ class Plugin(plugin.PluginBase):
             ),
             'extract_key': True,
             'extra_action': _apache_extra_action,
+            'shortLife': True,
         },
     )
 

--- a/packaging/setup/plugins/ovirt-engine-rename/websocket_proxy/pki.py
+++ b/packaging/setup/plugins/ovirt-engine-rename/websocket_proxy/pki.py
@@ -45,6 +45,7 @@ class Plugin(plugin.PluginBase):
                 'ca_cert': None,
                 'extract_key': True,
                 'extra_action': None,
+                'shortLife': True,
             }
         )
 


### PR DESCRIPTION
In commit 67e77630f00ea4ff83a4002fac3aa68c1ce61bff, ‘shortLife’ entity
key was introduced to distinguish between short-lived (e.g. web) and
long-lived (e.g. CA, hosts) certificates.  The key was also used
in ovirt-engine-rename without adding it to the corresponding
entities, resulting in KeyError on ovirt-engine-rename invocation.

This patch fixes the problem by adding the missing keys.

Bug-Url: https://bugzilla.redhat.com/2089803