### PR TITLE
core: Add missing AttachUserToVmFromPoolAndRun job properties

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/AttachUserToVmFromPoolAndRunCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/AttachUserToVmFromPoolAndRunCommand.java
@@ -10,6 +10,7 @@ import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.Typed;
 import javax.inject.Inject;
 
+import org.apache.commons.lang.StringUtils;
 import org.ovirt.engine.core.bll.context.CommandContext;
 import org.ovirt.engine.core.bll.job.ExecutionContext;
 import org.ovirt.engine.core.bll.quota.QuotaClusterConsumptionParameter;
@@ -296,6 +297,16 @@ public class AttachUserToVmFromPoolAndRunCommand<T extends AttachUserToVmFromPoo
         default:
             return AuditLogType.USER_ATTACH_USER_TO_VM_FROM_POOL_FINISHED_FAILURE;
         }
+    }
+
+    @Override
+    public Map<String, String> getJobMessageProperties() {
+        if (jobProperties == null) {
+            jobProperties = super.getJobMessageProperties();
+            jobProperties.put(VdcObjectType.VM.name().toLowerCase(), StringUtils.defaultString(getVmName()));
+            jobProperties.put(VdcObjectType.User.name().toLowerCase(), StringUtils.defaultString(getAdUserName()));
+        }
+        return jobProperties;
     }
 
     private void detachUserFromVmFromPool() {


### PR DESCRIPTION
Added missing job properties in AttachUserToVmFromPoolAndRunCommand that
were appearing as <UNKNOWN> values.

Change-Id: I1c6446e275cbb266a2093f65a4cadc08c489ea26
Bug-Url: https://bugzilla.redhat.com/2016341
Signed-off-by: Shmuel Melamud <smelamud@redhat.com>