### PR TITLE
core: Quota name in audit log when deleting quota

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/quota/QuotaCRUDCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/quota/QuotaCRUDCommand.java
@@ -25,7 +25,9 @@ public abstract class QuotaCRUDCommand extends CommandBase<QuotaCRUDParameters> 
 
     public QuotaCRUDCommand(QuotaCRUDParameters parameters, CommandContext cmdContext) {
         super(parameters, cmdContext);
-        setStoragePoolId(getParameters().getQuota().getStoragePoolId());
+        if (getParameters().getQuota() != null) {
+            setStoragePoolId(getParameters().getQuota().getStoragePoolId());
+        }
     }
 
     public Quota getQuota() {
@@ -49,7 +51,7 @@ public abstract class QuotaCRUDCommand extends CommandBase<QuotaCRUDParameters> 
         Quota quota = getParameters().getQuota();
 
         // Cannot add or update a quota to be default using this command
-        if (quota.isDefault()) {
+        if (quota == null || quota.isDefault()) {
             addValidationMessage(EngineMessage.ACTION_TYPE_FAILED_QUOTA_IS_NOT_VALID);
             return false;
         }
@@ -78,9 +80,11 @@ public abstract class QuotaCRUDCommand extends CommandBase<QuotaCRUDParameters> 
     private void fillQuotaParameter() {
         Quota quotaParameter = getParameters().getQuota();
 
-        setQuotaStorage(quotaParameter);
-        setQuotaCluster(quotaParameter);
-        setQuotaThresholdDefaults(quotaParameter);
+        if (quotaParameter != null) {
+            setQuotaStorage(quotaParameter);
+            setQuotaCluster(quotaParameter);
+            setQuotaThresholdDefaults(quotaParameter);
+        }
     }
 
     private void setQuotaStorage(Quota quota) {
@@ -157,7 +161,7 @@ public abstract class QuotaCRUDCommand extends CommandBase<QuotaCRUDParameters> 
     }
 
     public String getQuotaName() {
-        return quota.getQuotaName();
+        return getQuota().getQuotaName();
     }
 
 }

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/quota/RemoveQuotaCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/quota/RemoveQuotaCommand.java
@@ -90,4 +90,9 @@ public class RemoveQuotaCommand extends CommandBase<IdParameters> {
     public void setQuota(Quota quota) {
         this.quota = quota;
     }
+
+    public String getQuotaName() {
+        return getQuota().getQuotaName();
+    }
+
 }

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/quota/RemoveQuotaCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/quota/RemoveQuotaCommand.java
@@ -5,31 +5,32 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import org.ovirt.engine.core.bll.CommandBase;
 import org.ovirt.engine.core.bll.context.CommandContext;
 import org.ovirt.engine.core.bll.utils.PermissionSubject;
 import org.ovirt.engine.core.common.AuditLogType;
 import org.ovirt.engine.core.common.VdcObjectType;
-import org.ovirt.engine.core.common.action.IdParameters;
+import org.ovirt.engine.core.common.action.QuotaCRUDParameters;
 import org.ovirt.engine.core.common.businessentities.Quota;
 import org.ovirt.engine.core.common.businessentities.QuotaEnforcementTypeEnum;
 import org.ovirt.engine.core.common.errors.EngineMessage;
 import org.ovirt.engine.core.dao.QuotaDao;
 
-public class RemoveQuotaCommand extends CommandBase<IdParameters> {
+public class RemoveQuotaCommand extends QuotaCRUDCommand {
 
     @Inject
     private QuotaDao quotaDao;
 
-    private Quota quota;
-
-    public RemoveQuotaCommand(IdParameters parameters, CommandContext cmdContext) {
+    public RemoveQuotaCommand(QuotaCRUDParameters parameters, CommandContext cmdContext) {
         super(parameters, cmdContext);
     }
 
     @Override
+    protected void init() {
+    }
+
+    @Override
     protected boolean validate() {
-        if (getParameters() == null || getParameters().getId() == null) {
+        if (getParameters() == null || getParameters().getQuotaId() == null) {
             addValidationMessage(EngineMessage.ACTION_TYPE_FAILED_QUOTA_NOT_EXIST);
             return false;
         }
@@ -58,14 +59,14 @@ public class RemoveQuotaCommand extends CommandBase<IdParameters> {
 
     @Override
     protected void executeCommand() {
-        quotaDao.remove(getParameters().getId());
-        getQuotaManager().removeQuotaFromCache(getQuota().getStoragePoolId(), getParameters().getId());
+        quotaDao.remove(getParameters().getQuotaId());
+        getQuotaManager().removeQuotaFromCache(getQuota().getStoragePoolId(), getParameters().getQuotaId());
         getReturnValue().setSucceeded(true);
     }
 
     @Override
     public List<PermissionSubject> getPermissionCheckSubjects() {
-        return Collections.singletonList(new PermissionSubject(getParameters().getId(),
+        return Collections.singletonList(new PermissionSubject(getParameters().getQuotaId(),
                 VdcObjectType.Quota, getActionType().getActionGroup()));
     }
 
@@ -78,21 +79,6 @@ public class RemoveQuotaCommand extends CommandBase<IdParameters> {
     @Override
     public AuditLogType getAuditLogTypeValue() {
         return getSucceeded() ? AuditLogType.USER_DELETE_QUOTA : AuditLogType.USER_FAILED_DELETE_QUOTA;
-    }
-
-    public Quota getQuota() {
-        if (quota == null) {
-            setQuota(quotaDao.getById(getParameters().getId()));
-        }
-        return quota;
-    }
-
-    public void setQuota(Quota quota) {
-        this.quota = quota;
-    }
-
-    public String getQuotaName() {
-        return getQuota().getQuotaName();
     }
 
 }

--- a/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/quota/RemoveQuotaCommandTest.java
+++ b/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/quota/RemoveQuotaCommandTest.java
@@ -9,7 +9,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.ovirt.engine.core.bll.BaseCommandTest;
 import org.ovirt.engine.core.bll.ValidateTestUtils;
-import org.ovirt.engine.core.common.action.IdParameters;
+import org.ovirt.engine.core.common.action.QuotaCRUDParameters;
 import org.ovirt.engine.core.common.businessentities.Quota;
 import org.ovirt.engine.core.common.businessentities.QuotaCluster;
 import org.ovirt.engine.core.common.businessentities.QuotaStorage;
@@ -60,7 +60,7 @@ public class RemoveQuotaCommandTest extends BaseCommandTest {
     }
 
     private RemoveQuotaCommand createCommand() {
-        IdParameters param = new IdParameters(quotaGuid);
+        QuotaCRUDParameters param = new QuotaCRUDParameters(quotaGuid);
         return new RemoveQuotaCommand(param, null);
     }
 

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/QuotaCRUDParameters.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/QuotaCRUDParameters.java
@@ -3,7 +3,6 @@ package org.ovirt.engine.core.common.action;
 import java.io.Serializable;
 
 import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
 
 import org.ovirt.engine.core.common.businessentities.Quota;
 import org.ovirt.engine.core.compat.Guid;
@@ -15,12 +14,15 @@ public class QuotaCRUDParameters extends StoragePoolParametersBase implements Se
     private Guid quotaId;
 
     @Valid
-    @NotNull
     private Quota quota;
 
     private boolean copyPermissions;
 
     public QuotaCRUDParameters() {
+    }
+
+    public QuotaCRUDParameters(Guid quotaId) {
+        this.quotaId = quotaId;
     }
 
     public QuotaCRUDParameters(Quota quota) {

--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendQuotaResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendQuotaResource.java
@@ -10,7 +10,6 @@ import org.ovirt.engine.api.resource.QuotaStorageLimitsResource;
 import org.ovirt.engine.core.common.VdcObjectType;
 import org.ovirt.engine.core.common.action.ActionParametersBase;
 import org.ovirt.engine.core.common.action.ActionType;
-import org.ovirt.engine.core.common.action.IdParameters;
 import org.ovirt.engine.core.common.action.QuotaCRUDParameters;
 import org.ovirt.engine.core.common.queries.GetPermissionsForObjectParameters;
 import org.ovirt.engine.core.common.queries.IdQueryParameters;
@@ -55,7 +54,7 @@ public class BackendQuotaResource extends AbstractBackendSubResource<Quota, org.
     @Override
     public Response remove() {
         get();
-        IdParameters prms = new IdParameters(asGuid(id));
+        QuotaCRUDParameters prms = new QuotaCRUDParameters(asGuid(id));
         return performAction(ActionType.RemoveQuota, prms);
     }
 

--- a/backend/manager/modules/restapi/jaxrs/src/test/java/org/ovirt/engine/api/restapi/resource/BackendQuotaResourceTest.java
+++ b/backend/manager/modules/restapi/jaxrs/src/test/java/org/ovirt/engine/api/restapi/resource/BackendQuotaResourceTest.java
@@ -5,7 +5,6 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.ovirt.engine.api.model.Quota;
 import org.ovirt.engine.core.common.action.ActionType;
-import org.ovirt.engine.core.common.action.IdParameters;
 import org.ovirt.engine.core.common.action.QuotaCRUDParameters;
 import org.ovirt.engine.core.common.queries.IdQueryParameters;
 import org.ovirt.engine.core.common.queries.QueryType;
@@ -47,8 +46,8 @@ public class BackendQuotaResourceTest extends AbstractBackendSubResourceTest<Quo
         setUpGetEntityExpectations();
         setUriInfo(setUpActionExpectations(
                 ActionType.RemoveQuota,
-                IdParameters.class,
-                new String[] { "Id" },
+                QuotaCRUDParameters.class,
+                new String[] { "QuotaId" },
                 new Object[] { QUOTA_ID },
                 true,
                 true));

--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/quota/QuotaListModel.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/quota/QuotaListModel.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import org.ovirt.engine.core.common.action.ActionParametersBase;
 import org.ovirt.engine.core.common.action.ActionType;
-import org.ovirt.engine.core.common.action.IdParameters;
 import org.ovirt.engine.core.common.action.QuotaCRUDParameters;
 import org.ovirt.engine.core.common.businessentities.Cluster;
 import org.ovirt.engine.core.common.businessentities.Quota;
@@ -583,7 +582,7 @@ public class QuotaListModel<E> extends ListWithSimpleDetailsModel<E, Quota> {
 
         ArrayList<ActionParametersBase> prms = new ArrayList<>();
         for (Quota a : getSelectedItems()) {
-            IdParameters idParameters = new IdParameters(a.getId());
+            QuotaCRUDParameters idParameters = new QuotaCRUDParameters(a.getId());
             prms.add(idParameters);
         }
 


### PR DESCRIPTION
Added missing method for ${QuotaName} substitution in the audit log
message for RemoveQuotaCommand.

Change-Id: I9826e1965b7faf8dc46afa80d1218ae49fc4a34b
Bug-Url: https://bugzilla.redhat.com/2018412
Signed-off-by: Shmuel Melamud <smelamud@redhat.com>