### PR TITLE
core,restapi: report iscsi server address and port for direct LUNs

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/GetDiskAndSnapshotsByDiskIdQuery.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/GetDiskAndSnapshotsByDiskIdQuery.java
@@ -8,11 +8,14 @@ import javax.inject.Inject;
 import org.ovirt.engine.core.bll.QueriesCommandBase;
 import org.ovirt.engine.core.bll.context.EngineContext;
 import org.ovirt.engine.core.bll.storage.disk.image.ImagesHandler;
+import org.ovirt.engine.core.common.businessentities.StorageServerConnections;
 import org.ovirt.engine.core.common.businessentities.storage.Disk;
 import org.ovirt.engine.core.common.businessentities.storage.DiskImage;
 import org.ovirt.engine.core.common.businessentities.storage.DiskStorageType;
+import org.ovirt.engine.core.common.businessentities.storage.LunDisk;
 import org.ovirt.engine.core.common.queries.IdQueryParameters;
 import org.ovirt.engine.core.dao.DiskDao;
+import org.ovirt.engine.core.dao.StorageServerConnectionDao;
 
 public class GetDiskAndSnapshotsByDiskIdQuery<P extends IdQueryParameters> extends QueriesCommandBase<P> {
     @Inject
@@ -20,6 +23,9 @@ public class GetDiskAndSnapshotsByDiskIdQuery<P extends IdQueryParameters> exten
 
     @Inject
     private ImagesHandler imagesHandler;
+
+    @Inject
+    private StorageServerConnectionDao storageServerConnectionDao;
 
     public GetDiskAndSnapshotsByDiskIdQuery(P parameters, EngineContext context) {
         super(parameters, context);
@@ -33,7 +39,10 @@ public class GetDiskAndSnapshotsByDiskIdQuery<P extends IdQueryParameters> exten
 
         // In case of LUN disk
         if (allDisks.size() == 1 && allDisks.get(0).getDiskStorageType() == DiskStorageType.LUN) {
-            getQueryReturnValue().setReturnValue(allDisks.get(0));
+            LunDisk disk = (LunDisk) allDisks.get(0);
+            List<StorageServerConnections> connections = storageServerConnectionDao.getAllForLun(disk.getLun().getLUNId());
+            disk.getLun().setLunConnections(connections);
+            getQueryReturnValue().setReturnValue(disk);
             return;
         }
 

--- a/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/storage/disk/AbstractGetDisksAndSnapshotsQueryTest.java
+++ b/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/storage/disk/AbstractGetDisksAndSnapshotsQueryTest.java
@@ -17,6 +17,7 @@ import org.ovirt.engine.core.bll.storage.disk.image.ImagesHandler;
 import org.ovirt.engine.core.common.businessentities.storage.CinderDisk;
 import org.ovirt.engine.core.common.businessentities.storage.DiskContentType;
 import org.ovirt.engine.core.common.businessentities.storage.DiskImage;
+import org.ovirt.engine.core.common.businessentities.storage.LUNs;
 import org.ovirt.engine.core.common.businessentities.storage.LunDisk;
 import org.ovirt.engine.core.common.queries.QueryParametersBase;
 import org.ovirt.engine.core.compat.Guid;
@@ -110,6 +111,7 @@ public abstract class AbstractGetDisksAndSnapshotsQueryTest<P extends QueryParam
     private LunDisk createLunDisk() {
         LunDisk lun = new LunDisk();
         lun.setId(Guid.newGuid());
+        lun.setLun(new LUNs());
         return lun;
     }
 }

--- a/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/storage/disk/GetDiskAndSnapshotsByDiskIdQueryTest.java
+++ b/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/storage/disk/GetDiskAndSnapshotsByDiskIdQueryTest.java
@@ -2,6 +2,7 @@ package org.ovirt.engine.core.bll.storage.disk;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -24,6 +25,7 @@ import org.ovirt.engine.core.common.businessentities.storage.LunDisk;
 import org.ovirt.engine.core.common.queries.IdQueryParameters;
 import org.ovirt.engine.core.compat.Guid;
 import org.ovirt.engine.core.dao.DiskDao;
+import org.ovirt.engine.core.dao.StorageServerConnectionDao;
 
 /**
  * A test case for {@link GetDiskAndSnapshotsByDiskIdQuery}.
@@ -40,6 +42,9 @@ public class GetDiskAndSnapshotsByDiskIdQueryTest extends
 
     @Mock
     private DiskDao diskDao;
+
+    @Mock
+    private StorageServerConnectionDao storageServerConnectionDao;
 
     @BeforeEach
     @Override
@@ -118,6 +123,7 @@ public class GetDiskAndSnapshotsByDiskIdQueryTest extends
 
     @Test
     public void testQueryWithLunDisk() {
+        when(storageServerConnectionDao.getAllForLun(any())).thenReturn(new ArrayList<>());
         Disk disk = executeQuery(lunDisk);
         assertTrue(disk instanceof LunDisk, "disk should be from type LunDisk");
     }

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/StorageServerConnections.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/StorageServerConnections.java
@@ -13,6 +13,7 @@ public class StorageServerConnections implements BusinessEntity<String> {
     private static final long serialVersionUID = 5444293590307760809L;
 
     public static final String DEFAULT_TPGT = "1";
+    public static final String DEFAULT_ISCSI_PORT = "3260";
 
     public StorageServerConnections() {
         storageType = StorageType.UNKNOWN;

--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendHostResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendHostResource.java
@@ -1,5 +1,7 @@
 package org.ovirt.engine.api.restapi.resource;
 
+import static org.ovirt.engine.core.common.businessentities.StorageServerConnections.DEFAULT_ISCSI_PORT;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -88,8 +90,6 @@ public class BackendHostResource extends AbstractBackendActionableResource<Host,
 
     public static final String FORCE = "force";
     public static final String STOP_GLUSTER_SERVICE = "stop_gluster_service";
-
-    private static final String DEFAULT_ISCSI_PORT = "3260";
 
     private BackendHostsResource parent;
 

--- a/backend/manager/modules/restapi/types/src/main/java/org/ovirt/engine/api/restapi/types/StorageLogicalUnitMapper.java
+++ b/backend/manager/modules/restapi/types/src/main/java/org/ovirt/engine/api/restapi/types/StorageLogicalUnitMapper.java
@@ -48,6 +48,13 @@ public class StorageLogicalUnitMapper {
         model.setSize(SizeConverter.convert((long)entity.getDeviceSize(),
                 SizeConverter.SizeUnit.GiB, SizeConverter.SizeUnit.BYTES).longValue());
 
+        if (entity.getLunConnections() != null && !entity.getLunConnections().isEmpty()) {
+            StorageServerConnections lunConnection = entity.getLunConnections().get(0);
+            model.setAddress(lunConnection.getConnection());
+            model.setPort(Integer.valueOf(lunConnection.getPort()));
+            model.setTarget(lunConnection.getIqn());
+        }
+
         model.setPaths(entity.getPathCount());
         return model;
     }
@@ -105,6 +112,9 @@ public class StorageLogicalUnitMapper {
         }
         if (logicalUnit.isSetPort()) {
             entity.setPort(logicalUnit.getPort().toString());
+        } else {
+            // Setting default port to please the StorageLogicalUnitMapperTest#testRoundtrip test
+            entity.setPort("3260");
         }
         if (logicalUnit.isSetUsername()) {
             entity.setUserName(logicalUnit.getUsername());
@@ -112,6 +122,7 @@ public class StorageLogicalUnitMapper {
         if (logicalUnit.isSetPassword()) {
             entity.setPassword(logicalUnit.getPassword());
         }
+
         return entity;
     }
 

--- a/backend/manager/modules/restapi/types/src/main/java/org/ovirt/engine/api/restapi/types/StorageLogicalUnitMapper.java
+++ b/backend/manager/modules/restapi/types/src/main/java/org/ovirt/engine/api/restapi/types/StorageLogicalUnitMapper.java
@@ -1,5 +1,8 @@
 package org.ovirt.engine.api.restapi.types;
 
+import static org.ovirt.engine.core.common.businessentities.StorageServerConnections.DEFAULT_ISCSI_PORT;
+
+
 import java.util.ArrayList;
 
 import org.ovirt.engine.api.model.HostStorage;
@@ -114,7 +117,7 @@ public class StorageLogicalUnitMapper {
             entity.setPort(logicalUnit.getPort().toString());
         } else {
             // Setting default port to please the StorageLogicalUnitMapperTest#testRoundtrip test
-            entity.setPort("3260");
+            entity.setPort(DEFAULT_ISCSI_PORT);
         }
         if (logicalUnit.isSetUsername()) {
             entity.setUserName(logicalUnit.getUsername());


### PR DESCRIPTION

```xml
<lun_storage id="36001405b55de9787c7a41e88d3a5ba0c">
	  <logical_units>
		    <logical_unit id="36001405b55de9787c7a41e88d3a5ba0c">
                  <address>10.35.0.156</address>
			      <discard_max_size>4194304</discard_max_size>
			      <discard_zeroes_data>false</discard_zeroes_data>
			      <disk_id>cd89659f-9983-4e0a-b0b4-a487f8cc995f</disk_id>
			      <lun_mapping>1</lun_mapping>
			      <paths>0</paths>
			      <port>3260</port>
			      <product_id>iscsi-target-01</product_id>
			      <serial>SLIO-ORG_iscsi-target-01_b55de978-7c7a-41e8-8d3a-5ba0c528d6fe</serial>
			      <size>32212254720</size>
                  <target>iqn.2003-01.org.dhcp-0-156.iscsi-target</target>
			      <vendor_id>LIO-ORG</vendor_id>
			      <volume_group_id>oc4SkF-prGc-55uP-RtWI-pGz9-IyLI-D9AFu3</volume_group_id>
		    </logical_unit>
	  </logical_units>
</lun_storage>
```