### PR TITLE
ansible runner client refactoring

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleClientFactory.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleClientFactory.java
@@ -1,18 +1,12 @@
 package org.ovirt.engine.core.common.utils.ansible;
 
-import javax.inject.Inject;
 import javax.inject.Singleton;
 
 @Singleton
 public class AnsibleClientFactory {
 
-    @Inject
-    private AnsibleCommandLogFileFactory ansibleCommandLogFileFactory;
-
     public AnsibleRunnerClient create(AnsibleCommandConfig command) {
-        AnsibleRunnerLogger runnerLogger = ansibleCommandLogFileFactory.create(command);
         AnsibleRunnerClient client = new AnsibleRunnerClient();
-        client.setLogger(runnerLogger);
         return client;
     }
 

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleReturnValue.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleReturnValue.java
@@ -51,6 +51,7 @@ public class AnsibleReturnValue {
     public AnsibleReturnValue(AnsibleReturnCode ansibleReturnCode, String stdout) {
         this.ansibleReturnCode = ansibleReturnCode;
         this.stdout = stdout;
+        this.lastEventId = 0;
     }
 
     public AnsibleReturnCode getAnsibleReturnCode() {


### PR DESCRIPTION
eliminate wrong use of singleton's class properties - they get
overwritten by each run. Whole state is now passed through
AnsibleReturnValue object consistently.
