### PR TITLE
Release CPUs reminders

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/SchedulingManager.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/SchedulingManager.java
@@ -754,6 +754,8 @@ public class SchedulingManager implements BackendService {
         // Create individual VmGroups for the rest of VMs that are not in affinity groups
         vmsById.values().forEach(vm -> vmGroups.add(Collections.singletonList(vm)));
 
+        vmGroups.forEach(vmGroup -> vmGroup.sort(new VmsCpuPinningPolicyComparator().reversed()));
+
         return vmGroups;
     }
 

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/utils/VdsCpuUnitPinningHelper.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/utils/VdsCpuUnitPinningHelper.java
@@ -141,7 +141,6 @@ public class VdsCpuUnitPinningHelper {
     }
 
     private List<VdsCpuUnit> allocateDedicatedCpus(List<VdsCpuUnit> cpuTopology, VM vm, Guid hostId) {
-        // We can assume that a valid pinning exists here (because the host was filtered beforehand).
         List<VdsCpuUnit> cpusToBeAllocated = new ArrayList<>();
         int socketsLeft = vm.getNumOfSockets();
         int onlineSockets = getOnlineSockets(cpuTopology).size();
@@ -197,7 +196,8 @@ public class VdsCpuUnitPinningHelper {
             int coresReminder = coreCount % vm.getCpuPerSocket();
             for (int i = 0; i < coresReminder * vm.getThreadsPerCpu(); i++) {
                 if (!cpusToBeAllocated.isEmpty()) {
-                    cpusToBeAllocated.remove(cpusToBeAllocated.size() - 1);
+                    VdsCpuUnit releasedCpu = cpusToBeAllocated.remove(cpusToBeAllocated.size() - 1);
+                    releasedCpu.unPinVm(vm.getId());
                 }
             }
 


### PR DESCRIPTION
When we allocate CPUs we are basing upon the list we return back. This
is correct for the scheduling phase. But now we run the same logic on
canSchedule. There, when having a group of VMs, we are basing on the
cpuTopology list, not the list we selected to allocate. The overtaken
CPU wasn't released from the pinning itself and that harmed the
canSchedule logic for VM groups.

Also, when grouping the VMs, when the group is having an affinity set,
it is reordered. Therefore, it is required to sort them there as well.

Change-Id: Idcae90fed953c4798f2c4bf8893bff0a1b7086ea
Signed-off-by: Liran Rotenberg <lrotenbe@redhat.com>