### PR TITLE
ansible: make ovirt-vmconsole host certificate readable

### DIFF
--- a/packaging/ansible-runner-service-project/project/roles/ovirt-host-deploy-vm-console-certificates/tasks/main.yml
+++ b/packaging/ansible-runner-service-project/project/roles/ovirt-host-deploy-vm-console-certificates/tasks/main.yml
@@ -61,7 +61,7 @@
       src: "{{ ovirt_pki_dir }}/certs/{{ ovirt_vds_hostname }}-ssh-cert.pub"
       dest: "{{ ovirt_vmconsole_cert_file }}"
       remote_src: no
-      mode: preserve
+      mode: 0644
 
   - name: Set vmconsole key path
     set_fact:


### PR DESCRIPTION
ovirt-vmconsole is running under its own user and need access to
certificates. This only worked till now since the certificates were
mistakenly opened to others, but now it prevents sshd to acess its host
key
