### PR TITLE
packaging: Make sure OVN certificates are renewed when needed

### DIFF
--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/network/ovirtproviderovn.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/network/ovirtproviderovn.py
@@ -1113,6 +1113,7 @@ class Plugin(plugin.PluginBase):
         stage=plugin.Stages.STAGE_MISC,
         before=(
             oenginecons.Stages.OVN_PROVIDER_SERVICE_RESTART,
+            oenginecons.Stages.OVN_PROVIDER_OVN_DB,
         ),
         after=(
             oenginecons.Stages.CA_AVAILABLE,

--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/network/ovirtproviderovn.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/network/ovirtproviderovn.py
@@ -931,6 +931,7 @@ class Plugin(plugin.PluginBase):
         )
         if self._enabled or self._provider_installed:
             self._setup_firewalld_services()
+            self._generate_pki()
 
     def _print_commands(self, message, commands):
         self.dialog.note(
@@ -971,16 +972,6 @@ class Plugin(plugin.PluginBase):
         if ovnprovider_installed and \
                 keycloak_enabled and not keycloak_configured:
             self._user, self._password = self._get_provider_credentials()
-
-    @plugin.event(
-        stage=plugin.Stages.STAGE_MISC,
-        before=(
-            oenginecons.Stages.CA_UPGRADE,
-        ),
-        condition=lambda self: self._enabled or self._provider_installed,
-    )
-    def _misc_pki(self):
-        self._generate_pki()
 
     def _restart_service(self, service):
         self.services.startup(

--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/network/ovirtproviderovn.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/network/ovirtproviderovn.py
@@ -519,7 +519,7 @@ class Plugin(plugin.PluginBase):
 
         return user, password
 
-    def _generate_pki(self):
+    def _add_ovn_pki_entities(self):
         self.environment[oenginecons.PKIEnv.ENTITIES].extend(
             (
                 {
@@ -931,7 +931,7 @@ class Plugin(plugin.PluginBase):
         )
         if self._enabled or self._provider_installed:
             self._setup_firewalld_services()
-            self._generate_pki()
+            self._add_ovn_pki_entities()
 
     def _print_commands(self, message, commands):
         self.dialog.note(


### PR DESCRIPTION
Due to incorrect staging and missing dependencies, OVN certificates
are not renewed if there are no other certificate renewals needed.
This patch fixes it by changing when OVN certificate info to PKI
entities is added.  It must be done:

- In STAGE_CUSTOMIZATION rather than STAGE_MISC.  STAGE_CUSTOMIZATION
  is where we ask for certificate renewal if needed.

- After the OVN plugin attributes are initialized so that the event
  condition doesn’t crash on a missing attribute.

- Before certificate renewal check is performed.

It must be also done after
self.environment[oenginecons.PKIEnv.ENTITIES] is initialized but that
happens in STAGE_INIT, which is run early so no change is needed
here.  Note that we cannot add the OVN certificate info there in
STAGE_INIT because we don’t know yet whether OVN is used.

Bug-Url: https://bugzilla.redhat.com/2097558
Bug-Url: https://bugzilla.redhat.com/2097560