### PR TITLE
core: Use virtio-vga driver for VGA

### DIFF
--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/FeatureSupported.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/FeatureSupported.java
@@ -445,4 +445,14 @@ public class FeatureSupported {
     public static boolean isReplicateExtendSupported(Version version) {
         return Version.v4_7.lessOrEquals(version);
     }
+
+    /**
+     * Check 'virtio' driver for 'vga' display type is supported.
+     *
+     * @param version Compatibility version to check for.
+     * @return true if 'virtio' driver is supported
+     */
+    public static boolean isVirtioVgaSupported(Version version) {
+        return supportedInConfig(ConfigValues.VirtioVgaSupported, version);
+    }
 }

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/config/ConfigValues.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/config/ConfigValues.java
@@ -1612,6 +1612,9 @@ public enum ConfigValues {
     @TypeConverterAttribute(Boolean.class)
     EnableBochsDisplay,
 
+    @TypeConverterAttribute(Boolean.class)
+    VirtioVgaSupported,
+
     @TypeConverterAttribute(Integer.class)
     HostMonitoringWatchdogIntervalInSeconds,
 

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/builder/vminfo/LibvirtVmXmlBuilder.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/builder/vminfo/LibvirtVmXmlBuilder.java
@@ -3014,7 +3014,7 @@ public class LibvirtVmXmlBuilder {
         if (mdevDisplayOn) {
             writer.writeAttributeString("type", "none");
         } else {
-            writer.writeAttributeString("type", device.getDevice());
+            writer.writeAttributeString("type", getVideoType(device.getDevice()));
             Object vram = device.getSpecParams().get(VdsProperties.VIDEO_VRAM);
             writer.writeAttributeString("vram", vram != null ? vram.toString() : "32768");
             Object heads = device.getSpecParams().get(VdsProperties.VIDEO_HEADS);
@@ -3031,6 +3031,13 @@ public class LibvirtVmXmlBuilder {
         writeAlias(device);
         writeAddress(device);
         writer.writeEndElement();
+    }
+
+    private String getVideoType(String deviceType) {
+        if (!deviceType.equals("vga")) {
+            return deviceType;
+        }
+        return FeatureSupported.isVirtioVgaSupported(vm.getCompatibilityVersion()) && !legacyVirtio ? "virtio" : "vga";
     }
 
     private void writeDefaultVideo() {

--- a/packaging/dbscripts/upgrade/pre_upgrade/0000_config.sql
+++ b/packaging/dbscripts/upgrade/pre_upgrade/0000_config.sql
@@ -933,6 +933,8 @@ select fn_db_add_config_value_for_versions_up_to('NvramPersistenceSupported', 'f
 select fn_db_add_config_value_for_versions_up_to('NvramPersistenceSupported', 'true', '4.7');
 select fn_db_add_config_value_for_versions_up_to('EnableBochsDisplay','false','4.5');
 select fn_db_add_config_value_for_versions_up_to('EnableBochsDisplay','true','4.7');
+select fn_db_add_config_value_for_versions_up_to('VirtioVgaSupported','false','4.6');
+select fn_db_add_config_value_for_versions_up_to('VirtioVgaSupported','true','4.7');
 select fn_db_add_config_value_for_versions_up_to('ParallelMigrationsSupported', 'false', '4.6');
 select fn_db_add_config_value_for_versions_up_to('ParallelMigrationsSupported', 'true', '4.7');
 select fn_db_add_config_value_for_versions_up_to('IsDedicatedSupported', 'false', '4.6');

--- a/packaging/etc/engine-config/engine-config.properties
+++ b/packaging/etc/engine-config/engine-config.properties
@@ -593,6 +593,8 @@ NvramPersistenceSupported.description=Enable/Disable NVRAM data persistence.
 NvramPersistenceSupported.type=Boolean
 EnableBochsDisplay.type=Boolean
 EnableBochsDisplay.description=Enable bochs display type support
+VirtioVgaSupported.type=Boolean
+VirtioVgaSupported.description=Enable virtio-vga driver usage for VGA displays.
 # Host monitoring watchdog
 HostMonitoringWatchdogIntervalInSeconds.type=Integer
 HostMonitoringWatchdogIntervalInSeconds.description="Host monitoring watchdog service interval to check if host monitoring is running."


### PR DESCRIPTION
If VM is configured with VGA display type, use virtio-vga driver for it.
This behaviour may be configured through osinfo database.

Change-Id: I2476286e90cd84b51e35bd3170affeaee1924951
Bug-Url: https://bugzilla.redhat.com/2038694
Signed-off-by: Shmuel Melamud <smelamud@redhat.com>