### PR TITLE
setup: Make sure OVN key files are available before accessing them

### DIFF
--- a/packaging/setup/ovirt_engine_setup/engine/constants.py
+++ b/packaging/setup/ovirt_engine_setup/engine/constants.py
@@ -382,6 +382,7 @@ class Stages(object):
 
     MEMORY_CHECK = 'osetup.memory.check'
 
+    CA_UPGRADE = 'osetup.pki.ca.upgrade'
     CA_AVAILABLE = 'osetup.pki.ca.available'
     QEMU_CA_AVAILABLE = 'osetup.pki.qemu.ca.available'
 

--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/network/ovirtproviderovn.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/network/ovirtproviderovn.py
@@ -975,9 +975,9 @@ class Plugin(plugin.PluginBase):
     @plugin.event(
         stage=plugin.Stages.STAGE_MISC,
         before=(
-            oenginecons.Stages.CA_AVAILABLE,
+            oenginecons.Stages.CA_UPGRADE,
         ),
-        condition=lambda self: self._enabled,
+        condition=lambda self: self._enabled or self._provider_installed,
     )
     def _misc_pki(self):
         self._generate_pki()
@@ -996,7 +996,10 @@ class Plugin(plugin.PluginBase):
     @plugin.event(
         stage=plugin.Stages.STAGE_MISC,
         before=(
-                oenginecons.Stages.OVN_SERVICES_RESTART,
+            oenginecons.Stages.OVN_SERVICES_RESTART,
+        ),
+        after=(
+            oenginecons.Stages.CA_AVAILABLE,
         ),
         condition=lambda self: (
                 self._provider_installed and

--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/pki/ca.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/pki/ca.py
@@ -621,6 +621,7 @@ class Plugin(plugin.PluginBase):
 
     @plugin.event(
         stage=plugin.Stages.STAGE_MISC,
+        name=oenginecons.Stages.CA_UPGRADE,
         before=(
             oenginecons.Stages.CA_AVAILABLE,
             oenginecons.Stages.QEMU_CA_AVAILABLE,


### PR DESCRIPTION
When Engine CA certificate file is removed and then engine-setup with
certificate renewal is run, engine-setup may fail with the following
error:

[ ERROR ] Failed to execute stage 'Misc configuration': [Errno 2] No such file or directory: '/etc/pki/ovirt-engine/keys/ovn-sdb.key.nopass'

The problem is that
otopi.plugins.ovirt_engine_setup.ovirt_engine.network.ovirtproviderovn.Plugin._upgrade,
which requires the presence of the OVN keys,
may be run before
otopi.plugins.ovirt_engine_setup.ovirt_engine.pki.ca.Plugin._miscUpgrade,
which generates them if previously asked for that by
otopi.plugins.ovirt_engine_setup.ovirt_engine.network.ovirtproviderovn.Plugin._misc_pki.

Let’s ensure correct ordering of these three actions and also set up
OVN renewal if self._provider_installed is true, since this condition
is used to check whether
otopi.plugins.ovirt_engine_setup.ovirt_engine.network.ovirtproviderovn.Plugin._upgrade
should be run.