### PR TITLE
ci: Checkout the PR head, not the github merge commit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,6 +81,8 @@ jobs:
 
     - name: Checkout sources
       uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Setup maven cache
       uses: actions/cache@v2


### PR DESCRIPTION
In the CI github action, checkout the PR head commit instead of the
`actions/checkout@v2` default of the PR merge commit.  The practical
effect of this change is the exported artifacts snapshot suffix will
contain the commit id of the last commit on the PR instead of the
magic github generated merge commit.