### PR TITLE
webadmin: fix alignment on Resource Allocation popup

### DIFF
--- a/frontend/webadmin/modules/gwt-common/src/main/java/org/ovirt/engine/ui/common/widget/uicommon/storage/DisksAllocationView.java
+++ b/frontend/webadmin/modules/gwt-common/src/main/java/org/ovirt/engine/ui/common/widget/uicommon/storage/DisksAllocationView.java
@@ -2,7 +2,6 @@ package org.ovirt.engine.ui.common.widget.uicommon.storage;
 
 import java.util.ArrayList;
 
-import org.ovirt.engine.core.common.businessentities.QuotaEnforcementTypeEnum;
 import org.ovirt.engine.ui.common.CommonApplicationConstants;
 import org.ovirt.engine.ui.common.PopupSimpleTableResources;
 import org.ovirt.engine.ui.common.editor.UiCommonEditorDriver;
@@ -163,7 +162,7 @@ public class DisksAllocationView extends Composite implements HasEditorDriver<Di
     void updateColumnsAvailability(DisksAllocationModel model) {
         setShowVolumeType(model.getIsVolumeTypeAvailable());
         setShowVolumeFormat(model.getIsVolumeFormatAvailable());
-        setShowQuota(model.getQuotaEnforcementType() != QuotaEnforcementTypeEnum.DISABLED);
+        setShowQuota(model.isQuotaEnforced());
         setShowSource(model.isSourceAvailable());
         setShowTarget(model.isTargetAvailable());
     }
@@ -183,6 +182,7 @@ public class DisksAllocationView extends Composite implements HasEditorDriver<Di
             } else if ("QuotaEnforcmentType".equals(args.propertyName)) { //$NON-NLS-1$
                 updateColumnsAvailability(model);
                 updateListHeader();
+                addDiskList(model);
             }
         });
     }

--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/storage/DisksAllocationModel.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/storage/DisksAllocationModel.java
@@ -240,7 +240,7 @@ public class DisksAllocationModel extends EntityModel {
     }
 
     private void updateQuota(Guid storageDomainId, final ListModel<Quota> isItem, final Guid diskQuotaId) {
-        if (getQuotaEnforcementType() != QuotaEnforcementTypeEnum.DISABLED && storageDomainId != null) {
+        if (isQuotaEnforced() && storageDomainId != null) {
             AsyncDataProvider.getInstance().getAllRelevantQuotasForStorageSorted(new AsyncQuery<>(
                     list -> {
                         if (list == null) {
@@ -331,6 +331,7 @@ public class DisksAllocationModel extends EntityModel {
             diskModel.getVolumeFormat().setIsAvailable(isVolumeFormatAvailable);
             diskModel.getVolumeFormat().setIsChangeable(isVolumeFormatChangeable);
             diskModel.getAlias().setIsChangeable(isAliasChangeable);
+            diskModel.getQuota().setIsAvailable(isQuotaEnforced());
 
             if (isThinProvisioning) {
                 diskModel.getVolumeFormat().setSelectedItem(VolumeFormat.COW);
@@ -386,7 +387,7 @@ public class DisksAllocationModel extends EntityModel {
     private void updateQuotaAvailability() {
         if (disks != null) {
             for (DiskModel diskModel : disks) {
-                diskModel.getQuota().setIsAvailable(quotaEnforcementType != QuotaEnforcementTypeEnum.DISABLED);
+                diskModel.getQuota().setIsAvailable(isQuotaEnforced());
             }
         }
     }
@@ -512,6 +513,10 @@ public class DisksAllocationModel extends EntityModel {
 
     public boolean isSourceAvailable() {
         return isSourceStorageDomainAvailable || isSourceStorageDomainNameAvailable;
+    }
+
+    public boolean isQuotaEnforced() {
+        return getQuotaEnforcementType() != QuotaEnforcementTypeEnum.DISABLED;
     }
 
     public void initializeAutoSelectTarget(boolean changeable, boolean value) {


### PR DESCRIPTION
Screenshot: https://imgur.com/a/w1dMuCU

This patch fixes the alignment under Resource Allocation > Disk
Allocation, when cloning a VM.
The disk panel is being first created as part of the view initiation.
Determining the DC quota level (disabled/enforced) affects the number of
columns appear in the disk allocation view.
Since updating the quota happens later (not as part of initialization),
The columns' width can't be changed unless re-creating the disks lists
in the view, so the view needs to be created with the updated width.

Bug-Url: https://bugzilla.redhat.com/2081546
Signed-off-by: Shani Leviim <sleviim@redhat.com>