### PR TITLE
core: update actual size after conversion

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/ConvertDiskCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/ConvertDiskCommand.java
@@ -298,6 +298,8 @@ public class ConvertDiskCommand<T extends ConvertDiskCommandParameters> extends 
         DiskImage newImage = DiskImage.copyOf(getDiskImage());
         newImage.setImageId(getParameters().getNewVolGuid());
         newImage.setSize(info.getSize());
+        newImage.setActualSize(info.getActualSize());
+        newImage.setActualSizeInBytes(info.getActualSizeInBytes());
         if (getParameters().getVolumeFormat() != null) {
             if (info.getVolumeFormat() != getParameters().getVolumeFormat()) {
                 log.error("Requested format '{}' doesn't match format on storage '{}'",
@@ -323,7 +325,6 @@ public class ConvertDiskCommand<T extends ConvertDiskCommandParameters> extends 
         TransactionSupport.executeInNewTransaction(() -> {
             addDiskImageToDb(newImage, getCompensationContext(), true);
             imageDao.update(getDiskImage().getImage());
-
             return null;
         });
 


### PR DESCRIPTION
The actual size of a volume is reduced when converting the disk from COW/preallocated to COW/thin on a block storage domain is not updated, making it seem like disk consumes more than it actually does.

This patch updates the actual size after conversion.

Bug-Url: https://bugzilla.redhat.com/2086561
