### PR TITLE
core: set correct policy when reseting cpu pinning string

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ImportVmCommandBase.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ImportVmCommandBase.java
@@ -44,6 +44,7 @@ import org.ovirt.engine.core.common.action.LockProperties.Scope;
 import org.ovirt.engine.core.common.businessentities.ActionGroup;
 import org.ovirt.engine.core.common.businessentities.ArchitectureType;
 import org.ovirt.engine.core.common.businessentities.Cluster;
+import org.ovirt.engine.core.common.businessentities.CpuPinningPolicy;
 import org.ovirt.engine.core.common.businessentities.GraphicsType;
 import org.ovirt.engine.core.common.businessentities.Permission;
 import org.ovirt.engine.core.common.businessentities.StorageDomain;
@@ -614,7 +615,10 @@ public abstract class ImportVmCommandBase<T extends ImportVmParameters> extends 
         // if "run on host" field points to a non existent vds (in the current cluster) -> remove field and continue
         if (!vmHandler.validateDedicatedVdsExistOnSameCluster(getVm().getStaticData()).isValid()) {
             getVm().setDedicatedVmForVdsList(Collections.emptyList());
-            getVm().setCpuPinning(null);
+            if (!StringUtils.isBlank(getVm().getCpuPinning())) {
+                getVm().setCpuPinning(null);
+                getVm().setCpuPinningPolicy(CpuPinningPolicy.NONE);
+            }
         }
 
         if (getVm().getOriginalTemplateGuid() != null && !VmTemplateHandler.BLANK_VM_TEMPLATE_ID.equals(getVm().getOriginalTemplateGuid())) {


### PR DESCRIPTION
When we are importing a VM that is pinned to a host, and the host is not present in the cluster where the VM should be imported, the host pinning is cleared as well as the cpu pinning string. However, the cpu pinning policy was not updated and remained MANUAL causing the import to fail when inserting the VM into the database. 

This patch updates the cpu pinning policy to NONE when cpu pinning string is cleared during import.

Bug-Url: https://bugzilla.redhat.com/2104115