### PR TITLE
webadmin: Mark 'Incremental Backup' flag by default

### DIFF
--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/AbstractDiskModel.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/AbstractDiskModel.java
@@ -272,8 +272,9 @@ public abstract class AbstractDiskModel extends DiskModel {
         getIsSgIoUnfiltered().setEntity(false);
         getIsSgIoUnfiltered().getEntityChangedEvent().addListener(this);
 
+        // Incremental backup flag should be enabled by default (BZ 1915029)
         setIsIncrementalBackup(new EntityModel<>());
-        getIsIncrementalBackup().setEntity(false);
+        getIsIncrementalBackup().setEntity(true);
 
         setDiskStorageType(new EntityModel<>());
         getDiskStorageType().setEntity(DiskStorageType.IMAGE);


### PR DESCRIPTION
Screenshot: https://imgur.com/a/blTWJqy

When creating a new disk on the UI, the incremental backup flag should
be checked by default.

Bug-Url: https://bugzilla.redhat.com/1915029
Signed-off-by: Shani Leviim <sleviim@redhat.com>