### PR TITLE
webadmin: Disable New on Networks tab for Blank

### DIFF
--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/templates/TemplateInterfaceListModel.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/templates/TemplateInterfaceListModel.java
@@ -142,7 +142,7 @@ public class TemplateInterfaceListModel extends SearchableListModel<VmTemplate, 
     }
 
     private void updateActionAvailability() {
-        getNewCommand().setIsExecutionAllowed(getEntity() != null);
+        getNewCommand().setIsExecutionAllowed(getEntity() != null && !getEntity().isBlank());
         getEditCommand().setIsExecutionAllowed(getSelectedItems() != null && getSelectedItems().size() == 1
                 && getSelectedItem() != null);
         getRemoveCommand().setIsExecutionAllowed(getSelectedItems() != null && getSelectedItems().size() > 0);


### PR DESCRIPTION
As the Blank template is not associated with any DC/Cluster, it's not possible to assign any network vNIC profile to it. Therefore, the New button should be disabled.

Bug-Url: https://bugzilla.redhat.com/2100444