### PR TITLE
build: post ovirt-engine-4.5.1

### DIFF
--- a/backend/manager/dependencies/common/pom.xml
+++ b/backend/manager/dependencies/common/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core.manager</groupId>
     <artifactId>dependencies</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>common-dependencies</artifactId>

--- a/backend/manager/dependencies/pom.xml
+++ b/backend/manager/dependencies/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>dependencies</artifactId>

--- a/backend/manager/dependencies/tools/pom.xml
+++ b/backend/manager/dependencies/tools/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core.manager</groupId>
     <artifactId>dependencies</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>tools-dependencies</artifactId>

--- a/backend/manager/extensions-tool/pom.xml
+++ b/backend/manager/extensions-tool/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>extensions-tool</artifactId>

--- a/backend/manager/logutils/pom.xml
+++ b/backend/manager/logutils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>logutils</artifactId>

--- a/backend/manager/modules/aaa/pom.xml
+++ b/backend/manager/modules/aaa/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>aaa</artifactId>

--- a/backend/manager/modules/auth-plugin/pom.xml
+++ b/backend/manager/modules/auth-plugin/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>auth-plugin</artifactId>

--- a/backend/manager/modules/bll/pom.xml
+++ b/backend/manager/modules/bll/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>bll</artifactId>

--- a/backend/manager/modules/branding/pom.xml
+++ b/backend/manager/modules/branding/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
   <artifactId>branding</artifactId>
   <packaging>jar</packaging>

--- a/backend/manager/modules/builtin-extensions/pom.xml
+++ b/backend/manager/modules/builtin-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
   <groupId>org.ovirt.engine.extension.aaa</groupId>
   <artifactId>builtin</artifactId>

--- a/backend/manager/modules/common/pom.xml
+++ b/backend/manager/modules/common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>common</artifactId>

--- a/backend/manager/modules/compat/pom.xml
+++ b/backend/manager/modules/compat/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>compat</artifactId>

--- a/backend/manager/modules/dal/pom.xml
+++ b/backend/manager/modules/dal/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
   <artifactId>dal</artifactId>
   <packaging>jar</packaging>

--- a/backend/manager/modules/docs/pom.xml
+++ b/backend/manager/modules/docs/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>docs</artifactId>

--- a/backend/manager/modules/enginesso/pom.xml
+++ b/backend/manager/modules/enginesso/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>manager-modules</artifactId>
         <groupId>org.ovirt.engine.core</groupId>
-        <version>4.5.1.3-SNAPSHOT</version>
+        <version>4.5.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/backend/manager/modules/extensions-manager/pom.xml
+++ b/backend/manager/modules/extensions-manager/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>extensions-manager</artifactId>

--- a/backend/manager/modules/logger/pom.xml
+++ b/backend/manager/modules/logger/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>logger</artifactId>

--- a/backend/manager/modules/microbenchmarks/pom.xml
+++ b/backend/manager/modules/microbenchmarks/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>benchmarks</artifactId>

--- a/backend/manager/modules/pom.xml
+++ b/backend/manager/modules/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>manager-modules</artifactId>

--- a/backend/manager/modules/restapi/apidoc/pom.xml
+++ b/backend/manager/modules/restapi/apidoc/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>restapi-apidoc</artifactId>

--- a/backend/manager/modules/restapi/interface/common/jaxrs/pom.xml
+++ b/backend/manager/modules/restapi/interface/common/jaxrs/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>common-parent</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>interface-common-jaxrs</artifactId>

--- a/backend/manager/modules/restapi/interface/common/pom.xml
+++ b/backend/manager/modules/restapi/interface/common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>interface</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>common-parent</artifactId>

--- a/backend/manager/modules/restapi/interface/definition/pom.xml
+++ b/backend/manager/modules/restapi/interface/definition/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>interface</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>restapi-definition</artifactId>

--- a/backend/manager/modules/restapi/interface/pom.xml
+++ b/backend/manager/modules/restapi/interface/pom.xml
@@ -5,7 +5,7 @@ ven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>interface</artifactId>

--- a/backend/manager/modules/restapi/jaxrs/pom.xml
+++ b/backend/manager/modules/restapi/jaxrs/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>restapi-jaxrs</artifactId>

--- a/backend/manager/modules/restapi/pom.xml
+++ b/backend/manager/modules/restapi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>restapi-parent</artifactId>

--- a/backend/manager/modules/restapi/types/pom.xml
+++ b/backend/manager/modules/restapi/types/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>restapi-types</artifactId>

--- a/backend/manager/modules/restapi/webapp/pom.xml
+++ b/backend/manager/modules/restapi/webapp/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>restapi-webapp</artifactId>

--- a/backend/manager/modules/root/pom.xml
+++ b/backend/manager/modules/root/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>root-war</artifactId>

--- a/backend/manager/modules/scheduler/pom.xml
+++ b/backend/manager/modules/scheduler/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>scheduler</artifactId>

--- a/backend/manager/modules/searchbackend/pom.xml
+++ b/backend/manager/modules/searchbackend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>searchbackend</artifactId>

--- a/backend/manager/modules/services/pom.xml
+++ b/backend/manager/modules/services/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>services</artifactId>

--- a/backend/manager/modules/utils/pom.xml
+++ b/backend/manager/modules/utils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>utils</artifactId>

--- a/backend/manager/modules/uutils/pom.xml
+++ b/backend/manager/modules/uutils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>uutils</artifactId>

--- a/backend/manager/modules/vdsbroker/pom.xml
+++ b/backend/manager/modules/vdsbroker/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>vdsbroker</artifactId>

--- a/backend/manager/modules/welcome/pom.xml
+++ b/backend/manager/modules/welcome/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>welcome</artifactId>

--- a/backend/manager/pom.xml
+++ b/backend/manager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>backend</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
   <artifactId>manager</artifactId>
   <packaging>pom</packaging>

--- a/backend/manager/sso-client-registration-tool/pom.xml
+++ b/backend/manager/sso-client-registration-tool/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>sso-client-registration-tool</artifactId>

--- a/backend/manager/tools/pom.xml
+++ b/backend/manager/tools/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>tools</artifactId>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>backend</artifactId>

--- a/build-tools-root/checkstyles/pom.xml
+++ b/build-tools-root/checkstyles/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>build-tools-root</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
   <artifactId>checkstyles</artifactId>
   <packaging>jar</packaging>

--- a/build-tools-root/ovirt-checkstyle-extension/pom.xml
+++ b/build-tools-root/ovirt-checkstyle-extension/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>build-tools-root</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
   <artifactId>ovirt-checkstyle-extension</artifactId>
   <name>oVirt Checkstyle Checks</name>

--- a/build-tools-root/ovirt-findbugs-filters/pom.xml
+++ b/build-tools-root/ovirt-findbugs-filters/pom.xml
@@ -14,7 +14,7 @@ SPDX-License-Identifier: Apache-2.0
 
   <groupId>org.ovirt.engine</groupId>
   <artifactId>ovirt-findbugs-filters</artifactId>
-  <version>4.5.1.3-SNAPSHOT</version>
+  <version>4.5.2-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>oVirt Findbugs Filters</name>

--- a/build-tools-root/pom.xml
+++ b/build-tools-root/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
   <artifactId>build-tools-root</artifactId>
   <packaging>pom</packaging>

--- a/ear/pom.xml
+++ b/ear/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>engine-server-ear</artifactId>

--- a/frontend/brands/ovirt-brand/pom.xml
+++ b/frontend/brands/ovirt-brand/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>brands-all</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>ovirt-brand</artifactId>

--- a/frontend/brands/pom.xml
+++ b/frontend/brands/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>frontend-all</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
   <artifactId>brands-all</artifactId>
   <packaging>pom</packaging>

--- a/frontend/pom.xml
+++ b/frontend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
   <artifactId>frontend-all</artifactId>
   <groupId>org.ovirt.engine.ui</groupId>

--- a/frontend/webadmin/modules/frontend-assemblies/pom.xml
+++ b/frontend/webadmin/modules/frontend-assemblies/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>webadmin-modules</artifactId>
     <groupId>org.ovirt.engine.ui</groupId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
   <artifactId>frontend-assemblies</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/frontend/pom.xml
+++ b/frontend/webadmin/modules/frontend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
   <artifactId>frontend</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/gwt-aop/pom.xml
+++ b/frontend/webadmin/modules/gwt-aop/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
   <artifactId>gwt-aop</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/gwt-common/pom.xml
+++ b/frontend/webadmin/modules/gwt-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
   <artifactId>gwt-common</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/gwt-extension/pom.xml
+++ b/frontend/webadmin/modules/gwt-extension/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
   <artifactId>gwt-extension</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/pom.xml
+++ b/frontend/webadmin/modules/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-all</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
   <artifactId>webadmin-modules</artifactId>
   <packaging>pom</packaging>

--- a/frontend/webadmin/modules/uicommonweb/pom.xml
+++ b/frontend/webadmin/modules/uicommonweb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.ovirt.engine.ui</groupId>
         <artifactId>webadmin-modules</artifactId>
-        <version>4.5.1.3-SNAPSHOT</version>
+        <version>4.5.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>uicommonweb</artifactId>

--- a/frontend/webadmin/modules/uicompat/pom.xml
+++ b/frontend/webadmin/modules/uicompat/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
   <artifactId>uicompat</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/webadmin/pom.xml
+++ b/frontend/webadmin/modules/webadmin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>webadmin-modules</artifactId>
     <groupId>org.ovirt.engine.ui</groupId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
   <artifactId>webadmin</artifactId>
   <packaging>war</packaging>

--- a/frontend/webadmin/pom.xml
+++ b/frontend/webadmin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>frontend-all</artifactId>
-    <version>4.5.1.3-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
   </parent>
   <artifactId>webadmin-all</artifactId>
   <packaging>pom</packaging>

--- a/mavenmake/pom.xml
+++ b/mavenmake/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.ovirt.engine</groupId>
         <artifactId>root</artifactId>
-        <version>4.5.1.3-SNAPSHOT</version>
+        <version>4.5.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>make</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.ovirt.engine</groupId>
   <artifactId>root</artifactId>
-  <version>4.5.1.3-SNAPSHOT</version>
+  <version>4.5.2-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>ovirt-root</name>
   <description>oVirt Engine Root Project</description>
@@ -773,7 +773,7 @@
             <dependency>
               <groupId>org.ovirt.engine</groupId>
               <artifactId>ovirt-findbugs-filters</artifactId>
-              <version>4.5.1.3-SNAPSHOT</version>
+              <version>4.5.2-SNAPSHOT</version>
             </dependency>
           </dependencies>
         </plugin>


### PR DESCRIPTION
Created by:

find . -name pom.xml -exec sed -i "s:4.5.1.3-SNAPSHOT:4.5.2-SNAPSHOT:" {} +

Should have been done right after branching 4.5.1.z. Since we didn't, we
have in copr only 4.5.1.3-1 from that branch, instead of newer builds
from master (which are 4.5.1.3-0.something).

Change-Id: I965622cce3954d302d2d16c5c606f338e2f86b75
Signed-off-by: Yedidyah Bar David <didi@redhat.com>