### PR TITLE
core: Report names rather than ids in affinity conflicts

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/commands/AffinityGroupCRUDCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/commands/AffinityGroupCRUDCommand.java
@@ -47,6 +47,8 @@ public abstract class AffinityGroupCRUDCommand <T extends AffinityGroupCRUDParam
     private AffinityGroupDao affinityGroupDao;
     @Inject
     private LabelDao labelDao;
+    @Inject
+    private AffinityValidator affinityValidator;
 
     AffinityGroup affinityGroup = null;
 
@@ -179,7 +181,7 @@ public abstract class AffinityGroupCRUDCommand <T extends AffinityGroupCRUDParam
         affinityGroups.removeIf(g -> g.getId().equals(affinityGroupCopy.getId()));
         affinityGroups.add(affinityGroupCopy);
 
-        AffinityValidator.Result result = AffinityValidator.checkAffinityGroupConflicts(affinityGroups);
+        AffinityValidator.Result result = affinityValidator.checkAffinityGroupConflicts(affinityGroups);
         if (result.getValidationResult().isValid()) {
             result.getLoggingMethod().accept(this, auditLogDirector);
         }

--- a/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/scheduling/commands/AddAffinityGroupCommandTest.java
+++ b/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/scheduling/commands/AddAffinityGroupCommandTest.java
@@ -17,6 +17,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.ovirt.engine.core.bll.BaseCommandTest;
 import org.ovirt.engine.core.bll.ValidateTestUtils;
+import org.ovirt.engine.core.bll.validator.AffinityValidator;
 import org.ovirt.engine.core.common.AuditLogType;
 import org.ovirt.engine.core.common.businessentities.Cluster;
 import org.ovirt.engine.core.common.businessentities.Label;
@@ -49,6 +50,9 @@ public class AddAffinityGroupCommandTest extends BaseCommandTest {
     @Mock
     private VdsStaticDao vdsStaticDao;
 
+    @Mock
+    AffinityValidator affinityValidator;
+
     AffinityGroupCRUDParameters parameters = new AffinityGroupCRUDParameters(null, createAffinityGroup());
 
     @Spy
@@ -69,6 +73,8 @@ public class AddAffinityGroupCommandTest extends BaseCommandTest {
         Label vmLabel = new LabelBuilder().id(vmLabelId).build();
         Label hostLabel = new LabelBuilder().id(hostLabelId).build();
         doReturn(Arrays.asList(vmLabel, hostLabel)).when(labelDao).getAllByIds(any());
+
+        doReturn(AffinityValidator.Result.VALID).when(affinityValidator).checkAffinityGroupConflicts(any());
     }
 
     @Test

--- a/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/scheduling/commands/EditAffinityGroupCommandTest.java
+++ b/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/scheduling/commands/EditAffinityGroupCommandTest.java
@@ -18,6 +18,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.ovirt.engine.core.bll.BaseCommandTest;
 import org.ovirt.engine.core.bll.ValidateTestUtils;
+import org.ovirt.engine.core.bll.validator.AffinityValidator;
 import org.ovirt.engine.core.common.AuditLogType;
 import org.ovirt.engine.core.common.businessentities.Cluster;
 import org.ovirt.engine.core.common.businessentities.VmStatic;
@@ -45,6 +46,9 @@ public class EditAffinityGroupCommandTest extends BaseCommandTest {
     @Mock
     private VdsStaticDao vdsStaticDao;
 
+    @Mock
+    AffinityValidator affinityValidator;
+
     AffinityGroupCRUDParameters parameters = new AffinityGroupCRUDParameters(null, createAffinityGroup());
 
     @Spy
@@ -64,6 +68,7 @@ public class EditAffinityGroupCommandTest extends BaseCommandTest {
         vmStatic.setClusterId(clusterId);
         doReturn(Collections.singletonList(vmStatic)).when(vmStaticDao).getByIds(any());
         doReturn(clusterId).when(command).getClusterId();
+        doReturn(AffinityValidator.Result.VALID).when(affinityValidator).checkAffinityGroupConflicts(any());
     }
 
     @Test


### PR DESCRIPTION
When an affinity conflict occurs, the hosts or VMs participating in
the conflict are reported by their ids.  This is accurate but not very
user friendly, especially in the web UI dialog.  Let’s report the
conflicting entities by their names instead.

We must retrieve the names from the corresponding DAOs.  In theory,
AffinityGroup’s should contain entity names corresponding to the ids,
but this doesn’t hold and the names are often missing there.

Due to the DAO access, AffinityValidator.checkAffinityGroupConflicts
can no longer be static.  And because AffinityValidator is a
singleton, it cannot be used in tests as it is (AFAICT).  That means
we have to mock AffinityValidator.checkAffinityGroupConflicts in some
tests and give up on testing that method there.

Bug-Url: https://bugzilla.redhat.com/1991622