### PR TITLE
Delete next-run snapshot in a compensation context

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/VmHandler.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/VmHandler.java
@@ -1586,7 +1586,7 @@ public class VmHandler implements BackendService {
         // first remove existing snapshot
         Snapshot runSnap = snapshotDao.get(existingVm.getId(), Snapshot.SnapshotType.NEXT_RUN);
         if (runSnap != null) {
-            snapshotDao.remove(runSnap.getId());
+            CompensationUtils.removeEntity(runSnap, snapshotDao, compensationContext);
         }
 
         final VM newVm = new VM();


### PR DESCRIPTION
The next-run snapshot is created in a compensation context, which causes
it to be removed if something fails.
But the previous (if exists) next-run snapshot is removed outside the
compensation context.

This causes the VM's to lose its next-run snapshot if for example an
UpdateCluster fails.

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=2094729
Signed-off-by: Jean-Louis Dupond jean-louis@dupond.be