### PR TITLE
core: produce successful event if backup finished successfully

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/backup/HybridBackupCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/backup/HybridBackupCommand.java
@@ -238,6 +238,25 @@ public class HybridBackupCommand<T extends VmBackupParameters> extends StartVmBa
     }
 
     @Override
+    public AuditLogType getAuditLogTypeValue() {
+        VmBackup vmBackup = getParameters().getVmBackup();
+        addCustomValue("backupId", vmBackup.getId().toString());
+        switch (getActionState()) {
+            case EXECUTE:
+                return AuditLogType.VM_BACKUP_STARTED;
+            case END_FAILURE:
+                if (vmBackup.getPhase() == VmBackupPhase.SUCCEEDED) {
+                    return AuditLogType.VM_BACKUP_SUCCEEDED;
+                }
+
+                return AuditLogType.VM_BACKUP_FAILED;
+            case END_SUCCESS:
+                return AuditLogType.VM_BACKUP_SUCCEEDED;
+        }
+        return null;
+    }
+
+    @Override
     protected void restoreCommandState() {
         Guid backupId = getParameters().getVmBackup().getId();
         VmBackup vmBackup = vmBackupDao.get(backupId);


### PR DESCRIPTION
Even if we were unable to remove the auto-generated snapshot, the backup will be considered successful. This patch produces the right audit log entry to indicate the backup did not fail.