### PR TITLE
restapi: Pass display type from VmPool.vm to AddVmPoolParameters

### DIFF
--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendVmPoolsResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendVmPoolsResource.java
@@ -118,6 +118,9 @@ public class BackendVmPoolsResource
         AddVmPoolParameters params = new AddVmPoolParameters(entity, vm, size);
         params.setConsoleEnabled(pool.isSetVm() && pool.getVm().isSetConsole() && pool.getVm().getConsole().isSetEnabled() ?
                 pool.getVm().getConsole().isEnabled() : !getConsoleDevicesForEntity(template.getId()).isEmpty());
+        if (pool.isSetVm()) {
+            DisplayHelper.setGraphicsToParams(pool.getVm().getDisplay(), params);
+        }
         params.setVirtioScsiEnabled(!VmHelper.getVirtioScsiControllersForEntity(this, template.getId()).isEmpty());
         params.setSoundDeviceEnabled(pool.isSetSoundcardEnabled() ? pool.isSoundcardEnabled() : !VmHelper.getSoundDevicesForEntity(this, template.getId()).isEmpty());
         params.setRngDevice(pool.isSetVm() && pool.getVm().isSetRngDevice() ?


### PR DESCRIPTION
Display type passed in VmPool.vm should be converted to a list of
graphic types and passed in parameters to AddVmPoolCommand.

Change-Id: I44303911c4228b66b3b8a081be774dd51188321e
Bug-Url: https://bugzilla.redhat.com/2106349
Signed-off-by: Shmuel Melamud <smelamud@redhat.com>