### PR TITLE
packaging: Bump vdsm-jsonrpc-java to 1.7.2

### DIFF
--- a/ovirt-engine.spec.in
+++ b/ovirt-engine.spec.in
@@ -481,7 +481,7 @@ Requires:	mod_ssl
 Requires:	novnc >= 1.0.0
 Requires:	python3-%{name}-lib >= %{version}-%{release}
 Requires:	openssh
-Requires:	vdsm-jsonrpc-java >= 1.7.1, vdsm-jsonrpc-java < 1.8.0
+Requires:	vdsm-jsonrpc-java >= 1.7.2, vdsm-jsonrpc-java < 1.8.0
 Requires:	java-client-kubevirt >= 0.5.0
 Requires:	openssl
 Requires:	ovirt-engine-extension-aaa-jdbc >= 1.2.0

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <cxf.version>2.2.7</cxf.version>
     <sshd-core.version>2.8.0</sshd-core.version>
     <eddsa.version>0.3.0</eddsa.version>
-    <vdsm-jsonrpc-java.version>1.7.1</vdsm-jsonrpc-java.version>
+    <vdsm-jsonrpc-java.version>1.7.2</vdsm-jsonrpc-java.version>
     <slf4j.version>1.7.22</slf4j.version>
     <gwt.version>2.9.0</gwt.version>
     <mockito.version>3.8.0</mockito.version>


### PR DESCRIPTION
This patch bumps jsonrpc java version to fix an issue with hosts stayed
forever in 'connecting' state after an attempt to reconnect with expired
SSL certificates

Bug-Url: https://bugzilla.redhat.com/2090645
