### PR TITLE
engine: Save updated Numa Nodes into NEXT_RUN snapshot

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/snapshots/SnapshotsManager.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/snapshots/SnapshotsManager.java
@@ -293,7 +293,9 @@ public class SnapshotsManager {
      *            The VM to generate configuration from.
      * @return A String containing the VM configuration.
      */
-    private String generateVmConfiguration(VM vm, List<DiskImage> disks, Map<Guid, VmDevice> vmDevices) {
+    private String generateVmConfiguration(VM vm,
+            List<DiskImage> disks,
+            Map<Guid, VmDevice> vmDevices) {
         if (vm.getInterfaces() == null || vm.getInterfaces().isEmpty()) {
             vm.setInterfaces(vmNetworkInterfaceDao.getAllForVm(vm.getId()));
         }
@@ -323,7 +325,11 @@ public class SnapshotsManager {
         if (vm.getStaticData().getVmInit() == null) {
             vmHandler.updateVmInitFromDB(vm.getStaticData(), true);
         }
-        vmHandler.updateNumaNodesFromDb(vm);
+
+        if (vm.getStaticData().getvNumaNodeList() == null) {
+            vmHandler.updateNumaNodesFromDb(vm);
+        }
+
         return ovfManager.exportVm(vm,
                 fullEntityOvfData,
                 clusterUtils.getCompatibilityVersion(vm));

--- a/frontend/webadmin/modules/uicompat/src/main/java/org/ovirt/engine/ui/uicompat/NextRunFieldMessages.java
+++ b/frontend/webadmin/modules/uicompat/src/main/java/org/ovirt/engine/ui/uicompat/NextRunFieldMessages.java
@@ -86,6 +86,8 @@ public interface NextRunFieldMessages extends ConstantsWithLookup {
 
     String initrdUrl();
 
+    String vNumaNodeList();
+
     // Devices
 
     String memballoon();

--- a/frontend/webadmin/modules/uicompat/src/main/resources/org/ovirt/engine/ui/uicompat/NextRunFieldMessages.properties
+++ b/frontend/webadmin/modules/uicompat/src/main/resources/org/ovirt/engine/ui/uicompat/NextRunFieldMessages.properties
@@ -40,6 +40,7 @@ virtioScsiMultiQueuesEnabled=VirtIO-SCSI Multi Queue
 kernelUrl=Kernel URL
 kernelParams=Kernel Parameters
 initrdUrl=Initrd Url
+vNumaNodeList=NUMA Nodes Configuration
 # Devices - from VmManagementParametersBase with @EditableDeviceOnVmStatusField annotation
 memballoon=Memory Balloon
 watchdog=Watchdog


### PR DESCRIPTION
When creating a VM configuration string from the VM object, the NUMA Node list was always updated from the database. This caused that the new settings for the VM were not saved into the NEXT_RUN snapshot.

Bug-Url: https://bugzilla.redhat.com/2099225