### PR TITLE
core: Comment about VM affinity validation on migration

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/MaintenanceNumberOfVdssCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/MaintenanceNumberOfVdssCommand.java
@@ -553,6 +553,8 @@ public class MaintenanceNumberOfVdssCommand<T extends MaintenanceNumberOfVdssPar
             return true;
         }
 
+        // Only VM-to-VM hard affinity is checked here. Other affinity types, including VM-to-host hard affinity are
+        // probed by SchedulingManager.canSchedule() call in execution phase of the command.
         List<AffinityGroup> affinityGroups =
                 affinityGroupDao.getPositiveEnforcingAffinityGroupsByRunningVmsOnVdsId(vdsId);
         if (!affinityGroups.isEmpty()) {


### PR DESCRIPTION
Added a comment to MaintenanceNumberOfVdssCommand to avoid confusion
about VM affinity types checked in validation and execution phases of
the command.

Change-Id: I583f720ce1f82ca4f23541b987665cce4f0a11d9
Signed-off-by: Shmuel Melamud <smelamud@redhat.com>