### PR TITLE
engine: Fix incorrect value in audit log warning

### DIFF
--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/monitoring/HostMonitoring.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/monitoring/HostMonitoring.java
@@ -335,7 +335,7 @@ public class HostMonitoring implements HostMonitoringInterface {
         long memUsage = 100 - Math.round(100 * memFree / (double) memTotal);
 
         if (memUsage > maxUsedPercentageThreshold) {
-            logMemoryAuditLog(vds, cluster, stat, AuditLogType.VDS_HIGH_MEM_USE, maxUsedPercentageThreshold);
+            logMemoryAuditLog(vds, cluster, memUsage, AuditLogType.VDS_HIGH_MEM_USE, maxUsedPercentageThreshold);
         }
     }
 
@@ -346,6 +346,19 @@ public class HostMonitoring implements HostMonitoringInterface {
         if (stat.getMemFree() < maxUsedAbsoluteThreshold) {
             logMemoryAuditLog(vds, cluster, stat, AuditLogType.VDS_LOW_MEM, maxUsedAbsoluteThreshold);
         }
+    }
+
+    private void logMemoryAuditLog(VDS vds,
+            Cluster cluster,
+            Long memUsage,
+            AuditLogType valueToLog,
+            Integer threshold) {
+        AuditLogable logable = createAuditLogableForHost();
+        logable.addCustomValue("HostName", vds.getName());
+        logable.addCustomValue("Cluster", cluster.getName());
+        logable.addCustomValue("UsedMemory", memUsage.toString());
+        logable.addCustomValue("Threshold", threshold.toString());
+        auditLog(logable, valueToLog);
     }
 
     private void logMemoryAuditLog(VDS vds,


### PR DESCRIPTION
The memory usage number in VDS_HIGH_MEM_USE warning should be the usage of normal memory, not the total usage of normal memory and hugepages memory. This patch corrects the memory usage value in the audit log.

Bug-Url: https://bugzilla.redhat.com/2101503