### PR TITLE
Set initial event number for async ansible commands

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/AnsibleCallback.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/AnsibleCallback.java
@@ -68,7 +68,7 @@ public class AnsibleCallback implements CommandCallback {
         // Process the events if the playbook is running:
         totalEvents = runnerClient.getTotalEvents(playUuid);
 
-        if (msg.equalsIgnoreCase("running") || msg.equalsIgnoreCase("successful")
+        if (msg.equalsIgnoreCase("running") || totalEvents == 0 || msg.equalsIgnoreCase("successful")
                 && command.getParameters().getLastEventId() < totalEvents) {
             command.getParameters().setLastEventId(runnerClient.processEvents(
                     playUuid, command.getParameters().getLastEventId(), fn, msg, ret.getLogFile()));

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/AnsibleCommandBase.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/AnsibleCommandBase.java
@@ -64,7 +64,6 @@ public abstract class AnsibleCommandBase <T extends AnsibleCommandParameters> ex
         } else {
             getParameters().setPlayUuid(ansibleReturnValue.getPlayUuid());
             getParameters().setLogFile(ansibleReturnValue.getLogFile().toString());
-            getParameters().setLastEventId(ansibleReturnValue.getLastEventId());
             persistCommand(getParameters().getParentCommand(), true);
             setSucceeded(true);
         }

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/AnsibleCommandParameters.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/AnsibleCommandParameters.java
@@ -18,6 +18,7 @@ public class AnsibleCommandParameters extends ActionParametersBase {
     public AnsibleCommandParameters() {
         super();
         this.playUuid = UUID.randomUUID().toString();
+        this.lastEventId = 0;
     }
 
     public int getLastEventId() {


### PR DESCRIPTION
If the ansible playbook execution happened faster than the engine, we
may get a successful status and the correct number of events. In that
case we may skip the event processing in the ansible callback. Which may
lead us to wrong data returned to the command itself.

Change-Id: I432938a7fc241701eb260c1fbc460d1de7149092
Signed-off-by: Liran Rotenberg <lrotenbe@redhat.com>