### PR TITLE
core: Ignore isValid() == false, if migration succeeded

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/MaintenanceVdsCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/MaintenanceVdsCommand.java
@@ -92,7 +92,7 @@ public class MaintenanceVdsCommand<T extends MaintenanceVdsParameters> extends V
 
             ActionReturnValue returnValue = migrateAllVms(getExecutionContext());
             setSucceeded(returnValue.getSucceeded());
-            if (!returnValue.isValid()) {
+            if (!returnValue.getSucceeded() && !returnValue.isValid()) {
                 getReturnValue().setValid(false);
                 getReturnValue().getValidationMessages().addAll(returnValue.getValidationMessages());
             }


### PR DESCRIPTION
In MaintenanceVdsCommand, if migrateAllVms() returned successful return
value, do not check isValid() and do not copy validation messages from
it.

Change-Id: I9c38423c88b7a4e8a84d6187835abe490278def5
Bug-Url: https://bugzilla.redhat.com/2108000
Signed-off-by: Shmuel Melamud <smelamud@redhat.com>