### PR TITLE
core: Make sure at most one ramfb device is enabled

### DIFF
--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/builder/vminfo/LibvirtVmXmlBuilder.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/builder/vminfo/LibvirtVmXmlBuilder.java
@@ -1336,6 +1336,7 @@ public class LibvirtVmXmlBuilder {
     }
 
     void writeVGpu() {
+        boolean hasRamfb = false;
         for (VmDevice mdev : MDevTypesUtils.getMdevs(vmDevicesSupplier.get(), VmDeviceType.VGPU)) {
             final Version compatibilityVersion = vm.getCompatibilityVersion();
 
@@ -1347,8 +1348,9 @@ public class LibvirtVmXmlBuilder {
             if (!Boolean.TRUE.equals(mdevSpecParams.get(MDevTypesUtils.NODISPLAY))
                     && MDevTypesUtils.isMdevDisplayOnSupported(compatibilityVersion)) {
                 writer.writeAttributeString("display", "on");
-                if (FeatureSupported.isVgpuFramebufferSupported(compatibilityVersion)) {
+                if (!hasRamfb && FeatureSupported.isVgpuFramebufferSupported(compatibilityVersion)) {
                     writer.writeAttributeString("ramfb", "on");
+                    hasRamfb = true;
                 }
             }
 


### PR DESCRIPTION
When a VM has more than one ramfb vGPU devices enabled, it fails to
start.  ramfb is used only during boot, before the guest OS loads its
GPU driver (or if the GPU driver doesn’t work properly).  Then there
should be no noticeable difference for the user whether ramfb is
enabled on a given vGPU or not.

Under these circumstances, the simplest way to avoid the problem with
multiple ramfb-enabled vGPUs is to enable ramfb only for the first one
written to the domain XML, which is what this patch implements.

See the attached bug for more details.

Bug-Url: https://bugzilla.redhat.com/2079760