### PR TITLE
UI: Default VGA when backing from headless

### DIFF
--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/UnitVmModel.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/UnitVmModel.java
@@ -2614,7 +2614,7 @@ public class UnitVmModel extends Model implements HasValidatedTabs, ModelWithMig
         if (displayTypes.contains(selectedDisplayType)) {
             getDisplayType().setItems(displayTypes, selectedDisplayType);
         } else if (displayTypes.size() > 0) {
-            getDisplayType().setItems(displayTypes, displayTypes.iterator().next());
+            getDisplayType().setItems(displayTypes, behavior.getDefaultDisplayType(displayTypes));
         }
     }
 

--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/VmModelBehaviorBase.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/VmModelBehaviorBase.java
@@ -1864,4 +1864,12 @@ public abstract class VmModelBehaviorBase<TModel extends UnitVmModel> {
         }
     }
 
+    protected DisplayType getDefaultDisplayType(Set<DisplayType> displayTypes) {
+         // We know displayTypes size is > 0
+         if (displayTypes.contains(DisplayType.vga)) {
+             return DisplayType.vga;
+         }
+         return displayTypes.iterator().next();
+    }
+
 }

--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/instancetypes/NonClusterModelBehaviorBase.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/instancetypes/NonClusterModelBehaviorBase.java
@@ -39,8 +39,8 @@ public class NonClusterModelBehaviorBase extends VmModelBehaviorBase<UnitVmModel
         initGraphicsModel(selectedGrahicsTypes);
 
         if (selected == DisplayType.none) {
-            getModel().getDisplayType().setSelectedItem(DisplayType.qxl);
-            getModel().getGraphicsType().setSelectedItem(UnitVmModel.GraphicsTypes.SPICE);
+            getModel().getDisplayType().setSelectedItem(DisplayType.vga);
+            getModel().getGraphicsType().setSelectedItem(UnitVmModel.GraphicsTypes.VNC);
             getModel().getIsHeadlessModeEnabled().setEntity(true);
         }
     }


### PR DESCRIPTION
When switching back from headless VM, the default is SPICE/QXL.
This patch changes it to VNC/VGA.

Change-Id: Ic63dbf22e3cd199fc782dc8e8963c8899478a6ae
Signed-off-by: Liran Rotenberg <lrotenbe@redhat.com>