### PR TITLE
core: Remove @CopyOnNewVersion from VmBase.virtioScsiMultiQueues

### DIFF
--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/VmBase.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/VmBase.java
@@ -393,7 +393,6 @@ public class VmBase implements Queryable, BusinessEntity<Guid>, Nameable, Commen
      * > 0 - number of queues
      */
 
-    @CopyOnNewVersion
     @EditableVmField(onStatuses = VMStatus.Down)
     @EditableVmTemplateField
     private int virtioScsiMultiQueues;


### PR DESCRIPTION
For all VM fields annotated with @CopyOnNewVersion, values from the
template override the values from VM pool, if the latest template
version is used. Since we want virtioScsiMultiQueues value to be taken
from VM pool, need to remove this annotation.

Change-Id: Ia32bb852ffb5277ca2876d64cd85dbbcfe7b1512
Bug-Url: https://bugzilla.redhat.com/2080755
Signed-off-by: Shmuel Melamud <smelamud@redhat.com>