### PR TITLE
core: Change type of console_disconnect_action_delay parameters

### DIFF
--- a/packaging/dbscripts/vm_templates_sp.sql
+++ b/packaging/dbscripts/vm_templates_sp.sql
@@ -83,7 +83,7 @@ Create or replace FUNCTION InsertVmTemplate(v_child_count INTEGER,
  v_is_template_sealed BOOLEAN,
  v_cpu_pinning VARCHAR(4000),
  v_balloon_enabled BOOLEAN,
- v_console_disconnect_action_delay SMALLINT,
+ v_console_disconnect_action_delay INTEGER,
  v_cpu_pinning_policy SMALLINT,
  v_parallel_migrations SMALLINT)
 
@@ -362,7 +362,7 @@ Create or replace FUNCTION UpdateVmTemplate(v_child_count INTEGER,
  v_is_template_sealed BOOLEAN,
  v_cpu_pinning VARCHAR(4000),
  v_balloon_enabled BOOLEAN,
- v_console_disconnect_action_delay SMALLINT,
+ v_console_disconnect_action_delay INTEGER,
  v_cpu_pinning_policy SMALLINT,
  v_parallel_migrations SMALLINT)
 RETURNS VOID

--- a/packaging/dbscripts/vms_sp.sql
+++ b/packaging/dbscripts/vms_sp.sql
@@ -742,7 +742,7 @@ CREATE OR REPLACE FUNCTION InsertVmStatic (
     v_use_tsc_frequency BOOLEAN,
     v_namespace VARCHAR(253),
     v_balloon_enabled BOOLEAN,
-    v_console_disconnect_action_delay SMALLINT,
+    v_console_disconnect_action_delay INTEGER,
     v_cpu_pinning_policy SMALLINT,
     v_parallel_migrations SMALLINT)
   RETURNS VOID
@@ -1117,7 +1117,7 @@ v_virtio_scsi_multi_queues INTEGER,
 v_use_tsc_frequency BOOLEAN,
 v_namespace VARCHAR(253),
 v_balloon_enabled BOOLEAN,
-v_console_disconnect_action_delay SMALLINT,
+v_console_disconnect_action_delay INTEGER,
 v_cpu_pinning_policy SMALLINT,
 v_parallel_migrations SMALLINT)
 


### PR DESCRIPTION
After changing type of vm_static.console_disconnect_action_delay field
in the database to int, need to change type of stored procedure
parameters accordingly.

Change-Id: Ibaa4351cf863cf2032ca3a6605ff8da7ed553397
Bug-Url: https://bugzilla.redhat.com/2076053
Signed-off-by: Shmuel Melamud <smelamud@redhat.com>