### PR TITLE
fix snapshot removal when image already merged

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/snapshots/ColdMergeSnapshotSingleDiskCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/snapshots/ColdMergeSnapshotSingleDiskCommand.java
@@ -52,7 +52,7 @@ public class ColdMergeSnapshotSingleDiskCommand<T extends RemoveSnapshotSingleDi
         // Let doPolling() drive the execution; we don't have any guarantee that
         // executeCommand() will finish before doPolling() is called, and we don't
         // want to possibly run the first command twice.
-        getParameters().setCommandStep(RemoveSnapshotSingleDiskStep.PREPARE_MERGE);
+        getParameters().setCommandStep(getInitialMergeStepForImage());
         getParameters().setChildCommands(new HashMap<>());
         setSucceeded(true);
     }
@@ -111,6 +111,14 @@ public class ColdMergeSnapshotSingleDiskCommand<T extends RemoveSnapshotSingleDi
         } else {
             return false;
         }
+    }
+
+    private RemoveSnapshotSingleDiskStep getInitialMergeStepForImage() {
+        if (getImageInfoFromVdsm(getDestinationDiskImage()) == null) {
+            log.info("Image does not exist, attempting to synchronize the database");
+            return RemoveSnapshotSingleDiskStep.COMPLETE;
+        }
+        return RemoveSnapshotSingleDiskStep.PREPARE_MERGE;
     }
 
     @Override

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/snapshots/RemoveSnapshotSingleDiskLiveCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/snapshots/RemoveSnapshotSingleDiskLiveCommand.java
@@ -182,6 +182,13 @@ public class RemoveSnapshotSingleDiskLiveCommand<T extends RemoveSnapshotSingleD
                 return RemoveSnapshotSingleDiskStep.DESTROY_IMAGE;
             }
         }
+        if (getImageInfoFromVdsm(getDestinationDiskImage()) == null) {
+            log.info("Image does not exist, attempting to synchronize the database");
+            Set<Guid> imagesToRemove = new HashSet<>();
+            imagesToRemove.add(getDestinationDiskImage().getImageId());
+            getParameters().setMergeStatusReturnValue(new MergeStatusReturnValue(imagesToRemove));
+            return RemoveSnapshotSingleDiskStep.COMPLETE;
+        }
         return RemoveSnapshotSingleDiskStep.EXTEND;
     }
 


### PR DESCRIPTION
When trying to remove a snapshot which was already removed before
and image merged, but not removed from the DB for some reason -
the RemoveSnapshot command fails and the snapshot and images stay in
the DB and cannot be removed.

The reason for this is that during RemoveSnapshotSingleDiskLiveCommand
the DestroyImage command fails (since the image does not not exist),
thus the whole command fails, and the snapshot/image are not removed
from the DB.

In the ColdMerge case, the ColdMergeSnapshotSingleDiskCommand fails
already at the PrepareMerge stage.

In this change, for both Live and Cold merge - we first check that the
Destination image (or the Top Image) exists on storage with
GetVolumeInfo. If it does not, we conclude that it was already merged
and removed, and proceed to finishing the command successfully and
removing the snapshot and the image from the DB, skipping all the
steps.

Bug-Url: https://bugzilla.redhat.com/1948599