### PR TITLE
core: do not use double-brace initialization for parameter value

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/lsm/LiveMigrateDiskCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/lsm/LiveMigrateDiskCommand.java
@@ -235,9 +235,9 @@ public class LiveMigrateDiskCommand<T extends LiveMigrateDiskParameters> extends
                 DiskImage diskParams = new DiskImage();
 
                 diskParams.setInitialSizeInBytes(ImagesHandler.computeImageInitialSizeInBytes(disk.getImage()));
-                return new HashMap<>() {{
-                    put(disk.getId(), diskParams);
-                }};
+                Map<Guid, DiskImage> diskImagesMap = new HashMap<>();
+                diskImagesMap.put(disk.getId(), diskParams);
+                return diskImagesMap;
             }
         }
         return new HashMap<>();


### PR DESCRIPTION
Initializing a HashMap with double-brace create an inner class and the
value of diskImagesMap will be a HashMap wrapped in:
```
    org.ovirt.engine.core.bll.storage.lsm.LiveMigrateDiskCommand$1
```
Instead of just a HashMap, and LiveMigrateDiskCommand is not deserializable which will prevent ovirt-engine from starting when it tries to reload command_entities