### PR TITLE
Fix the calculation of the VM's CPU cores

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/SchedulingManager.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/SchedulingManager.java
@@ -541,8 +541,9 @@ public class SchedulingManager implements BackendService {
 
     private void addPendingResources(VM vm, VDS host, Map<Integer, NumaNodeMemoryConsumption> numaConsumption, List<VdsCpuUnit>  dedicatedCpus) {
         int numOfCpus = VmCpuCountHelper.getRuntimeNumOfCpu(vm, host);
+        int numOfCores = VmCpuCountHelper.getRuntimeNumOfCores(vm, host);
         Guid hostId = host.getId();
-        getPendingResourceManager().addPending(new PendingCpuCores(hostId, vm, numOfCpus));
+        getPendingResourceManager().addPending(new PendingCpuCores(hostId, vm, numOfCpus, numOfCores));
         getPendingResourceManager().addPending(new PendingMemory(hostId, vm, vmOverheadCalculator.getStaticOverheadInMb(vm)));
         getPendingResourceManager().addPending(new PendingOvercommitMemory(hostId, vm, vmOverheadCalculator.getTotalRequiredMemWithoutHugePagesMb(vm, numOfCpus)));
         getPendingResourceManager().addPending(new PendingVM(hostId, vm));

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/pending/PendingCpuCores.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/pending/PendingCpuCores.java
@@ -7,30 +7,42 @@ import org.ovirt.engine.core.common.businessentities.VM;
 import org.ovirt.engine.core.compat.Guid;
 
 /**
- * Represents a cpu core allocation that is going to be used
+ * Represents a cpu and core allocation that is going to be used
  * by not yet started VM on a specified host
  */
 public class PendingCpuCores extends PendingResource {
 
     private CpuPinningPolicy cpuPinningPolicy;
 
+    private int cpuCount;
+
     private int coreCount;
 
-    public PendingCpuCores(VDS host, VM vm, int coreCount) {
+    public PendingCpuCores(VDS host, VM vm, int cpuCount, int coreCount) {
         super(host, vm);
         this.cpuPinningPolicy = vm.getCpuPinningPolicy();
+        this.cpuCount = cpuCount;
         this.coreCount = coreCount;
         this.cpuPinningPolicy = vm.getCpuPinningPolicy();
     }
 
-    public PendingCpuCores(Guid host, VM vm, int coreCount) {
+    public PendingCpuCores(Guid host, VM vm, int cpuCount, int coreCount) {
         super(host, vm);
         this.cpuPinningPolicy = vm.getCpuPinningPolicy();
+        this.cpuCount = cpuCount;
         this.coreCount = coreCount;
         this.cpuPinningPolicy = vm.getCpuPinningPolicy();
     }
 
-    public long getCoreCount() {
+    public long getCpuCount() {
+        return cpuCount;
+    }
+
+    public void setCpuCount(int cpuCount) {
+        this.cpuCount = cpuCount;
+    }
+
+    public int getCoreCount() {
         return coreCount;
     }
 
@@ -56,7 +68,7 @@ public class PendingCpuCores extends PendingResource {
     public static int collectForHost(PendingResourceManager manager, Guid host) {
         int sum = 0;
         for (PendingCpuCores resource: manager.pendingHostResources(host, PendingCpuCores.class)) {
-            sum += resource.getCoreCount();
+            sum += resource.getCpuCount();
         }
 
         return sum;
@@ -66,7 +78,7 @@ public class PendingCpuCores extends PendingResource {
         int sum = 0;
         for (PendingCpuCores resource: manager.pendingHostResources(host, PendingCpuCores.class)) {
             if (!resource.getCpuPinningPolicy().isExclusive()) {
-                sum += resource.getCoreCount();
+                sum += resource.getCpuCount();
             }
         }
 

--- a/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/scheduling/pending/PendingResourceManagerTest.java
+++ b/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/scheduling/pending/PendingResourceManagerTest.java
@@ -29,7 +29,7 @@ public class PendingResourceManagerTest {
         manager.addPending(new PendingVM(host, vm1));
         manager.addPending(new PendingVM(host, vm2));
         manager.addPending(new PendingMemory(host, vm2, 1024));
-        manager.addPending(new PendingCpuCores(host, vm2, 10));
+        manager.addPending(new PendingCpuCores(host, vm2, 10, 5));
 
         manager.clearVm(vm2);
 
@@ -59,7 +59,7 @@ public class PendingResourceManagerTest {
         manager.addPending(new PendingVM(host, vm1));
         manager.addPending(new PendingVM(host, vm2));
         manager.addPending(new PendingMemory(host, vm2, 1024));
-        manager.addPending(new PendingCpuCores(host, vm2, 10));
+        manager.addPending(new PendingCpuCores(host, vm2, 10, 5));
 
         manager.clearHost(host);
 
@@ -84,11 +84,11 @@ public class PendingResourceManagerTest {
 
         manager.addPending(new PendingVM(host, vm1));
         manager.addPending(new PendingMemory(host, vm1, 768));
-        manager.addPending(new PendingCpuCores(host, vm1, 1));
+        manager.addPending(new PendingCpuCores(host, vm1, 1, 1));
 
         manager.addPending(new PendingVM(host, vm2));
         manager.addPending(new PendingMemory(host, vm2, 1024));
-        manager.addPending(new PendingCpuCores(host, vm2, 10));
+        manager.addPending(new PendingCpuCores(host, vm2, 10, 5));
 
         Set<Guid> pending = PendingVM.collectForHost(manager, host.getId());
         assertEquals(2, pending.size());
@@ -116,11 +116,11 @@ public class PendingResourceManagerTest {
 
         manager.addPending(new PendingVM(host1, vm1));
         manager.addPending(new PendingMemory(host1, vm1, 768));
-        manager.addPending(new PendingCpuCores(host1, vm1, 1));
+        manager.addPending(new PendingCpuCores(host1, vm1, 1, 1));
 
         manager.addPending(new PendingVM(host2, vm2));
         manager.addPending(new PendingMemory(host2, vm2, 1024));
-        manager.addPending(new PendingCpuCores(host2, vm2, 10));
+        manager.addPending(new PendingCpuCores(host2, vm2, 10, 5));
 
         assertEquals(host1.getId(), PendingVM.getScheduledHost(manager, vm1));
         assertEquals(host2.getId(), PendingVM.getScheduledHost(manager, vm2));
@@ -147,15 +147,15 @@ public class PendingResourceManagerTest {
 
         manager.addPending(new PendingVM(host1, vm1));
         manager.addPending(new PendingMemory(host1, vm1, 768));
-        manager.addPending(new PendingCpuCores(host1, vm1, 1));
+        manager.addPending(new PendingCpuCores(host1, vm1, 1, 1));
 
         manager.addPending(new PendingVM(host2, vm2));
         manager.addPending(new PendingMemory(host2, vm2, 1024));
-        manager.addPending(new PendingCpuCores(host2, vm2, 10));
+        manager.addPending(new PendingCpuCores(host2, vm2, 10, 5));
 
         manager.addPending(new PendingVM(host1, vm3));
         manager.addPending(new PendingMemory(host1, vm3, 1024));
-        manager.addPending(new PendingCpuCores(host1, vm3, 10));
+        manager.addPending(new PendingCpuCores(host1, vm3, 10, 5));
 
 
         List<PendingVM> vms = manager.pendingHostResources(host1.getId(), PendingVM.class);
@@ -184,11 +184,11 @@ public class PendingResourceManagerTest {
 
         manager.addPending(new PendingVM(host1, vm1));
         manager.addPending(new PendingMemory(host1, vm1, 768));
-        manager.addPending(new PendingCpuCores(host1, vm1, 1));
+        manager.addPending(new PendingCpuCores(host1, vm1, 1, 1));
 
         manager.addPending(new PendingVM(host2, vm2));
         manager.addPending(new PendingMemory(host2, vm2, 1024));
-        manager.addPending(new PendingCpuCores(host2, vm2, 10));
+        manager.addPending(new PendingCpuCores(host2, vm2, 10, 5));
 
         List<PendingMemory> memories = manager.pendingVmResources(vm1.getId(), PendingMemory.class);
 

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/VdsManager.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/VdsManager.java
@@ -182,7 +182,7 @@ public class VdsManager {
     private HostConnectionRefresherInterface hostRefresher;
     private volatile boolean inServerRebootTimeout;
     private List<VdsCpuUnit> cpuTopology;
-    private int minRequiredSharedCpusCount;
+    private int maxRunningVmsSharedCoresCount;
     private int vmsSharedCpusCount;
 
     VdsManager(VDS vds, ResourceManager resourceManager) {
@@ -1360,12 +1360,12 @@ public class VdsManager {
                 .forEach(cpu -> cpu.unPinVm(vmId));
     }
 
-    public void setMinRequiredSharedCpusCount(int minSharedCpusCount) {
-        this.minRequiredSharedCpusCount = minSharedCpusCount;
+    public void setMaxRunningVmsSharedCoresCount(int maxRunningVmsSharedCoresCount) {
+        this.maxRunningVmsSharedCoresCount = maxRunningVmsSharedCoresCount;
     }
 
-    public int getMinRequiredSharedCpusCount() {
-        return minRequiredSharedCpusCount < 1 ? 1 : minRequiredSharedCpusCount;
+    public int getMaxRunningVmsSharedCoresCount() {
+        return maxRunningVmsSharedCoresCount < 1 ? 1 : maxRunningVmsSharedCoresCount;
     }
 
     public void setVmsSharedCpusCount(int sharedCpuCount) {

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/monitoring/HostMonitoring.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/monitoring/HostMonitoring.java
@@ -892,7 +892,7 @@ public class HostMonitoring implements HostMonitoringInterface {
 
         int memCommited = host.getGuestOverhead();
         int vmsCoresCount = 0;
-        int maxSharedCpus = 0;
+        int maxSharedCores = 0;
         int vmsSharedCpusCount = 0;
 
         for (Map.Entry<Guid, VMStatus> entry : vmIdToStatus.entrySet()) {
@@ -904,9 +904,9 @@ public class HostMonitoring implements HostMonitoringInterface {
                 if (vmManager != null) {
                     memCommited += vmManager.getVmMemoryWithOverheadInMB();
                     vmsCoresCount += vmManager.getNumOfCpus();
-                    int sharedCpus = vmManager.getCpuPinningPolicy() != null && !vmManager.getCpuPinningPolicy().isExclusive()
-                            ? vmManager.getNumOfCpus() : 0;
-                    maxSharedCpus = Math.max(maxSharedCpus, sharedCpus);
+                    int sharedCores = vmManager.getCpuPinningPolicy() != null && !vmManager.getCpuPinningPolicy().isExclusive()
+                            ? vmManager.getNumOfCores() : 0;
+                    maxSharedCores = Math.max(maxSharedCores, sharedCores);
 
                     if (!vmManager.getCpuPinningPolicy().isExclusive()) {
                         vmsSharedCpusCount += vmManager.getNumOfCpus();
@@ -915,7 +915,7 @@ public class HostMonitoring implements HostMonitoringInterface {
             }
         }
 
-        resourceManager.getVdsManager(host.getId()).setMinRequiredSharedCpusCount(maxSharedCpus);
+        resourceManager.getVdsManager(host.getId()).setMaxRunningVmsSharedCoresCount(maxSharedCores);
 
         if (memCommited != host.getMemCommited()) {
             host.setMemCommited(memCommited);


### PR DESCRIPTION
After the refactoring of CpuPolicyUnit, we started to calculate required shared CPUs with countThreadsAsCores=true.
This caused that the VMs with RESIZE_AND_PIN cpu pinning policy were not able to migrate between identical hosts when cluster's countThreadsAsCores=false.

This patch changes the calculation in CpuPolicyUnit back to countThreadsAsCores=false and changes that also for the pending resources used in CpuPolicyUnit and the minRequiredSharedCpusCount of the host.

Bug-Url: https://bugzilla.redhat.com/2095259