### PR TITLE
Add deviceList parameter to connectStorageServer

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/RunVmCommandBase.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/RunVmCommandBase.java
@@ -298,6 +298,8 @@ public abstract class RunVmCommandBase<T extends VmOperationParameterBase> exten
                         .distinct()
                         .collect(groupingBy(StorageServerConnections::getStorageType, toList()));
 
+        List<String> lunIds = lunDisks.stream().map(d -> d.getLun().getLUNId()).collect(Collectors.toList());
+
         return connectionsByType.entrySet().stream()
                 .map(entry -> runVdsCommand(
                         VDSCommandType.ConnectStorageServer,
@@ -305,7 +307,8 @@ public abstract class RunVmCommandBase<T extends VmOperationParameterBase> exten
                                 hostId,
                                 getStoragePoolId(),
                                 entry.getKey(),
-                                entry.getValue())))
+                                entry.getValue(),
+                                lunIds)))
                 .noneMatch(vdsReturnValue -> !vdsReturnValue.getSucceeded());
     }
 

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/vdscommands/ExtendStorageDomainVDSCommandParameters.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/vdscommands/ExtendStorageDomainVDSCommandParameters.java
@@ -15,14 +15,14 @@ public class ExtendStorageDomainVDSCommandParameters extends ActivateStorageDoma
         setForce(force);
     }
 
-    private Set<String> privateDeviceList;
+    private Set<String> deviceList;
 
     public Set<String> getDeviceList() {
-        return privateDeviceList;
+        return deviceList;
     }
 
     private void setDeviceList(Set<String> value) {
-        privateDeviceList = value;
+        deviceList = value;
     }
 
     private boolean force;

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/vdscommands/StorageServerConnectionManagementVDSParameters.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/vdscommands/StorageServerConnectionManagementVDSParameters.java
@@ -10,6 +10,7 @@ import org.ovirt.engine.core.compat.Guid;
 public class StorageServerConnectionManagementVDSParameters extends GetStorageConnectionsListVDSCommandParameters {
     private StorageType privateStorageType;
     private boolean sendNetworkEventOnFailure = true;
+    private List<String> deviceList;
 
     public boolean getSendNetworkEventOnFailure() {
         return sendNetworkEventOnFailure;
@@ -37,11 +38,25 @@ public class StorageServerConnectionManagementVDSParameters extends GetStorageCo
         privateConnectionList = value;
     }
 
+    public List<String> getDeviceList() {
+        return deviceList;
+    }
+
+    private void setDeviceList(List<String> value) {
+        deviceList = value;
+    }
+
     public StorageServerConnectionManagementVDSParameters(Guid vdsId, Guid storagePoolId, StorageType storageType,
             List<StorageServerConnections> connectionList) {
         super(vdsId, storagePoolId);
         setStorageType(storageType);
         setConnectionList(connectionList);
+    }
+
+    public StorageServerConnectionManagementVDSParameters(Guid vdsId, Guid storagePoolId, StorageType storageType,
+            List<StorageServerConnections> connectionList, List<String> deviceList) {
+        this(vdsId, storagePoolId, storageType, connectionList);
+        setDeviceList(deviceList);
     }
 
     public StorageServerConnectionManagementVDSParameters() {
@@ -53,6 +68,7 @@ public class StorageServerConnectionManagementVDSParameters extends GetStorageCo
         return super.appendAttributes(tsb)
                 .append("storageType", getStorageType())
                 .append("connectionList", getConnectionList())
-                .append("sendNetworkEventOnFailure", getSendNetworkEventOnFailure());
+                .append("sendNetworkEventOnFailure", getSendNetworkEventOnFailure())
+                .append("deviceList", getDeviceList());
     }
 }

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/jsonrpc/JsonRpcVdsServer.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/jsonrpc/JsonRpcVdsServer.java
@@ -617,11 +617,13 @@ public class JsonRpcVdsServer implements IVdsServer {
     @Override
     public ServerConnectionStatusReturn connectStorageServer(int serverType,
             String spUUID,
-            Map<String, String>[] args) {
+            Map<String, String>[] args,
+            List<String> devicesList) {
         JsonRpcRequest request =
                 new RequestBuilder("StoragePool.connectStorageServer").withParameter("storagepoolID", spUUID)
                         .withParameter("domainType", serverType)
                         .withParameter("connectionParams", args)
+                        .withOptionalParameter("devlist", devicesList)
                         .build();
         Map<String, Object> response =
                 new FutureMap(this.client, request).withResponseKey("statuslist")

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/ConnectStorageServerVDSCommand.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/ConnectStorageServerVDSCommand.java
@@ -44,7 +44,8 @@ public class ConnectStorageServerVDSCommand<P extends StorageServerConnectionMan
     @Override
     protected void executeVdsBrokerCommand() {
         _result = getBroker().connectStorageServer(getParameters().getStorageType().getValue(),
-                getParameters().getStoragePoolId().toString(), buildStructFromConnectionListObject());
+                getParameters().getStoragePoolId().toString(), buildStructFromConnectionListObject(),
+                getParameters().getDeviceList());
         proceedProxyReturnValue();
         Map<String, String> returnValue = _result.convertToStatusList();
         setReturnValue(returnValue);

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/IVdsServer.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/IVdsServer.java
@@ -153,7 +153,8 @@ public interface IVdsServer {
     FenceStatusReturn fenceNode(String ip, String port, String type, String user, String password,
              String action, String secured, String options,  Map<String, Object> fencingPolicy);
 
-    ServerConnectionStatusReturn connectStorageServer(int serverType, String spUUID, Map<String, String>[] args);
+    ServerConnectionStatusReturn connectStorageServer(int serverType, String spUUID, Map<String, String>[] args,
+            List<String> devicesList);
 
     ServerConnectionStatusReturn disconnectStorageServer(int serverType, String spUUID,
             Map<String, String>[] args);

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/NullVdsServer.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/NullVdsServer.java
@@ -271,7 +271,8 @@ public class NullVdsServer implements IVdsServer {
 
     @Override public ServerConnectionStatusReturn connectStorageServer(int serverType,
             String spUUID,
-            Map<String, String>[] args) {
+            Map<String, String>[] args,
+            List<String> devicesList) {
         return null;
     }
 


### PR DESCRIPTION
Add a parameter to connectStorageServer, to send
information to the host with all device guids
(LUN wwids) that must be available on the host after
connecting, specifically for iSCSI storage.

This will prevent proceeding with a connection
before all the devices are available through
dm-multipath, which could lead to errors afterwards
(e.g., the VM not booting).

Depends on https://github.com/oVirt/vdsm/pull/256
Bug-Url: https://bugzilla.redhat.com/2074029
Signed-off-by: Albert Esteve <aesteve@redhat.com>