### PR TITLE
restapi: incorrect href for parent href

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/snapshots/GetDiskSnapshotByImageIdQuery.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/snapshots/GetDiskSnapshotByImageIdQuery.java
@@ -4,12 +4,17 @@ import javax.inject.Inject;
 
 import org.ovirt.engine.core.bll.QueriesCommandBase;
 import org.ovirt.engine.core.bll.context.EngineContext;
+import org.ovirt.engine.core.common.businessentities.storage.DiskImage;
 import org.ovirt.engine.core.common.queries.IdQueryParameters;
 import org.ovirt.engine.core.dao.DiskImageDao;
+import org.ovirt.engine.core.dao.ImageDao;
 
 public class GetDiskSnapshotByImageIdQuery<P extends IdQueryParameters> extends QueriesCommandBase<P> {
     @Inject
     private DiskImageDao diskImageDao;
+
+    @Inject
+    private ImageDao imageDao;
 
     public GetDiskSnapshotByImageIdQuery(P parameters, EngineContext engineContext) {
         super(parameters, engineContext);
@@ -17,6 +22,13 @@ public class GetDiskSnapshotByImageIdQuery<P extends IdQueryParameters> extends 
 
     @Override
     protected void executeQueryCommand() {
-        getQueryReturnValue().setReturnValue(diskImageDao.getSnapshotById(getParameters().getId()));
+        DiskImage diskImage = diskImageDao.getSnapshotById(getParameters().getId());
+        if (diskImage == null) {
+            getQueryReturnValue().setReturnValue(null);
+            return;
+        }
+        diskImage.setParentDiskId(imageDao.get(diskImage.getParentId()).getDiskId());
+
+        getQueryReturnValue().setReturnValue(diskImage);
     }
 }

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/storage/Disk.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/storage/Disk.java
@@ -4,7 +4,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import org.ovirt.engine.core.common.businessentities.TransientField;
 import org.ovirt.engine.core.common.businessentities.VmEntityType;
+import org.ovirt.engine.core.compat.Guid;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
@@ -30,6 +32,9 @@ public abstract class Disk extends BaseDisk {
     private List<String> templateVersionNames;
     private boolean plugged;
     private String logicalName;
+
+    @TransientField
+    private Guid parentDiskId;
 
     /**
      * Image Transfer information is only for display purposes
@@ -173,5 +178,15 @@ public abstract class Disk extends BaseDisk {
     @JsonIgnore
     public boolean isOvfStore() {
         return getContentType() == DiskContentType.OVF_STORE;
+    }
+
+    @JsonIgnore
+    public Guid getParentDiskId() {
+        return parentDiskId;
+    }
+
+    @JsonIgnore
+    public void setParentDiskId(Guid parentDiskId) {
+        this.parentDiskId = parentDiskId;
     }
 }

--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendDiskSnapshotResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendDiskSnapshotResource.java
@@ -7,6 +7,7 @@ import org.ovirt.engine.api.model.DiskSnapshot;
 import org.ovirt.engine.api.resource.DiskSnapshotResource;
 import org.ovirt.engine.core.common.action.ActionType;
 import org.ovirt.engine.core.common.action.RemoveDiskSnapshotsParameters;
+import org.ovirt.engine.core.common.businessentities.storage.DiskImage;
 import org.ovirt.engine.core.common.queries.IdQueryParameters;
 import org.ovirt.engine.core.common.queries.QueryType;
 import org.ovirt.engine.core.compat.Guid;
@@ -26,14 +27,16 @@ public class BackendDiskSnapshotResource
 
     @Override
     public DiskSnapshot get() {
-        DiskSnapshot diskSnapshot = performGet(QueryType.GetDiskSnapshotByImageId,
-                new IdQueryParameters(guid), Disk.class);
+        DiskImage diskImage = runQuery(QueryType.GetDiskSnapshotByImageId,
+                new IdQueryParameters(guid)).getReturnValue();
+        DiskSnapshot diskSnapshot = map(diskImage, null);
         diskSnapshot.setDisk(new Disk());
         diskSnapshot.getDisk().setId(diskId.toString());
         diskSnapshot.getDisk().setHref(backendDiskSnapshotsResource.buildParentHref(diskId.toString(), false));
-        diskSnapshot.setHref(backendDiskSnapshotsResource.buildHref(diskId.toString(), diskSnapshot.getId().toString()));
-        if (diskSnapshot.getParent() != null) {
-            diskSnapshot.getParent().setHref(backendDiskSnapshotsResource.buildHref(diskId.toString(),
+        diskSnapshot.setHref(backendDiskSnapshotsResource.buildHref(diskId.toString(), diskSnapshot.getId()));
+        Guid parentDiskId = diskImage.getParentDiskId();
+        if (parentDiskId != null && diskSnapshot.getParent() != null) {
+            diskSnapshot.getParent().setHref(backendDiskSnapshotsResource.buildHref(parentDiskId.toString(),
                     diskSnapshot.getParent().getId()));
         }
         return diskSnapshot;

--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendDiskSnapshotsResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendDiskSnapshotsResource.java
@@ -36,13 +36,18 @@ public class BackendDiskSnapshotsResource
     protected DiskSnapshots mapCollection(List<org.ovirt.engine.core.common.businessentities.storage.Disk> entities) {
         DiskSnapshots collection = new DiskSnapshots();
         for (org.ovirt.engine.core.common.businessentities.storage.Disk disk : entities) {
-            DiskSnapshot diskSnapshot = getMapper(org.ovirt.engine.core.common.businessentities.storage.Disk.class, DiskSnapshot.class).map(disk, null);
+            DiskSnapshot diskSnapshot = getMapper(org.ovirt.engine.core.common.businessentities.storage.Disk.class, DiskSnapshot.class)
+                    .map(disk, null);
             diskSnapshot.setDisk(new Disk());
-            diskSnapshot.getDisk().setId(this.diskId.toString());
+            diskSnapshot.getDisk().setId(disk.getId().toString());
             collection.getDiskSnapshots().add(addLinks(populate(diskSnapshot, disk), Disk.class));
-            diskSnapshot.setHref(buildHref(diskId.toString(), diskSnapshot.getId().toString()));
-            if (diskSnapshot.getParent() != null) {
-                diskSnapshot.getParent().setHref(buildParentHref(diskId.toString(), false));
+            diskSnapshot.setHref(buildHref(disk.getId().toString(), diskSnapshot.getId()));
+            Guid parentDiskId = disk.getParentDiskId();
+            if (parentDiskId != null) {
+                diskSnapshot.getParent().setHref(buildHref(parentDiskId.toString(),
+                        diskSnapshot.getParent().getId()));
+            } else if (diskSnapshot.getParent() != null) {
+                diskSnapshot.getParent().setHref(buildHref(disk.getId().toString(), diskSnapshot.getParent().getId()));
             }
         }
         return collection;


### PR DESCRIPTION
If User send REST API request  for ovirt-engine/api/disks/{diskid}/disksnapshots?include_active&include_template he will get this  incorrect href back \<parent href="/ovirt-engine/api/disks/{diskid}" id="{parentid}"/\>.
Now it will get correct output that will look like this \<parent href="/ovirt-engine/api/disks/{parentdiskid}/disksnapshots/{parentid}" id="{parentid}"/\>.

Bug-Url: https://bugzilla.redhat.com/2013697
Signed-off-by: Artiom Divak <adivak@redhat.com>