### PR TITLE
core: Set valid = true when creating a successful return value

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/MaintenanceVdsCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/MaintenanceVdsCommand.java
@@ -157,6 +157,7 @@ public class MaintenanceVdsCommand<T extends MaintenanceVdsParameters> extends V
     private ActionReturnValue migrateVms(List<VM> vms, ExecutionContext parentContext) {
         if (vms.isEmpty()) {
             ActionReturnValue returnValue = new ActionReturnValue();
+            returnValue.setValid(true);
             returnValue.setSucceeded(true);
             return returnValue;
         }


### PR DESCRIPTION
ActionReturnValue is created with 'valid' property set to false. If we
need to return a successful return value, we need to set both 'valid'
and 'succeeded' to true to avoid errors caused by inconsistency.

Change-Id: Idb5f5236c2280a2a133a67cb866b40cece21e3a1
Bug-Url: https://bugzilla.redhat.com/2108000
Signed-off-by: Shmuel Melamud <smelamud@redhat.com>