### PR TITLE
Change lock message of disks being downloaded

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/TransferDiskImageCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/TransferDiskImageCommand.java
@@ -453,7 +453,7 @@ public class TransferDiskImageCommand<T extends TransferDiskImageParameters> ext
 
         if (getDiskImage() != null && getParameters().getTransferType() == TransferType.Download) {
             locks.put(getDiskImage().getId().toString(),
-                    LockMessagesMatchUtil.makeLockingPair(LockingGroup.DISK, EngineMessage.ACTION_TYPE_FAILED_DISK_IS_LOCKED));
+                    LockMessagesMatchUtil.makeLockingPair(LockingGroup.DISK, getDiskIsBeingTransferredLockMessage()));
         }
 
         return locks;


### PR DESCRIPTION
We changed the lock of disks that are being downloaded to be a shared
lock instead of an exclusive lock. Here we change the message that is
associated with this lock to be the same as we use for the exclusive lock
in case of upload-disk, which is more informative.