### PR TITLE
webadmin: Fix template import

### DIFF
--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/ImportVmFromExportDomainModel.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/ImportVmFromExportDomainModel.java
@@ -82,7 +82,9 @@ public class ImportVmFromExportDomainModel extends ImportVmModel {
         }
         getClusterQuota().setIsAvailable(dataCenter.getQuotaEnforcementType() != QuotaEnforcementTypeEnum.DISABLED);
         getCluster().getSelectedItemChangedEvent().addListener(clusterChangedListener);
-        getCluster().getSelectedItemChangedEvent().addListener(vmImportGeneralModel);
+        if (vmImportGeneralModel != null) {
+            getCluster().getSelectedItemChangedEvent().addListener(vmImportGeneralModel);
+        }
         // get cluster
         getCluster().setItems(null);
         AsyncDataProvider.getInstance().getClusterByServiceList(new AsyncQuery<>(clusters -> {


### PR DESCRIPTION
The import of the template failed because one of the provided listeners on cluster changes was null. The listener was used to load OS into a list for the VM, however, it is not needed for the templates. This patch adds a check and
does not add the listener if it is null (as is the case for the templates).

Bug-Url: https://bugzilla.redhat.com/2104597