### PR TITLE
packaging: unify ovirt admin user email

### DIFF
--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/config/aaajdbc.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/config/aaajdbc.py
@@ -293,7 +293,7 @@ class Plugin(plugin.PluginBase):
         ].rsplit('@', 1)[0]
 
         # Should this be configurable? User can change it later.
-        adminEmail = 'root@localhost'
+        adminEmail = 'admin@localhost'
 
         if not self._userExists(
             toolArgs=toolArgs,


### PR DESCRIPTION
This patch changes default ovirt admin email address to one required
(hardcoded) by grafana so that oVirt SSO works when Keycloak integration
is disabled.
