### PR TITLE
engine: Remove md_clear from Nehalem and Westmere

### DIFF
--- a/packaging/dbscripts/upgrade/pre_upgrade/0000_config.sql
+++ b/packaging/dbscripts/upgrade/pre_upgrade/0000_config.sql
@@ -451,9 +451,9 @@ select fn_db_add_config_value('ServerCPUList',
     '4.3');
 select fn_db_add_config_value('ServerCPUList',
     '1:Intel Nehalem Family:vmx,nx,model_Nehalem:Nehalem:x86_64; '
-        || '2:Secure Intel Nehalem Family:vmx,spec_ctrl,ssbd,md_clear,model_Nehalem:Nehalem,+spec-ctrl,+ssbd,+md-clear:x86_64; '
+        || '2:Secure Intel Nehalem Family:vmx,spec_ctrl,ssbd,model_Nehalem:Nehalem,+spec-ctrl,+ssbd:x86_64; '
         || '3:Intel Westmere Family:aes,vmx,nx,model_Westmere:Westmere:x86_64; '
-        || '4:Secure Intel Westmere Family:aes,vmx,spec_ctrl,ssbd,md_clear,model_Westmere:Westmere,+pcid,+spec-ctrl,+ssbd,+md-clear:x86_64; '
+        || '4:Secure Intel Westmere Family:aes,vmx,spec_ctrl,ssbd,model_Westmere:Westmere,+pcid,+spec-ctrl,+ssbd:x86_64; '
         || '5:Intel SandyBridge Family:vmx,nx,model_SandyBridge:SandyBridge:x86_64; '
         || '6:Secure Intel SandyBridge Family:vmx,spec_ctrl,ssbd,md_clear,model_SandyBridge:SandyBridge,+pcid,+spec-ctrl,+ssbd,+md-clear:x86_64; '
         || '7:Intel IvyBridge Family:vmx,nx,model_IvyBridge:IvyBridge:x86_64; '
@@ -482,9 +482,9 @@ select fn_db_add_config_value('ServerCPUList',
 
 select fn_db_add_config_value('ServerCPUList',
     '1:Intel Nehalem Family:vmx,nx,model_Nehalem:Nehalem:x86_64; '
-        || '2:Secure Intel Nehalem Family:vmx,spec_ctrl,ssbd,md_clear,model_Nehalem:Nehalem,+spec-ctrl,+ssbd,+md-clear:x86_64; '
+        || '2:Secure Intel Nehalem Family:vmx,spec_ctrl,ssbd,model_Nehalem:Nehalem,+spec-ctrl,+ssbd:x86_64; '
         || '3:Intel Westmere Family:aes,vmx,nx,model_Westmere:Westmere:x86_64; '
-        || '4:Secure Intel Westmere Family:aes,vmx,spec_ctrl,ssbd,md_clear,model_Westmere:Westmere,+pcid,+spec-ctrl,+ssbd,+md-clear:x86_64; '
+        || '4:Secure Intel Westmere Family:aes,vmx,spec_ctrl,ssbd,model_Westmere:Westmere,+pcid,+spec-ctrl,+ssbd:x86_64; '
         || '5:Intel SandyBridge Family:vmx,nx,model_SandyBridge:SandyBridge:x86_64; '
         || '6:Secure Intel SandyBridge Family:vmx,spec_ctrl,ssbd,md_clear,model_SandyBridge:SandyBridge,+pcid,+spec-ctrl,+ssbd,+md-clear:x86_64; '
         || '7:Intel IvyBridge Family:vmx,nx,model_IvyBridge:IvyBridge:x86_64; '
@@ -515,9 +515,9 @@ select fn_db_add_config_value('ServerCPUList',
 
 select fn_db_add_config_value('ServerCPUList',
     '1:Intel Nehalem Family:vmx,nx,model_Nehalem:Nehalem:x86_64; '
-        || '2:Secure Intel Nehalem Family:vmx,spec_ctrl,ssbd,md_clear,model_Nehalem:Nehalem,+spec-ctrl,+ssbd,+md-clear:x86_64; '
+        || '2:Secure Intel Nehalem Family:vmx,spec_ctrl,ssbd,model_Nehalem:Nehalem,+spec-ctrl,+ssbd:x86_64; '
         || '3:Intel Westmere Family:aes,vmx,nx,model_Westmere:Westmere:x86_64; '
-        || '4:Secure Intel Westmere Family:aes,vmx,spec_ctrl,ssbd,md_clear,model_Westmere:Westmere,+pcid,+spec-ctrl,+ssbd,+md-clear:x86_64; '
+        || '4:Secure Intel Westmere Family:aes,vmx,spec_ctrl,ssbd,model_Westmere:Westmere,+pcid,+spec-ctrl,+ssbd:x86_64; '
         || '5:Intel SandyBridge Family:vmx,nx,model_SandyBridge:SandyBridge:x86_64; '
         || '6:Secure Intel SandyBridge Family:vmx,spec_ctrl,ssbd,md_clear,model_SandyBridge:SandyBridge,+pcid,+spec-ctrl,+ssbd,+md-clear:x86_64; '
         || '7:Intel IvyBridge Family:vmx,nx,model_IvyBridge:IvyBridge:x86_64; '
@@ -548,9 +548,9 @@ select fn_db_add_config_value('ServerCPUList',
 
 select fn_db_add_config_value('ServerCPUList',
     '1:Intel Nehalem Family:vmx,nx,model_Nehalem:Nehalem:x86_64; '
-        || '2:Secure Intel Nehalem Family:vmx,spec_ctrl,ssbd,md_clear,model_Nehalem:Nehalem,+spec-ctrl,+ssbd,+md-clear:x86_64; '
+        || '2:Secure Intel Nehalem Family:vmx,spec_ctrl,ssbd,model_Nehalem:Nehalem,+spec-ctrl,+ssbd:x86_64; '
         || '3:Intel Westmere Family:aes,vmx,nx,model_Westmere:Westmere:x86_64; '
-        || '4:Secure Intel Westmere Family:aes,vmx,spec_ctrl,ssbd,md_clear,model_Westmere:Westmere,+pcid,+spec-ctrl,+ssbd,+md-clear:x86_64; '
+        || '4:Secure Intel Westmere Family:aes,vmx,spec_ctrl,ssbd,model_Westmere:Westmere,+pcid,+spec-ctrl,+ssbd:x86_64; '
         || '5:Intel SandyBridge Family:vmx,nx,model_SandyBridge:SandyBridge:x86_64; '
         || '6:Secure Intel SandyBridge Family:vmx,spec_ctrl,ssbd,md_clear,model_SandyBridge:SandyBridge,+pcid,+spec-ctrl,+ssbd,+md-clear:x86_64; '
         || '7:Intel IvyBridge Family:vmx,nx,model_IvyBridge:IvyBridge:x86_64; '
@@ -1227,9 +1227,9 @@ select fn_db_update_config_value('ServerCPUList',
     '4.3');
 select fn_db_update_config_value('ServerCPUList',
     '1:Intel Nehalem Family:vmx,nx,model_Nehalem:Nehalem:x86_64; '
-        || '2:Secure Intel Nehalem Family:vmx,spec_ctrl,ssbd,md_clear,model_Nehalem:Nehalem,+spec-ctrl,+ssbd,+md-clear:x86_64; '
+        || '2:Secure Intel Nehalem Family:vmx,spec_ctrl,ssbd,model_Nehalem:Nehalem,+spec-ctrl,+ssbd:x86_64; '
         || '3:Intel Westmere Family:aes,vmx,nx,model_Westmere:Westmere:x86_64; '
-        || '4:Secure Intel Westmere Family:aes,vmx,spec_ctrl,ssbd,md_clear,model_Westmere:Westmere,+pcid,+spec-ctrl,+ssbd,+md-clear:x86_64; '
+        || '4:Secure Intel Westmere Family:aes,vmx,spec_ctrl,ssbd,model_Westmere:Westmere,+pcid,+spec-ctrl,+ssbd:x86_64; '
         || '5:Intel SandyBridge Family:vmx,nx,model_SandyBridge:SandyBridge:x86_64; '
         || '6:Secure Intel SandyBridge Family:vmx,spec_ctrl,ssbd,md_clear,model_SandyBridge:SandyBridge,+pcid,+spec-ctrl,+ssbd,+md-clear:x86_64; '
         || '7:Intel IvyBridge Family:vmx,nx,model_IvyBridge:IvyBridge:x86_64; '
@@ -1257,9 +1257,9 @@ select fn_db_update_config_value('ServerCPUList',
     '4.4');
 select fn_db_update_config_value('ServerCPUList',
     '1:Intel Nehalem Family:vmx,nx,model_Nehalem:Nehalem:x86_64; '
-        || '2:Secure Intel Nehalem Family:vmx,spec_ctrl,ssbd,md_clear,model_Nehalem:Nehalem,+spec-ctrl,+ssbd,+md-clear:x86_64; '
+        || '2:Secure Intel Nehalem Family:vmx,spec_ctrl,ssbd,model_Nehalem:Nehalem,+spec-ctrl,+ssbd:x86_64; '
         || '3:Intel Westmere Family:aes,vmx,nx,model_Westmere:Westmere:x86_64; '
-        || '4:Secure Intel Westmere Family:aes,vmx,spec_ctrl,ssbd,md_clear,model_Westmere:Westmere,+pcid,+spec-ctrl,+ssbd,+md-clear:x86_64; '
+        || '4:Secure Intel Westmere Family:aes,vmx,spec_ctrl,ssbd,model_Westmere:Westmere,+pcid,+spec-ctrl,+ssbd:x86_64; '
         || '5:Intel SandyBridge Family:vmx,nx,model_SandyBridge:SandyBridge:x86_64; '
         || '6:Secure Intel SandyBridge Family:vmx,spec_ctrl,ssbd,md_clear,model_SandyBridge:SandyBridge,+pcid,+spec-ctrl,+ssbd,+md-clear:x86_64; '
         || '7:Intel IvyBridge Family:vmx,nx,model_IvyBridge:IvyBridge:x86_64; '
@@ -1289,9 +1289,9 @@ select fn_db_update_config_value('ServerCPUList',
     '4.5');
 select fn_db_update_config_value('ServerCPUList',
     '1:Intel Nehalem Family:vmx,nx,model_Nehalem:Nehalem:x86_64; '
-        || '2:Secure Intel Nehalem Family:vmx,spec_ctrl,ssbd,md_clear,model_Nehalem:Nehalem,+spec-ctrl,+ssbd,+md-clear:x86_64; '
+        || '2:Secure Intel Nehalem Family:vmx,spec_ctrl,ssbd,model_Nehalem:Nehalem,+spec-ctrl,+ssbd:x86_64; '
         || '3:Intel Westmere Family:aes,vmx,nx,model_Westmere:Westmere:x86_64; '
-        || '4:Secure Intel Westmere Family:aes,vmx,spec_ctrl,ssbd,md_clear,model_Westmere:Westmere,+pcid,+spec-ctrl,+ssbd,+md-clear:x86_64; '
+        || '4:Secure Intel Westmere Family:aes,vmx,spec_ctrl,ssbd,model_Westmere:Westmere,+pcid,+spec-ctrl,+ssbd:x86_64; '
         || '5:Intel SandyBridge Family:vmx,nx,model_SandyBridge:SandyBridge:x86_64; '
         || '6:Secure Intel SandyBridge Family:vmx,spec_ctrl,ssbd,md_clear,model_SandyBridge:SandyBridge,+pcid,+spec-ctrl,+ssbd,+md-clear:x86_64; '
         || '7:Intel IvyBridge Family:vmx,nx,model_IvyBridge:IvyBridge:x86_64; '
@@ -1319,6 +1319,38 @@ select fn_db_update_config_value('ServerCPUList',
         || '3:IBM z13s, z13:sie,model_z13-base:z13-base:s390x; '
         || '4:IBM z14:sie,model_z14-base:z14-base:s390x;',
     '4.6');
+select fn_db_update_config_value('ServerCPUList',
+    '1:Intel Nehalem Family:vmx,nx,model_Nehalem:Nehalem:x86_64; '
+        || '2:Secure Intel Nehalem Family:vmx,spec_ctrl,ssbd,model_Nehalem:Nehalem,+spec-ctrl,+ssbd:x86_64; '
+        || '3:Intel Westmere Family:aes,vmx,nx,model_Westmere:Westmere:x86_64; '
+        || '4:Secure Intel Westmere Family:aes,vmx,spec_ctrl,ssbd,model_Westmere:Westmere,+pcid,+spec-ctrl,+ssbd:x86_64; '
+        || '5:Intel SandyBridge Family:vmx,nx,model_SandyBridge:SandyBridge:x86_64; '
+        || '6:Secure Intel SandyBridge Family:vmx,spec_ctrl,ssbd,md_clear,model_SandyBridge:SandyBridge,+pcid,+spec-ctrl,+ssbd,+md-clear:x86_64; '
+        || '7:Intel IvyBridge Family:vmx,nx,model_IvyBridge:IvyBridge:x86_64; '
+        || '8:Secure Intel IvyBridge Family:vmx,spec_ctrl,ssbd,md_clear,model_IvyBridge:IvyBridge,+pcid,+spec-ctrl,+ssbd,+md-clear:x86_64; '
+        || '9:Intel Haswell Family:vmx,nx,model_Haswell-noTSX:Haswell-noTSX:x86_64; '
+        || '10:Secure Intel Haswell Family:vmx,spec_ctrl,ssbd,md_clear,model_Haswell-noTSX:Haswell-noTSX,+spec-ctrl,+ssbd,+md-clear:x86_64; '
+        || '11:Intel Broadwell Family:vmx,nx,model_Broadwell-noTSX:Broadwell-noTSX:x86_64; '
+        || '12:Secure Intel Broadwell Family:vmx,spec_ctrl,ssbd,md_clear,model_Broadwell-noTSX:Broadwell-noTSX,+spec-ctrl,+ssbd,+md-clear:x86_64; '
+        || '13:Intel Skylake Client Family:vmx,nx,model_Skylake-Client:Skylake-Client,-hle,-rtm,-mpx:x86_64; '
+        || '14:Secure Intel Skylake Client Family:vmx,ssbd,md_clear,model_Skylake-Client-noTSX-IBRS:Skylake-Client-noTSX-IBRS,+ssbd,+md-clear,-mpx:x86_64; '
+        || '15:Intel Skylake Server Family:vmx,nx,model_Skylake-Server:Skylake-Server,-hle,-rtm,-mpx:x86_64; '
+        || '16:Secure Intel Skylake Server Family:vmx,ssbd,md_clear,model_Skylake-Server-noTSX-IBRS:Skylake-Server-noTSX-IBRS,+ssbd,+md-clear,-mpx:x86_64; '
+        || '17:Intel Cascadelake Server Family:vmx,model_Cascadelake-Server:Cascadelake-Server,-hle,-rtm,-mpx:x86_64; '
+        || '18:Secure Intel Cascadelake Server Family:vmx,model_Cascadelake-Server-noTSX:Cascadelake-Server-noTSX,-mpx:x86_64; '
+        || '19:Intel Icelake Server Family:vmx,model_Icelake-Server-noTSX:Icelake-Server-noTSX,-mpx:x86_64; '
+        || '20:Secure Intel Icelake Server Family:vmx,arch-capabilities,rdctl-no,ibrs-all,skip-l1dfl-vmentry,mds-no,pschange-mc-no,taa-no,model_Icelake-Server-noTSX:Icelake-Server-noTSX,+arch-capabilities,+rdctl-no,+ibrs-all,+skip-l1dfl-vmentry,+mds-no,+pschange-mc-no,+taa-no,-mpx:x86_64; '
+        || '1:AMD Opteron G4:svm,nx,model_Opteron_G4:Opteron_G4:x86_64; '
+        || '2:AMD Opteron G5:svm,nx,model_Opteron_G5:Opteron_G5:x86_64; '
+        || '3:AMD EPYC:svm,nx,model_EPYC:EPYC:x86_64; '
+        || '4:Secure AMD EPYC:svm,nx,ibpb,ssbd,model_EPYC:EPYC,+ibpb,+virt-ssbd:x86_64; '
+        || '1:IBM POWER8:powernv,model_POWER8:POWER8:ppc64; '
+        || '2:IBM POWER9:powernv,model_POWER9:POWER9:ppc64; '
+        || '1:IBM z114, z196:sie,model_z196-base:z196-base:s390x; '
+        || '2:IBM zBC12, zEC12:sie,model_zEC12-base:zEC12-base:s390x; '
+        || '3:IBM z13s, z13:sie,model_z13-base:z13-base:s390x; '
+        || '4:IBM z14:sie,model_z14-base:z14-base:s390x;',
+    '4.7');
 -- qemu-guest-agent is also a viable agent
 select fn_db_update_config_value('AgentAppName','ovirt-guest-agent-common,ovirt-guest-agent,qemu-guest-agent','general');
 


### PR DESCRIPTION
It was not possible to use Secure CPU types of the old CPUs (Nehalem and Westmere) because they expected
the md_clear flag to be present. However, the microcode update with MDS mitigations was not released for those CPUs.

Bug-Url: https://bugzilla.redhat.com/2079267