### PR TITLE
core: ignore UploadStreamVDSCommand network failure

### DIFF
--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/irsbroker/UploadStreamVDSCommand.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/irsbroker/UploadStreamVDSCommand.java
@@ -31,6 +31,11 @@ public class UploadStreamVDSCommand<P extends UploadStreamVDSCommandParameters> 
     }
 
     @Override
+    protected void executeVDSCommand() {
+        executeVdsCommandWithNetworkEvent(false);
+    }
+
+    @Override
     protected AsyncTaskType getCreatedTaskType() {
         return AsyncTaskType.downloadImageFromStream;
     }


### PR DESCRIPTION
When UploadStreamVDSCommand fails due to network error, the host is
moved to "not responding" status and then fenced. The network error
might happen for different reasons, one of them is timeout, which is
not necessarily a network error. This command uses HTTP rather than
JSON RPC, and the default timeout for HTTP client is set to be 20
seconds, which in some rare cases is not enough for this VDS command
to finish.

This patch prevents sending a network error event when UploadStream
command fails due to network error, which in turn prevents
disconnecting and fencing of the host, so that this error will not
have such an impact on otherwise healthy system.

Bug-Url: https://bugzilla.redhat.com/2070045