### PR TITLE
core: update cpuTopology on status changes

### DIFF
--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/VdsManager.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/VdsManager.java
@@ -207,7 +207,7 @@ public class VdsManager {
         handlePreviousStatus();
         handleSecureSetup();
         initVdsBroker();
-        initAvailableCpus();
+        updateCpuTopology();
     }
 
     public void handleSecureSetup() {
@@ -300,7 +300,7 @@ public class VdsManager {
                                 getVdsName(), getVdsId());
                         return;
                     }
-
+                    updateCpuTopology();
                     try {
                         updateIteration();
                         if (isMonitoringNeeded()) {
@@ -761,9 +761,11 @@ public class VdsManager {
                     this.cachedVds.setUsageMemPercent(0);
                     this.cachedVds.setUsageNetworkPercent(0);
                 }
+                updateCpuTopology();
                 break;
             case Up:
                 vds.setInFenceFlow(false);
+                updateCpuTopology();
                 break;
             default:
                 break;
@@ -1331,7 +1333,19 @@ public class VdsManager {
     }
 
 
-    private void initAvailableCpus() {
+    private void updateCpuTopology() {
+
+        if (!cpuTopology.isEmpty()) {
+            if (cachedVds.getDynamicData().getStatus() == VDSStatus.Maintenance) {
+                cpuTopology = new ArrayList<>();
+            }
+            return;
+        }
+
+        if (cachedVds.getDynamicData().getStatus() != VDSStatus.Up) {
+            return;
+        }
+
         List<VdsCpuUnit> cpuTopology = cachedVds.getCpuTopology();
         if (cpuTopology == null) {
             return;


### PR DESCRIPTION
Previously, once the CPU topology was initialized in the VdsManager, it was not possible to change it without
restarting the engine. There are 2 use cases:

1. When adding a new host, the manager is created, but no CPU topology has been reported yet. As a result, the host
would act as if it does not support exclusive pinning until the engine is restarted.
2. Changing the CPU topology of the host (not a common scenario, but happens during development when using hosts in a virtual machine).

This patch updates the CPU topology in the VmManager if the state of the host changes and the CPU topology has not been initialized yet.

Bug-Url: https://bugzilla.redhat.com/2104858