### PR TITLE
AnsibleRunner: reset lastEvent

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleRunnerClient.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleRunnerClient.java
@@ -121,6 +121,8 @@ public class AnsibleRunnerClient {
             BiConsumer<String, String> fn,
             String msg,
             Path logFile) {
+        // Reset of the lastEvent because of the callback singleton usage
+        lastEvent = "";
         String jobEvents = getJobEventsDir(playUuid);
         while(true){
             String event = getNextEvent(playUuid, lastEventId);


### PR DESCRIPTION
When the runner gets `LastEventId`: 0 and  `totalEvents`: 0. The client does not find any new events so we have `null` event and break the `while(true)`.
https://github.com/oVirt/ovirt-engine/blob/9336b4f87376a47c952545db405ed0b3cffd87ec/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleRunnerClient.java#L124-L128

The AnsibleCallback is using a singleton of the AnsibleRunnerClient because of this we get the previous run `lastEvent` which is not empty so we call getLastEventId`.
https://github.com/oVirt/ovirt-engine/blob/9336b4f87376a47c952545db405ed0b3cffd87ec/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleRunnerClient.java#L194

In the `getLastEventId` we get the return of the prefix index of the file which is the `lastEventId` and because it's from the previous run it overrides the current id.
https://github.com/oVirt/ovirt-engine/blob/9336b4f87376a47c952545db405ed0b3cffd87ec/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleRunnerClient.java#L111-L113