### PR TITLE
engine: Fix NPE when misconfiguring NUMA with hugepages

### DIFF
--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/utils/NumaPinningHelper.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/utils/NumaPinningHelper.java
@@ -150,8 +150,8 @@ public class NumaPinningHelper {
                         // in NumaValidator
                         int hugePageSizeMB = hugePageSize.get() / 1024;
                         int requiredHugePages = (int) vmNode.getMemTotal() / hugePageSizeMB;
-                        int hostFreePages = HugePageUtils.hugePagesToMap(hostNumaNodesData.get(pinnedIndex).getHugePages()).get(hugePageSize.get());
-                        if (hostFreePages < requiredHugePages) {
+                        Integer hostFreePages = HugePageUtils.hugePagesToMap(hostNumaNodesData.get(pinnedIndex).getHugePages()).get(hugePageSize.get());
+                        if (hostFreePages == null || hostFreePages < requiredHugePages) {
                             return;
                         }
 


### PR DESCRIPTION
When a VM with NUMA is set with hugepages with a size that is different than the one reported by the host, the
running of the VM fails with NPE in NumaPinningHelper.

This patch fixes the NPE.