### PR TITLE
core: Check for real FIPS when adding username to a VNC ticket

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/ConfigureConsoleOptionsQuery.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/ConfigureConsoleOptionsQuery.java
@@ -156,7 +156,7 @@ public class ConfigureConsoleOptionsQuery<P extends ConfigureConsoleOptionsParam
         options.setSmartcardEnabled(getCachedVm().isSmartcardEnabled());
         if (getParameters().isSetTicket()) {
             options.setTicket(generateTicket());
-            if (isKernelFips()) {
+            if (isFips()) {
                 options.setUsername(ConfigureConsoleOptionsParams.VNC_USERNAME_PREFIX + getCachedVm().getId());
             }
         }
@@ -333,8 +333,8 @@ public class ConfigureConsoleOptionsQuery<P extends ConfigureConsoleOptionsParam
         return vdsDynamicDao.get(getCachedVm().getRunOnVds());
     }
 
-    protected boolean isKernelFips() {
-        return vdsStaticDao.get(getCachedVm().getRunOnVds()).isKernelCmdlineFips();
+    protected boolean isFips() {
+        return getHost().isFipsEnabled();
     }
 
     protected boolean isVncEncryptionEnabled() {
@@ -397,7 +397,7 @@ public class ConfigureConsoleOptionsQuery<P extends ConfigureConsoleOptionsParam
                     new IdQueryParameters(getCachedVm().getId()));
             result = returnValue.getReturnValue();
         } else if (getParameters().getOptions().getGraphicsType() == GraphicsType.VNC
-                   && (isKernelFips() || isVncEncryptionEnabled())) {
+                   && (isFips() || isVncEncryptionEnabled())) {
             // If VNC encyption is enabled (at cluster level or because of FIPS mode)
             // the console descriptor must contain host name,
             // to match TLS certificate for connection

--- a/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/ConfigureConsoleOptionsQueryTest.java
+++ b/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/ConfigureConsoleOptionsQueryTest.java
@@ -133,7 +133,7 @@ public class ConfigureConsoleOptionsQueryTest extends
         result.setActionReturnValue("nbusr123");
         doReturn(result).when(backend).runAction(eq(ActionType.SetVmTicket), any());
         doReturn(null).when(getQuery()).getHost();
-        doReturn(false).when(getQuery()).isKernelFips();
+        doReturn(false).when(getQuery()).isFips();
         doReturn(false).when(getQuery()).isVncEncryptionEnabled();
 
         getQuery().getQueryReturnValue().setSucceeded(true);
@@ -157,7 +157,7 @@ public class ConfigureConsoleOptionsQueryTest extends
         VdsDynamic vds = new VdsDynamic();
         vds.setVncEncryptionEnabled(true);
         doReturn(vds).when(getQuery()).getHost();
-        doReturn(false).when(getQuery()).isKernelFips();
+        doReturn(false).when(getQuery()).isFips();
         doReturn(false).when(getQuery()).isVncEncryptionEnabled();
 
         getQuery().getQueryReturnValue().setSucceeded(true);
@@ -188,7 +188,7 @@ public class ConfigureConsoleOptionsQueryTest extends
         VdsDynamic vdsDynamic = new VdsDynamic();
         vdsDynamic.setVncEncryptionEnabled(true);
         doReturn(vdsDynamic).when(getQuery()).getHost();
-        doReturn(true).when(getQuery()).isKernelFips();
+        doReturn(true).when(getQuery()).isFips();
 
         getQuery().getQueryReturnValue().setSucceeded(true);
         getQuery().executeQueryCommand();


### PR DESCRIPTION
FIPS can be enabled on a host without the corresponding parameter in
the kernel command line.  In such a case, the host expects username in
the VNC display ticket.  But Engine inserts username only when the
FIPS parameter is in the kernel command line and VNC connection
doesn’t work is such a case.

To fix this, let’s check in Engine for what the host says about FIPS
rather than for the kernel command line parameter.