### PR TITLE
Do not allow hot plug CPU with exclusive pinning

### DIFF
--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/utils/VmCommonUtils.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/utils/VmCommonUtils.java
@@ -20,6 +20,11 @@ public class VmCommonUtils {
      * @return true, if any CPUs are to be hotplugged, false otherwise
      */
     public static boolean isCpusToBeHotpluggedOrUnplugged(VM source, VM destination) {
+        return cpuSocketsChanged(source, destination)
+                && !source.getCpuPinningPolicy().isExclusive();
+    }
+
+    private static boolean cpuSocketsChanged(VM source, VM destination) {
         return source.getCpuPerSocket() == destination.getCpuPerSocket()
                 && source.getNumOfSockets() != destination.getNumOfSockets()
                 && source.getThreadsPerCpu() == destination.getThreadsPerCpu();

--- a/frontend/webadmin/modules/uicompat/src/main/java/org/ovirt/engine/ui/uicompat/NextRunFieldMessages.java
+++ b/frontend/webadmin/modules/uicompat/src/main/java/org/ovirt/engine/ui/uicompat/NextRunFieldMessages.java
@@ -88,6 +88,8 @@ public interface NextRunFieldMessages extends ConstantsWithLookup {
 
     String vNumaNodeList();
 
+    String cpuPinningPolicy();
+
     // Devices
 
     String memballoon();

--- a/frontend/webadmin/modules/uicompat/src/main/resources/org/ovirt/engine/ui/uicompat/NextRunFieldMessages.properties
+++ b/frontend/webadmin/modules/uicompat/src/main/resources/org/ovirt/engine/ui/uicompat/NextRunFieldMessages.properties
@@ -41,6 +41,7 @@ kernelUrl=Kernel URL
 kernelParams=Kernel Parameters
 initrdUrl=Initrd Url
 vNumaNodeList=NUMA Nodes Configuration
+cpuPinningPolicy=CPU Pinning Policy
 # Devices - from VmManagementParametersBase with @EditableDeviceOnVmStatusField annotation
 memballoon=Memory Balloon
 watchdog=Watchdog


### PR DESCRIPTION
It is not possible to hot plug CPUs when using exclusive CPU pinning. Instead of failing on the backend, the CPU is now listed as "Changes that require Virtual Machine restart" instead of "Changes that can be applied immediately" in the "Pending Virtual Machine changes" dialog.

![image](https://user-images.githubusercontent.com/2078072/179974898-f541ce48-4caa-483c-8afe-8b8a81f7d087.png)

Bug-Url: https://bugzilla.redhat.com/2097717
Bug-Url: https://bugzilla.redhat.com/2111088
