### PR TITLE
Set VMs that preview memory snapshots to suspended

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/GetArchitectureCapabilitiesQuery.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/GetArchitectureCapabilitiesQuery.java
@@ -58,8 +58,6 @@ public class GetArchitectureCapabilitiesQuery<P extends ArchCapabilitiesParamete
         switch (archCapabilitiesVerb) {
         case GetMigrationSupport:
             return FeatureSupported.isMigrationSupported(architecture, version);
-        case GetMemorySnapshotSupport:
-            return FeatureSupported.isMemorySnapshotSupportedByArchitecture(architecture, version);
         case GetSuspendSupport:
             return FeatureSupported.isSuspendSupportedByArchitecture(architecture, version);
         case GetMemoryHotUnplugSupport:

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/HibernateVmCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/HibernateVmCommand.java
@@ -10,6 +10,7 @@ import org.ovirt.engine.core.bll.context.CommandContext;
 import org.ovirt.engine.core.bll.memory.MemoryDisks;
 import org.ovirt.engine.core.bll.memory.MemoryStorageHandler;
 import org.ovirt.engine.core.bll.memory.MemoryUtils;
+import org.ovirt.engine.core.bll.snapshots.SnapshotsValidator;
 import org.ovirt.engine.core.bll.storage.disk.image.DisksFilter;
 import org.ovirt.engine.core.bll.tasks.CommandCoordinatorUtil;
 import org.ovirt.engine.core.bll.validator.VmValidator;
@@ -60,6 +61,8 @@ public class HibernateVmCommand<T extends VmOperationParameterBase> extends VmOp
     private SnapshotDao snapshotDao;
     @Inject
     private CommandCoordinatorUtil commandCoordinatorUtil;
+    @Inject
+    protected SnapshotsValidator snapshotsValidator;
 
     /**
      * Constructor for command creation when compensation is applied on startup
@@ -228,6 +231,12 @@ public class HibernateVmCommand<T extends VmOperationParameterBase> extends VmOp
         }
 
         if (!validate(vmValidator.vmNotHavingNvdimmDevices())) {
+            return false;
+        }
+
+        // we block hibernating a vm in preview mode because there is a bug that
+        // would result in keeping the hibernation metadata volume
+        if (!validate(snapshotsValidator.vmNotInPreview(getVm().getId()))) {
             return false;
         }
 

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/RunVmCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/RunVmCommand.java
@@ -210,12 +210,7 @@ public class RunVmCommand<T extends RunVmParams> extends RunVmCommandBase<T>
     protected boolean shouldRestoreMemory() {
         // If the memory from the snapshot could have been restored already, the disks might be
         // non coherent with the memory, thus we don't want to try to restore the memory again
-        return !memoryFromSnapshotUsed &&
-                (getFlow() == RunVmFlow.RESUME_HIBERNATE ||
-                FeatureSupported.isMemorySnapshotSupportedByArchitecture(
-                getVm().getClusterArch(),
-                getVm().getCompatibilityVersion())) &&
-                getActiveSnapshot().containsMemory();
+        return !memoryFromSnapshotUsed && getActiveSnapshot().containsMemory();
     }
 
     /**

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/snapshots/CreateLiveSnapshotForVmCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/snapshots/CreateLiveSnapshotForVmCommand.java
@@ -84,7 +84,7 @@ public class CreateLiveSnapshotForVmCommand<T extends CreateSnapshotForVmParamet
         List<Disk> pluggedDisksForVm = diskDao.getAllForVm(getVm().getId(), true);
         List<DiskImage> filteredPluggedDisksForVm = DisksFilter.filterImageDisks(pluggedDisksForVm,
                 ONLY_SNAPABLE, ONLY_ACTIVE);
-        boolean memoryDump = getParameters().isMemorySnapshotSupported() && snapshot.containsMemory();
+        boolean memoryDump = snapshot.containsMemory();
 
         // 'filteredPluggedDisks' should contain only disks from 'getDisksList()' that are plugged to the VM.
         List<DiskImage> filteredPluggedDisks = ImagesHandler.imagesIntersection(filteredPluggedDisksForVm, getParameters().getCachedSelectedActiveDisks());

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/snapshots/SnapshotsManager.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/snapshots/SnapshotsManager.java
@@ -38,9 +38,11 @@ import org.ovirt.engine.core.common.businessentities.Snapshot;
 import org.ovirt.engine.core.common.businessentities.Snapshot.SnapshotStatus;
 import org.ovirt.engine.core.common.businessentities.Snapshot.SnapshotType;
 import org.ovirt.engine.core.common.businessentities.VM;
+import org.ovirt.engine.core.common.businessentities.VMStatus;
 import org.ovirt.engine.core.common.businessentities.VmDevice;
 import org.ovirt.engine.core.common.businessentities.VmDeviceGeneralType;
 import org.ovirt.engine.core.common.businessentities.VmDeviceId;
+import org.ovirt.engine.core.common.businessentities.VmDynamic;
 import org.ovirt.engine.core.common.businessentities.VmStatic;
 import org.ovirt.engine.core.common.businessentities.VmTemplate;
 import org.ovirt.engine.core.common.businessentities.aaa.DbUser;
@@ -455,7 +457,9 @@ public class SnapshotsManager {
         }
 
         vm.setAppList(snapshot.getAppList());
-        vmDynamicDao.update(vm.getDynamicData());
+        VmDynamic vmDynamic = vm.getDynamicData();
+        vmDynamic.setStatus(withMemory ? VMStatus.Suspended : VMStatus.Down);
+        vmDynamicDao.update(vmDynamic);
 
         List<DiskImage> imagesToExclude = diskImageDao.getAttachedDiskSnapshotsToVm(vm.getId(), Boolean.TRUE);
 

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/snapshots/TryBackToAllSnapshotsOfVmCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/snapshots/TryBackToAllSnapshotsOfVmCommand.java
@@ -218,7 +218,7 @@ public class TryBackToAllSnapshotsOfVmCommand<T extends TryBackToAllSnapshotsOfV
                 getCompensationContext(),
                 getCurrentUser(),
                 new VmInterfaceManager(getMacPool()),
-                isRestoreMemory());
+                getParameters().isRestoreMemory());
 
         // custom preview - without leases
         if (!getParameters().isRestoreLease()) {
@@ -242,7 +242,7 @@ public class TryBackToAllSnapshotsOfVmCommand<T extends TryBackToAllSnapshotsOfV
 
     @Override
     protected void executeVmCommand() {
-        final boolean restoreMemory = isRestoreMemory();
+        final boolean restoreMemory = getParameters().isRestoreMemory();
 
         final Guid newActiveSnapshotId = Guid.newGuid();
         final Snapshot snapshotToBePreviewed = getDstSnapshot();
@@ -431,13 +431,9 @@ public class TryBackToAllSnapshotsOfVmCommand<T extends TryBackToAllSnapshotsOfV
         return dstLeaseDomainId != null ? LeaseAction.CREATE_NEW_LEASE : LeaseAction.DO_NOTHING;
     }
 
-    private boolean isRestoreMemory() {
-        return getParameters().isRestoreMemory();
-    }
-
     private boolean updateClusterCompatibilityVersionToOldCluster(boolean disableLock) {
         Version oldClusterVersion = getVm().getClusterCompatibilityVersionOrigin();
-        if (isRestoreMemory() && getVm().getCustomCompatibilityVersion() == null &&
+        if (getParameters().isRestoreMemory() && getVm().getCustomCompatibilityVersion() == null &&
                 oldClusterVersion.less(getVm().getClusterCompatibilityVersion())) {
             // the snapshot was taken before cluster version change, call the UpdateVmCommand
 
@@ -636,7 +632,7 @@ public class TryBackToAllSnapshotsOfVmCommand<T extends TryBackToAllSnapshotsOfV
             return false;
         }
 
-        if (isRestoreMemory() && !validateMemoryTakenInSupportedVersion()) {
+        if (getParameters().isRestoreMemory() && !validateMemoryTakenInSupportedVersion()) {
             return false;
         }
 

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/snapshots/TryBackToAllSnapshotsOfVmCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/snapshots/TryBackToAllSnapshotsOfVmCommand.java
@@ -39,7 +39,6 @@ import org.ovirt.engine.core.bll.validator.storage.DiskSnapshotsValidator;
 import org.ovirt.engine.core.bll.validator.storage.MultipleStorageDomainsValidator;
 import org.ovirt.engine.core.bll.validator.storage.StoragePoolValidator;
 import org.ovirt.engine.core.common.AuditLogType;
-import org.ovirt.engine.core.common.FeatureSupported;
 import org.ovirt.engine.core.common.VdcObjectType;
 import org.ovirt.engine.core.common.action.ActionReturnValue;
 import org.ovirt.engine.core.common.action.ActionType;
@@ -433,9 +432,7 @@ public class TryBackToAllSnapshotsOfVmCommand<T extends TryBackToAllSnapshotsOfV
     }
 
     private boolean isRestoreMemory() {
-        return getParameters().isRestoreMemory() &&
-                FeatureSupported.isMemorySnapshotSupportedByArchitecture(
-                        getVm().getClusterArch(), getVm().getCompatibilityVersion());
+        return getParameters().isRestoreMemory();
     }
 
     private boolean updateClusterCompatibilityVersionToOldCluster(boolean disableLock) {

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/ActionUtils.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/ActionUtils.java
@@ -157,7 +157,7 @@ public final class ActionUtils {
                 EnumSet.of(ActionType.HibernateVm, ActionType.RunVm,
                         ActionType.RunVmOnce, ActionType.AddVmTemplate, ActionType.RemoveVm,
                         ActionType.ExportVm, ActionType.ImportVm, ActionType.ChangeDisk,
-                        ActionType.AddVmInterface, ActionType.UpdateVmInterface,
+                        ActionType.AddVmInterface, ActionType.UpdateVmInterface, ActionType.RestoreAllSnapshots,
                         ActionType.RemoveVmInterface, ActionType.MigrateVm, ActionType.CancelMigrateVm,
                         ActionType.ExtendImageSize, ActionType.RebootVm, ActionType.ResetVm));
         vmMatrix.put(
@@ -173,7 +173,7 @@ public final class ActionUtils {
                         ActionType.AddVmTemplate, ActionType.RemoveVm, ActionType.MigrateVm,
                         ActionType.ExportVm, ActionType.ImportVm,
                         ActionType.ChangeDisk, ActionType.AddVmInterface,
-                        ActionType.UpdateVmInterface,
+                        ActionType.UpdateVmInterface, ActionType.RestoreAllSnapshots,
                         ActionType.RemoveVmInterface, ActionType.CancelMigrateVm,
                         ActionType.ExtendImageSize, ActionType.RebootVm, ActionType.ResetVm));
         vmMatrix.put(
@@ -181,7 +181,7 @@ public final class ActionUtils {
                 EnumSet.of(ActionType.HibernateVm, ActionType.RunVm,
                         ActionType.RunVmOnce, ActionType.AddVmTemplate, ActionType.RemoveVm,
                         ActionType.ExportVm, ActionType.ImportVm, ActionType.ChangeDisk,
-                        ActionType.AddVmInterface, ActionType.UpdateVmInterface,
+                        ActionType.AddVmInterface, ActionType.UpdateVmInterface, ActionType.RestoreAllSnapshots,
                         ActionType.RemoveVmInterface, ActionType.CancelMigrateVm,
                         ActionType.ExtendImageSize));
         vmMatrix.put(
@@ -189,7 +189,7 @@ public final class ActionUtils {
                 EnumSet.of(ActionType.HibernateVm, ActionType.RunVm,
                         ActionType.RunVmOnce, ActionType.AddVmTemplate, ActionType.RemoveVm,
                         ActionType.ExportVm, ActionType.ImportVm, ActionType.ChangeDisk,
-                        ActionType.AddVmInterface, ActionType.UpdateVmInterface,
+                        ActionType.AddVmInterface, ActionType.UpdateVmInterface, ActionType.RestoreAllSnapshots,
                         ActionType.RemoveVmInterface, ActionType.CancelMigrateVm,
                         ActionType.ExtendImageSize, ActionType.RebootVm));
         vmMatrix.put(
@@ -198,7 +198,7 @@ public final class ActionUtils {
                         ActionType.RunVmOnce, ActionType.AddVmTemplate, ActionType.RemoveVm,
                         ActionType.HibernateVm, ActionType.MigrateVm, ActionType.ExportVm,
                         ActionType.ImportVm, ActionType.ChangeDisk,
-                        ActionType.AddVmInterface, ActionType.UpdateVmInterface,
+                        ActionType.AddVmInterface, ActionType.UpdateVmInterface, ActionType.RestoreAllSnapshots,
                         ActionType.RemoveVmInterface, ActionType.CreateSnapshotForVm,
                         ActionType.ExtendImageSize, ActionType.RebootVm, ActionType.ResetVm));
         vmMatrix.put(
@@ -214,7 +214,7 @@ public final class ActionUtils {
                 EnumSet.of(ActionType.RemoveVm, ActionType.HibernateVm,
                         ActionType.AddVmTemplate, ActionType.RunVmOnce, ActionType.ExportVm,
                         ActionType.ImportVm, ActionType.ExtendImageSize,
-                        ActionType.AddVmInterface, ActionType.UpdateVmInterface,
+                        ActionType.AddVmInterface, ActionType.UpdateVmInterface, ActionType.RestoreAllSnapshots,
                         ActionType.RemoveVmInterface, ActionType.CancelMigrateVm,
                         ActionType.RebootVm, ActionType.ResetVm));
         vmMatrix.put(
@@ -224,7 +224,7 @@ public final class ActionUtils {
                         ActionType.HibernateVm, ActionType.MigrateVm, ActionType.RemoveVm,
                         ActionType.AddVmTemplate, ActionType.ExportVm,
                         ActionType.ImportVm, ActionType.ChangeDisk,
-                        ActionType.AddVmInterface, ActionType.UpdateVmInterface,
+                        ActionType.AddVmInterface, ActionType.UpdateVmInterface, ActionType.RestoreAllSnapshots,
                         ActionType.RemoveVmInterface, ActionType.CancelMigrateVm,
                         ActionType.ExtendImageSize, ActionType.RebootVm, ActionType.ResetVm));
         vmMatrix.put(
@@ -234,7 +234,7 @@ public final class ActionUtils {
                         ActionType.HibernateVm, ActionType.MigrateVm, ActionType.RemoveVm,
                         ActionType.AddVmTemplate, ActionType.ExportVm,
                         ActionType.ImportVm, ActionType.ChangeDisk,
-                        ActionType.AddVmInterface, ActionType.UpdateVmInterface,
+                        ActionType.AddVmInterface, ActionType.UpdateVmInterface, ActionType.RestoreAllSnapshots,
                         ActionType.RemoveVmInterface, ActionType.CancelMigrateVm, ActionType.ExtendImageSize,
                         ActionType.RebootVm, ActionType.ResetVm));
 
@@ -257,6 +257,7 @@ public final class ActionUtils {
                         ActionType.ChangeDisk,
                         ActionType.AddVmInterface,
                         ActionType.UpdateVmInterface,
+                        ActionType.RestoreAllSnapshots,
                         ActionType.CreateSnapshotForVm,
                         ActionType.RemoveVmInterface,
                         ActionType.CancelMigrateVm,
@@ -271,7 +272,7 @@ public final class ActionUtils {
                         ActionType.HibernateVm, ActionType.MigrateVm, ActionType.RemoveVm,
                         ActionType.AddVmTemplate, ActionType.ExportVm,
                         ActionType.ImportVm, ActionType.ChangeDisk, ActionType.CreateSnapshotForVm,
-                        ActionType.AddVmInterface, ActionType.UpdateVmInterface,
+                        ActionType.AddVmInterface, ActionType.UpdateVmInterface, ActionType.RestoreAllSnapshots,
                         ActionType.RemoveVmInterface, ActionType.CancelMigrateVm, ActionType.ExtendImageSize,
                         ActionType.RebootVm, ActionType.ResetVm));
         vmMatrix.put(
@@ -280,7 +281,7 @@ public final class ActionUtils {
                         ActionType.RunVmOnce, ActionType.HibernateVm, ActionType.MigrateVm,
                         ActionType.RemoveVm, ActionType.AddVmTemplate, ActionType.ExportVm,
                         ActionType.ImportVm, ActionType.ChangeDisk, ActionType.CreateSnapshotForVm,
-                        ActionType.AddVmInterface, ActionType.UpdateVmInterface,
+                        ActionType.AddVmInterface, ActionType.UpdateVmInterface, ActionType.RestoreAllSnapshots,
                         ActionType.RemoveVmInterface, ActionType.CancelMigrateVm, ActionType.ExtendImageSize,
                         ActionType.RebootVm, ActionType.ResetVm));
 
@@ -291,7 +292,7 @@ public final class ActionUtils {
                         ActionType.HibernateVm, ActionType.MigrateVm, ActionType.RemoveVm,
                         ActionType.AddVmTemplate, ActionType.ExportVm,
                         ActionType.ImportVm, ActionType.ChangeDisk, ActionType.CreateSnapshotForVm,
-                        ActionType.AddVmInterface, ActionType.UpdateVmInterface,
+                        ActionType.AddVmInterface, ActionType.UpdateVmInterface, ActionType.RestoreAllSnapshots,
                         ActionType.RemoveVmInterface, ActionType.CancelMigrateVm, ActionType.ExtendImageSize,
                         ActionType.RebootVm, ActionType.ResetVm));
         vmMatrix.put(

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/FeatureSupported.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/FeatureSupported.java
@@ -96,18 +96,6 @@ public class FeatureSupported {
     }
 
     /**
-     * Checks if memory snapshot is supported by architecture
-     *
-     * @param architecture
-     *            The CPU architecture
-     * @param version
-     *            Compatibility version to check for.
-     */
-    public static boolean isMemorySnapshotSupportedByArchitecture(ArchitectureType architecture, Version version) {
-        return supportedInConfig(ConfigValues.IsMemorySnapshotSupported, version, architecture);
-    }
-
-    /**
      * Checks if suspend is supported by architecture
      *
      * @param architecture

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/CreateSnapshotForVmParameters.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/CreateSnapshotForVmParameters.java
@@ -60,6 +60,7 @@ public class CreateSnapshotForVmParameters extends VmOperationParameterBase impl
 
     private List<DiskImage> cachedSelectedActiveDisks;
 
+    @Deprecated
     private boolean memorySnapshotSupported;
 
     private boolean parentLiveMigrateDisk;

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/config/ConfigValues.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/config/ConfigValues.java
@@ -1191,9 +1191,6 @@ public enum ConfigValues {
     ScsiReservationSupported,
 
     @TypeConverterAttribute(Map.class)
-    IsMemorySnapshotSupported,
-
-    @TypeConverterAttribute(Map.class)
     IsSuspendSupported,
 
     @TypeConverterAttribute(SerialNumberPolicy.class)

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/queries/ArchCapabilitiesParameters.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/queries/ArchCapabilitiesParameters.java
@@ -20,7 +20,6 @@ public class ArchCapabilitiesParameters extends QueryParametersBase {
 
     public enum ArchCapabilitiesVerb {
         GetMigrationSupport,
-        GetMemorySnapshotSupport,
         GetSuspendSupport,
         GetMemoryHotUnplugSupport,
         GetTpmDeviceSupport

--- a/frontend/webadmin/modules/gwt-common/src/main/java/org/ovirt/engine/ui/common/widget/uicommon/popup/vm/VmSnapshotCreatePopupWidget.java
+++ b/frontend/webadmin/modules/gwt-common/src/main/java/org/ovirt/engine/ui/common/widget/uicommon/popup/vm/VmSnapshotCreatePopupWidget.java
@@ -19,7 +19,6 @@ import org.ovirt.engine.ui.common.widget.editor.generic.EntityModelCheckBoxEdito
 import org.ovirt.engine.ui.common.widget.editor.generic.StringEntityModelTextBoxEditor;
 import org.ovirt.engine.ui.common.widget.table.column.AbstractTextColumn;
 import org.ovirt.engine.ui.common.widget.uicommon.popup.AbstractModelBoundPopupWidget;
-import org.ovirt.engine.ui.uicommonweb.dataprovider.AsyncDataProvider;
 import org.ovirt.engine.ui.uicommonweb.models.ListModel;
 import org.ovirt.engine.ui.uicommonweb.models.vms.SnapshotModel;
 import org.ovirt.engine.ui.uicompat.Event;
@@ -134,9 +133,7 @@ public class VmSnapshotCreatePopupWidget extends AbstractModelBoundPopupWidget<S
                     return;
                 }
 
-                boolean memorySnapshotSupported =
-                        AsyncDataProvider.getInstance().isMemorySnapshotSupported(vm);
-                memoryEditor.setVisible(memorySnapshotSupported && vm.isRunning());
+                memoryEditor.setVisible(vm.isRunning());
                 // The memory option is enabled by default, so in case its checkbox
                 // is not visible, we should disable it explicitly
                 if (!memoryEditor.isVisible()) {

--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/dataprovider/AsyncDataProvider.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/dataprovider/AsyncDataProvider.java
@@ -291,9 +291,6 @@ public class AsyncDataProvider {
     // cached architecture support for live migration
     private Map<ArchitectureType, Map<Version, Boolean>> migrationSupport;
 
-    // cached architecture support for memory snapshot
-    private Map<ArchitectureType, Map<Version, Boolean>> memorySnapshotSupport;
-
     // cached architecture support for memory hot unplug
     private Map<ArchitectureType, Map<Version, Boolean>> memoryHotUnplugSupport;
 
@@ -348,7 +345,6 @@ public class AsyncDataProvider {
         initDefaultOSes();
         initGet64BitOss();
         initMigrationSupportMap();
-        initMemorySnapshotSupportMap();
         initMemoryHotUnplugSupportMap();
         initTpmDeviceSupportMap();
         initCustomPropertiesList();
@@ -477,10 +473,6 @@ public class AsyncDataProvider {
         return migrationSupport.get(architecture).get(version);
     }
 
-    public Boolean isMemorySnapshotSupportedByArchitecture(ArchitectureType architecture, Version version) {
-        return memorySnapshotSupport.get(architecture).get(version);
-    }
-
     public Boolean isMemoryHotUnplugSupportedByArchitecture(ArchitectureType architecture, Version version) {
         return memoryHotUnplugSupport.get(architecture).get(version);
     }
@@ -511,12 +503,6 @@ public class AsyncDataProvider {
                 new AsyncQuery<QueryReturnValue>(returnValue -> migrationSupport = returnValue.getReturnValue()));
     }
 
-    private void initMemorySnapshotSupportMap() {
-        Frontend.getInstance().runQuery(QueryType.GetArchitectureCapabilities,
-                new ArchCapabilitiesParameters(ArchCapabilitiesVerb.GetMemorySnapshotSupport),
-                new AsyncQuery<QueryReturnValue>(returnValue -> memorySnapshotSupport = returnValue.getReturnValue()));
-    }
-
     private void initMemoryHotUnplugSupportMap() {
         Frontend.getInstance().runQuery(QueryType.GetArchitectureCapabilities,
                 new ArchCapabilitiesParameters(ArchCapabilitiesVerb.GetMemoryHotUnplugSupport),
@@ -527,19 +513,6 @@ public class AsyncDataProvider {
         Frontend.getInstance().runQuery(QueryType.GetArchitectureCapabilities,
                 new ArchCapabilitiesParameters(ArchCapabilitiesVerb.GetTpmDeviceSupport),
                 new AsyncQuery<QueryReturnValue>(returnValue -> tpmDeviceSupport = returnValue.getReturnValue()));
-    }
-
-    /**
-     * Check if memory snapshot is supported
-     */
-    public boolean isMemorySnapshotSupported(VM vm) {
-        if (vm == null) {
-            return false;
-        }
-
-        return isMemorySnapshotSupportedByArchitecture(
-                vm.getClusterArch(),
-                vm.getCompatibilityVersion());
     }
 
     public void initNicHotplugSupportMap() {

--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/VmSnapshotListModel.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/VmSnapshotListModel.java
@@ -842,6 +842,7 @@ public class VmSnapshotListModel extends SearchableListModel<VM, Snapshot> {
         List<VM> vmList = vm != null ? Collections.singletonList(vm) : Collections.emptyList();
 
         boolean isVmDown = vm != null && vm.getStatus() == VMStatus.Down;
+        boolean isVmDownOrSuspended = vm != null && vm.getStatus() == VMStatus.Down || vm.getStatus() == VMStatus.Suspended;
         boolean isVmImageLocked = vm != null && vm.getStatus() == VMStatus.ImageLocked;
         boolean isVmQualifiedForSnapshotMerge = vm != null && vm.getStatus().isQualifiedForSnapshotMerge();
         boolean isPreviewing = getItems().stream().anyMatch(s -> s.getStatus() == SnapshotStatus.IN_PREVIEW);
@@ -856,8 +857,8 @@ public class VmSnapshotListModel extends SearchableListModel<VM, Snapshot> {
         getNewCommand().setIsExecutionAllowed(!isPreviewing && !isLocked && !isVmImageLocked && !isStateless && isManaged);
         getPreviewCommand().setIsExecutionAllowed(isSelected && !isLocked && !isPreviewing && isVmDown && !isStateless);
         getCustomPreviewCommand().setIsExecutionAllowed(getPreviewCommand().getIsExecutionAllowed());
-        getCommitCommand().setIsExecutionAllowed(isPreviewing && isVmDown && !isStateless);
-        getUndoCommand().setIsExecutionAllowed(isPreviewing && isVmDown && !isStateless);
+        getCommitCommand().setIsExecutionAllowed(isPreviewing && isVmDownOrSuspended && !isStateless);
+        getUndoCommand().setIsExecutionAllowed(isPreviewing && isVmDownOrSuspended && !isStateless);
         getRemoveCommand().setIsExecutionAllowed(isSelected && !isLocked && !isPreviewing && !isStateless
                 && isVmQualifiedForSnapshotMerge);
         getCloneVmCommand().setIsExecutionAllowed(isSelected && !isLocked && !isPreviewing

--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/VmSnapshotListModel.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/VmSnapshotListModel.java
@@ -165,19 +165,6 @@ public class VmSnapshotListModel extends SearchableListModel<VM, Snapshot> {
         onPropertyChanged(new PropertyChangedEventArgs("SnapshotsMap")); //$NON-NLS-1$
     }
 
-    private boolean memorySnapshotSupported;
-
-    public boolean isMemorySnapshotSupported() {
-        return memorySnapshotSupported;
-    }
-
-    private void setMemorySnapshotSupported(boolean value) {
-        if (memorySnapshotSupported != value) {
-            memorySnapshotSupported = value;
-            onPropertyChanged(new PropertyChangedEventArgs("IsMemorySnapshotSupported")); //$NON-NLS-1$
-        }
-    }
-
     private List<DiskImage> vmDisks;
 
     public List<DiskImage> getVmDisks() {
@@ -248,7 +235,6 @@ public class VmSnapshotListModel extends SearchableListModel<VM, Snapshot> {
 
     @Override
     public void setEntity(VM value) {
-        updateIsMemorySnapshotSupported(value);
         super.setEntity(value);
         updateVmActiveDisks();
     }
@@ -390,7 +376,7 @@ public class VmSnapshotListModel extends SearchableListModel<VM, Snapshot> {
             ArrayList<DiskImage> snapshotDisks = v.getDiskList();
             List<DiskImage> disksExcludedFromSnapshot = imagesSubtract(getVmDisks(), snapshotDisks);
 
-            boolean showMemorySnapshotWarning = isMemorySnapshotSupported() && snapshot.containsMemory();
+            boolean showMemorySnapshotWarning = snapshot.containsMemory();
             boolean showPartialSnapshotWarning = !disksExcludedFromSnapshot.isEmpty();
 
             if (showMemorySnapshotWarning || showPartialSnapshotWarning) {
@@ -880,15 +866,6 @@ public class VmSnapshotListModel extends SearchableListModel<VM, Snapshot> {
                 && !isVmImageLocked && !isStateless && !isVmConfigurationBroken);
     }
 
-    private void updateIsMemorySnapshotSupported(Object entity) {
-        if (entity == null) {
-            return;
-        }
-
-        VM vm = (VM) entity;
-
-        setMemorySnapshotSupported(AsyncDataProvider.getInstance().isMemorySnapshotSupported(vm));
-    }
 
     @Override
     public void executeCommand(UICommand command) {

--- a/packaging/dbscripts/upgrade/04_05_0300_remove_vdc_option_IsMemorySnapshotSupported.sql
+++ b/packaging/dbscripts/upgrade/04_05_0300_remove_vdc_option_IsMemorySnapshotSupported.sql
@@ -1,0 +1,1 @@
+SELECT fn_db_delete_config_value_all_versions('IsMemorySnapshotSupported');


### PR DESCRIPTION
If the VMs are set to restore memory, we would now set them to
Suspended status so they'll be treated as VMs that were hibernated
(e.g., create next-run snapshots when their configuration changes)

Bug-Url: https://bugzilla.redhat.com/1257644