### PR TITLE
Release core reminders for isolate threads

### DIFF
--- a/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/scheduling/utils/VdsCpuUnitPinningHelperTest.java
+++ b/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/scheduling/utils/VdsCpuUnitPinningHelperTest.java
@@ -416,4 +416,40 @@ public class VdsCpuUnitPinningHelperTest {
         assertEquals(6, cpus.stream().filter(cpu -> cpu.getSocket() == 1).count());
     }
 
+    @Test
+    public void releaseReminderOnIsolateThreads() {
+        VM vm = new VM();
+        vm.setId(Guid.newGuid());
+        vm.setNumOfSockets(2);
+        vm.setCpuPerSocket(3);
+        vm.setThreadsPerCpu(1);
+        vm.setCpuPinningPolicy(CpuPinningPolicy.ISOLATE_THREADS);
+
+        List<VdsCpuUnit> cpuTopology = new ArrayList<>();
+        cpuTopology.add(new VdsCpuUnit(0, 0, 0, 0));
+        cpuTopology.add(new VdsCpuUnit(0, 0, 0, 1));
+        cpuTopology.add(new VdsCpuUnit(0, 0, 1, 0));
+        VdsCpuUnit vdsmTaken = new VdsCpuUnit(0, 0, 1, 1);
+        vdsmTaken.pinVm(Guid.SYSTEM, CpuPinningPolicy.MANUAL);
+        cpuTopology.add(vdsmTaken);
+        cpuTopology.add(new VdsCpuUnit(0, 0, 2, 0));
+        cpuTopology.add(new VdsCpuUnit(0, 0, 2, 1));
+        cpuTopology.add(new VdsCpuUnit(0, 0, 3, 0));
+        cpuTopology.add(new VdsCpuUnit(0, 0, 3, 1));
+
+        cpuTopology.add(new VdsCpuUnit(1, 1, 0, 0));
+        cpuTopology.add(new VdsCpuUnit(1, 1, 0, 1));
+        cpuTopology.add(new VdsCpuUnit(1, 1, 1, 0));
+        cpuTopology.add(new VdsCpuUnit(1, 1, 1, 0));
+        cpuTopology.add(new VdsCpuUnit(1, 1, 2, 0));
+        cpuTopology.add(new VdsCpuUnit(1, 1, 2, 1));
+        cpuTopology.add(new VdsCpuUnit(1, 1, 3, 0));
+        cpuTopology.add(new VdsCpuUnit(1, 1, 3, 1));
+
+        when(vdsManager.getCpuTopology()).thenReturn(cpuTopology);
+        List<VdsCpuUnit> cpus = vdsCpuUnitPinningHelper.updatePhysicalCpuAllocations(vm, new HashMap<>(), host.getId());
+        assertEquals(12, cpus.size());
+        assertEquals(12, cpuTopology.stream().filter(VdsCpuUnit::isExclusive).count());
+    }
+
 }


### PR DESCRIPTION
We now release using unPin the VdsCpuUnit we need. This is good for
`dedicated` policy. When we are handling `isolate-threads` policy we
need to release the whole core. Otherwise the engine thinks it's taken.

Change-Id: I0b028e0dc5db72f5ef3099059f355d975a81fc90
Bug-Url: https://bugzilla.redhat.com/2103620
Signed-off-by: Liran Rotenberg <lrotenbe@redhat.com>