### PR TITLE
Change iSCSI storage connection validation to properly avoid duplications

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/connection/ISCSIStorageHelper.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/connection/ISCSIStorageHelper.java
@@ -207,6 +207,14 @@ public class ISCSIStorageHelper extends StorageHelperBase {
         return null;
     }
 
+    public List<StorageServerConnections> findConnectionsByAddressPortAndIqn(StorageServerConnections connection) {
+        return storageServerConnectionDao.getStorageConnectionsByConnectionPortAndIqn(
+                        connection.getConnection(),
+                        connection.getPort(),
+                        connection.getIqn()
+                );
+    }
+
     private void fillConnectionDetailsIfNeeded(StorageServerConnections connection) {
         // in case that the connection id is null (in case it wasn't loaded from the db before) - we can attempt to load
         // it from the db by its details.

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/connection/StorageServerConnectionCommandBase.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/connection/StorageServerConnectionCommandBase.java
@@ -80,10 +80,7 @@ public abstract class StorageServerConnectionCommandBase<T extends StorageServer
             String connectionField = connection.getConnection();
             connections = storageServerConnectionDao.getAllForStorage(connectionField);
         } else {
-            StorageServerConnections sameConnection = iscsiStorageHelper.findConnectionWithSameDetails(connection);
-            connections =
-                    sameConnection != null ? Collections.singletonList(sameConnection)
-                            : Collections.emptyList();
+            connections = iscsiStorageHelper.findConnectionsByAddressPortAndIqn(connection);
         }
 
         return (connections != null && connections.size() > 0 &&

--- a/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/storage/connection/AddStorageServerConnectionCommandTest.java
+++ b/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/storage/connection/AddStorageServerConnectionCommandTest.java
@@ -181,7 +181,7 @@ public class AddStorageServerConnectionCommandTest extends
        StorageServerConnections  existingConn = createISCSIConnection("1.2.3.4", StorageType.ISCSI, "iqn.2013-04.myhat.com:aaa-target1", "3650", "user1", "mypassword123");
        existingConn.setId(Guid.newGuid().toString());
 
-       when(iscsiStorageHelper.findConnectionWithSameDetails(newISCSIConnection)).thenReturn(existingConn);
+       when(iscsiStorageHelper.findConnectionsByAddressPortAndIqn(newISCSIConnection)).thenReturn(Collections.singletonList(existingConn));
        String isExists = command.isConnWithSameDetailsExists(newISCSIConnection, null);
        assertFalse(isExists.isEmpty());
     }

--- a/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/storage/connection/UpdateStorageServerConnectionCommandTest.java
+++ b/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/storage/connection/UpdateStorageServerConnectionCommandTest.java
@@ -645,7 +645,7 @@ public class UpdateStorageServerConnectionCommandTest extends
        StorageServerConnections  newISCSIConnection = createISCSIConnection("1.2.3.4", StorageType.ISCSI, "iqn.2013-04.myhat.com:aaa-target1", "3260", "user1", "mypassword123");
 
        StorageServerConnections connection1 = createISCSIConnection("1.2.3.4", StorageType.ISCSI, "iqn.2013-04.myhat.com:aaa-target1", "3260", "user1", "mypassword123");
-       when(iscsiStorageHelper.findConnectionWithSameDetails(newISCSIConnection)).thenReturn(connection1);
+       when(iscsiStorageHelper.findConnectionsByAddressPortAndIqn(newISCSIConnection)).thenReturn(Collections.singletonList(connection1));
        boolean isExists = !command.isConnWithSameDetailsExists(newISCSIConnection, null).isEmpty();
        assertTrue(isExists);
     }
@@ -653,7 +653,7 @@ public class UpdateStorageServerConnectionCommandTest extends
     @Test
     public void isConnWithSameDetailsExistCheckSameConn() {
        StorageServerConnections  newISCSIConnection = createISCSIConnection("1.2.3.4", StorageType.ISCSI, "iqn.2013-04.myhat.com:aaa-target1", "3260", "user1", "mypassword123");
-       when(iscsiStorageHelper.findConnectionWithSameDetails(newISCSIConnection)).thenReturn(newISCSIConnection);
+       when(iscsiStorageHelper.findConnectionsByAddressPortAndIqn(newISCSIConnection)).thenReturn(Collections.singletonList(newISCSIConnection));
        boolean isExists = !command.isConnWithSameDetailsExists(newISCSIConnection, null).isEmpty();
         assertTrue(isExists);
     }

--- a/backend/manager/modules/dal/src/main/java/org/ovirt/engine/core/dao/StorageServerConnectionDao.java
+++ b/backend/manager/modules/dal/src/main/java/org/ovirt/engine/core/dao/StorageServerConnectionDao.java
@@ -122,6 +122,17 @@ public interface StorageServerConnectionDao extends GenericDao<StorageServerConn
             StorageServerConnections connection);
 
     /**
+     * Retrieves all connections for the specified address, port and iqn
+     *
+     * @param connection the address of the connection
+     * @param port the port of the connection
+     * @param iqn the IQN (iSCSI Qualified Name) of the connection
+     * @return the list of connections
+     */
+    List<StorageServerConnections> getStorageConnectionsByConnectionPortAndIqn(
+            String connection, String port, String iqn);
+
+    /**
      * Retrieves all connections used by the specified storage domain
      * @return the list of connections
      */

--- a/backend/manager/modules/dal/src/main/java/org/ovirt/engine/core/dao/StorageServerConnectionDaoImpl.java
+++ b/backend/manager/modules/dal/src/main/java/org/ovirt/engine/core/dao/StorageServerConnectionDaoImpl.java
@@ -117,6 +117,18 @@ public class StorageServerConnectionDaoImpl extends BaseDao implements
     }
 
     @Override
+    public List<StorageServerConnections> getStorageConnectionsByConnectionPortAndIqn(
+            String connection, String port, String iqn) {
+        return getCallsHandler().executeReadList("GetStorageConnectionsByConnectionPortAndIqn",
+                mapper,
+                getCustomMapSqlParameterSource()
+                        .addValue("iqn", iqn)
+                        .addValue("connection", connection)
+                        .addValue("port", port));
+    }
+
+
+    @Override
     public List<StorageServerConnections> getAllForDomain(Guid domainId) {
         return getCallsHandler().executeReadList("GetStorageServerConnectionsForDomain", mapper,
                         getCustomMapSqlParameterSource().addValue("storage_domain_id", domainId));

--- a/packaging/dbscripts/storages_san_sp.sql
+++ b/packaging/dbscripts/storages_san_sp.sql
@@ -542,6 +542,24 @@ BEGIN
 END;$PROCEDURE$
 LANGUAGE plpgsql;
 
+CREATE OR REPLACE FUNCTION GetStorageConnectionsByConnectionPortAndIqn (
+    v_iqn VARCHAR(128),
+    v_connection VARCHAR(250),
+    v_port VARCHAR(50)
+    )
+RETURNS SETOF storage_server_connections STABLE AS $PROCEDURE$
+BEGIN
+    RETURN QUERY
+
+    SELECT *
+    FROM storage_server_connections
+    WHERE iqn = v_iqn
+        AND connection = v_connection
+        AND port = v_port;
+END;$PROCEDURE$
+LANGUAGE plpgsql;
+
+
 CREATE OR REPLACE FUNCTION Getstorage_server_connectionsByStorageType (v_storage_type INT)
 RETURNS SETOF storage_server_connections STABLE AS $PROCEDURE$
 BEGIN


### PR DESCRIPTION
Currently when adding/updating iSCSI storage server connection, there
is a validation that checks if a duplicate connection exists by iqn,
address, port, portal, username and password. This allows creating
two storage connections with the same iqn, address and port, but with
different portals.

There cannot be two portals with the same iqn-address-port, thus
creating two such connections does not make sense and will lead to
errors connecting the host to storage.

This change fixes the validation to fail add/update request if
connection with the same iqn-address-port combination exists

Bug-Url: https://bugzilla.redhat.com/2079903