### PR TITLE
Perform cleanup after insufficient free space error during LSM

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/lsm/LiveMigrateDiskCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/lsm/LiveMigrateDiskCommand.java
@@ -273,9 +273,10 @@ public class LiveMigrateDiskCommand<T extends LiveMigrateDiskParameters> extends
             }
 
             updateStage(LiveDiskMigrateStage.SOURCE_IMAGE_DELETION);
-            removeImage(getParameters().getSourceStorageDomainId(), getParameters()
-                    .getImageGroupID(), getParameters().getDestinationImageId(), AuditLogType
-                    .USER_MOVE_IMAGE_GROUP_FAILED_TO_DELETE_SRC_IMAGE);
+            removeImage(getParameters().getSourceStorageDomainId(),
+                    getParameters().getImageGroupID(),
+                    getParameters().getDestinationImageId(),
+                    AuditLogType.USER_MOVE_IMAGE_GROUP_FAILED_TO_DELETE_SRC_IMAGE);
             updateStage(LiveDiskMigrateStage.LIVE_MIGRATE_DISK_EXEC_COMPLETED);
             return true;
         }
@@ -388,7 +389,7 @@ public class LiveMigrateDiskCommand<T extends LiveMigrateDiskParameters> extends
         }
 
         super.endWithFailure();
-        handleDestDisk();
+        cleanupDestDiskAfterFailure();
 
         // Handle snapshot removal
         log.info("Attempting to remove the auto-generated snapshot");
@@ -743,7 +744,7 @@ public class LiveMigrateDiskCommand<T extends LiveMigrateDiskParameters> extends
                 + String.format("$DiskName %1$s", disk != null ? disk.getDiskAlias() : "");
     }
 
-    private void handleDestDisk() {
+    private void cleanupDestDiskAfterFailure() {
         if (getParameters().getLiveDiskMigrateStage() != LiveDiskMigrateStage.CREATE_SNAPSHOT &&
                 getParameters().getLiveDiskMigrateStage() != LiveDiskMigrateStage.CLONE_IMAGE_STRUCTURE &&
                 getParameters().getLiveDiskMigrateStage() != LiveDiskMigrateStage.SOURCE_IMAGE_DELETION) {
@@ -772,9 +773,10 @@ public class LiveMigrateDiskCommand<T extends LiveMigrateDiskParameters> extends
 
             log.error("Attempting to delete the target of disk '{}' of vm '{}'",
                     getParameters().getImageGroupID(), getParameters().getVmId());
-            removeImage(getParameters().getTargetStorageDomainId(), getParameters()
-                    .getImageGroupID(), getParameters().getDestinationImageId(), AuditLogType
-                    .USER_MOVE_IMAGE_GROUP_FAILED_TO_DELETE_DST_IMAGE);
+            removeImage(getParameters().getTargetStorageDomainId(),
+                    getParameters().getImageGroupID(),
+                    getParameters().getDestinationImageId(),
+                    AuditLogType.USER_MOVE_IMAGE_GROUP_FAILED_TO_DELETE_DST_IMAGE);
         }
     }
 

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/lsm/LiveMigrateDiskCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/lsm/LiveMigrateDiskCommand.java
@@ -745,9 +745,12 @@ public class LiveMigrateDiskCommand<T extends LiveMigrateDiskParameters> extends
     }
 
     private void cleanupDestDiskAfterFailure() {
-        if (getParameters().getLiveDiskMigrateStage() != LiveDiskMigrateStage.CREATE_SNAPSHOT &&
-                getParameters().getLiveDiskMigrateStage() != LiveDiskMigrateStage.CLONE_IMAGE_STRUCTURE &&
-                getParameters().getLiveDiskMigrateStage() != LiveDiskMigrateStage.SOURCE_IMAGE_DELETION) {
+        if (getParameters().getLiveDiskMigrateStage() == LiveDiskMigrateStage.CREATE_SNAPSHOT ||
+                getParameters().getLiveDiskMigrateStage() == LiveDiskMigrateStage.SOURCE_IMAGE_DELETION) {
+            return;
+        }
+
+        if (getParameters().getLiveDiskMigrateStage() != LiveDiskMigrateStage.CLONE_IMAGE_STRUCTURE) {
             if (Guid.Empty.equals(getParameters().getVdsId())) {
                 log.error("Failed during live storage migration of disk '{}' of vm '{}', as the vm is not running" +
                                 " on any host not attempting to end the replication before the target disk deletion",
@@ -770,14 +773,14 @@ public class LiveMigrateDiskCommand<T extends LiveMigrateDiskParameters> extends
                     }
                 }
             }
-
-            log.error("Attempting to delete the target of disk '{}' of vm '{}'",
-                    getParameters().getImageGroupID(), getParameters().getVmId());
-            removeImage(getParameters().getTargetStorageDomainId(),
-                    getParameters().getImageGroupID(),
-                    getParameters().getDestinationImageId(),
-                    AuditLogType.USER_MOVE_IMAGE_GROUP_FAILED_TO_DELETE_DST_IMAGE);
         }
+
+        log.error("Attempting to delete the target of disk '{}' of vm '{}'",
+                getParameters().getImageGroupID(), getParameters().getVmId());
+        removeImage(getParameters().getTargetStorageDomainId(),
+                getParameters().getImageGroupID(),
+                getParameters().getDestinationImageId(),
+                AuditLogType.USER_MOVE_IMAGE_GROUP_FAILED_TO_DELETE_DST_IMAGE);
     }
 
     @Override


### PR DESCRIPTION
In case of Live Storage Migration failure during `LiveDiskMigrateStage.CLONE_IMAGE_STRUCTURE` the remove image cleanup was skipped.
It should be performed in order to free the already allocated space on the target Storage Domain.

Bug-Url: https://bugzilla.redhat.com/2102149