### PR TITLE
Block hot plug CPU with exclusive pinning

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/HotSetNumberOfCpusCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/HotSetNumberOfCpusCommand.java
@@ -88,10 +88,6 @@ public class HotSetNumberOfCpusCommand<T extends HotSetNumberOfCpusParameters> e
             valid = failValidation(EngineMessage.HOT_PLUG_CPU_CONFLICT,
                     String.format("%1$s", getVm().getCpuPinningPolicy().name()));
         }
-        if (getVm().getCpuPinningPolicy().isExclusive()) {
-            valid = failValidation(EngineMessage.HOT_PLUG_CPU_IS_NOT_SUPPORTED_DEDICATED,
-                    String.format("$policy %1$s", getVm().getCpuPinningPolicy().name()));
-        }
 
         return valid;
     }

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/UpdateVmCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/UpdateVmCommand.java
@@ -28,6 +28,8 @@ import org.ovirt.engine.core.bll.quota.QuotaClusterConsumptionParameter;
 import org.ovirt.engine.core.bll.quota.QuotaConsumptionParameter;
 import org.ovirt.engine.core.bll.quota.QuotaSanityParameter;
 import org.ovirt.engine.core.bll.quota.QuotaVdsDependent;
+import org.ovirt.engine.core.bll.scheduling.SlaValidator;
+import org.ovirt.engine.core.bll.scheduling.utils.VdsCpuUnitPinningHelper;
 import org.ovirt.engine.core.bll.snapshots.SnapshotVmConfigurationHelper;
 import org.ovirt.engine.core.bll.storage.domain.IsoDomainListSynchronizer;
 import org.ovirt.engine.core.bll.tasks.interfaces.CommandCallback;
@@ -189,6 +191,8 @@ public class UpdateVmCommand<T extends VmManagementParametersBase> extends VmMan
     private AffinityValidator affinityValidator;
     @Inject
     private SnapshotVmConfigurationHelper snapshotVmConfigurationHelper;
+    @Inject
+    private VdsCpuUnitPinningHelper vdsCpuUnitPinningHelper;
 
     private VM oldVm;
     private boolean quotaSanityOnly = false;
@@ -1195,8 +1199,14 @@ public class UpdateVmCommand<T extends VmManagementParametersBase> extends VmMan
             return failValidation(EngineMessage.USE_HOST_CPU_REQUESTED_ON_UNSUPPORTED_ARCH);
         }
 
-        if (isHotSetEnabled() && !validateCPUHotplug(getParameters().getVmStaticData())) {
-            return failValidation(EngineMessage.CPU_HOTPLUG_TOPOLOGY_INVALID);
+        if (isHotSetEnabled() && getVm().isRunningOrPaused()) {
+            if (!validateCPUHotplug(getParameters().getVmStaticData())) {
+                return failValidation(EngineMessage.CPU_HOTPLUG_TOPOLOGY_INVALID);
+            }
+            if (!validateCpuPinningPolicyWithHotplug(getParameters().getVmStaticData())) {
+                return failValidation(EngineMessage.HOT_PLUG_CPU_IS_NOT_SUPPORTED_DEDICATED,
+                        String.format("$policy %1$s", getVm().getCpuPinningPolicy().name()));
+            }
         }
 
         if (!validateMemoryAlignment(getParameters().getVmStaticData())) {
@@ -1407,6 +1417,26 @@ public class UpdateVmCommand<T extends VmManagementParametersBase> extends VmMan
             return failValidation(EngineMessage.ACTION_TYPE_FAILED_ILLEGAL_CONSOLE_DISCONNECT_ACTION_DELAY);
         }
 
+        return true;
+    }
+
+    private boolean validateCPUHotplug(VmStatic vmStaticData) {
+        // Can't set more CPUs than available on the host where VM is running.
+        boolean countThreadsAsCores = getCluster().getCountThreadsAsCores();
+        int availableCpus = SlaValidator.getEffectiveCpuCores(getVds(), countThreadsAsCores) -
+                vdsCpuUnitPinningHelper.countUnavailableCpus(
+                        getVdsManager(getVdsId()).getCpuTopology(),  countThreadsAsCores);
+        if (vmStaticData.getNumOfCpus(false) > availableCpus) {
+            return false;
+        }
+        return true;
+    }
+
+    private boolean validateCpuPinningPolicyWithHotplug(VmStatic vmStaticData) {
+        if (getVm().getCpuPinningPolicy().isExclusive()
+                && vmStaticData.getNumOfCpus(false) != getVm().getNumOfCpus(false)) {
+            return false;
+        }
         return true;
     }
 

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/VmManagementCommandBase.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/VmManagementCommandBase.java
@@ -115,19 +115,6 @@ public abstract class VmManagementCommandBase<T extends VmManagementParametersBa
                 getUserIdIfExternal().orElse(null)));
     }
 
-    protected boolean validateCPUHotplug(VmStatic vmStaticData) {
-        if (getVm().isRunningOrPaused()) {
-            // Can't set more CPUs than available on the host where VM is running.
-            // Potential overcommit (interference with other running VMs) will be resolved by scheduler.
-            // In alignment with the CPUPolicyUnit, VM's hyperthreading is not considered.
-            if (getVds() != null && vmStaticData.getNumOfCpus(false) > getVds().getCpuThreads()) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
     protected boolean validateMemoryAlignment(VmStatic vmStaticData) {
         if (getCluster().getArchitecture().getFamily() == ArchitectureType.ppc && vmStaticData.getMemSizeMb() % 256 != 0) {
             return failValidation(EngineMessage.MEMORY_SIZE_NOT_MULTIPLE_OF_256_ON_PPC,


### PR DESCRIPTION
This patch prevent the user from hotplugging CPU when the VM is set with
exclusive pinning as we don't support it. Currently it will add a new
CPU without any pinning, which breaks the VM configuration.
With this patch, it won't be allowed and the user will be noticed.

Change-Id: Ie8d32b9e85879e6764bab63399c3d5762ba806db
Signed-off-by: Liran Rotenberg <lrotenbe@redhat.com>