### PR TITLE
setup: Don’t fail cleanup on empty remote engine environment

### DIFF
--- a/packaging/setup/plugins/ovirt-engine-common/base/remote_engine/remote_engine.py
+++ b/packaging/setup/plugins/ovirt-engine-common/base/remote_engine/remote_engine.py
@@ -65,7 +65,7 @@ class Plugin(plugin.PluginBase):
         ] = remote_engine.RemoteEngine(plugin=self)
 
     @plugin.event(
-        stage=plugin.Stages.STAGE_CLEANUP,
+        stage=plugin.Stages.STAGE_CLOSEUP,
     )
     def _cleanup(self):
         self.environment[


### PR DESCRIPTION
When engine-setup fails on dnf repositories download, the followup
cleanup fails with

[ ERROR ] Failed to execute stage 'Clean up': 'NoneType' object has no attribute 'cleanup'

This patch fixes it and allows the cleanup finish normally.