### PR TITLE
core: Fix NPE on invalid affinity group ID

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/commands/AffinityGroupCRUDCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/commands/AffinityGroupCRUDCommand.java
@@ -202,7 +202,7 @@ public abstract class AffinityGroupCRUDCommand <T extends AffinityGroupCRUDParam
 
     @Override
     public Guid getClusterId() {
-        return getAffinityGroup().getClusterId();
+        return getAffinityGroup() != null ? getAffinityGroup().getClusterId() : Guid.Empty;
     }
 
     @Override


### PR DESCRIPTION
Added null check in AffinityGroupCRUDCommand.getClusterId() to avoid NPE
when the affinity group does not exist. The command fails in the
validation later.

Change-Id: I473969a190ab5db1577615d28970d72e10341846
Bug-Url: https://bugzilla.redhat.com/2067104
Signed-off-by: Shmuel Melamud <smelamud@redhat.com>