### PR TITLE
Bump metamodel to 1.3.9 and model to 4.5.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- Versions of the API model and tools: -->
-    <metamodel.version>1.3.7</metamodel.version>
-    <model.version>4.5.10</model.version>
+    <metamodel.version>1.3.9</metamodel.version>
+    <model.version>4.5.11</model.version>
 
     <ovirt-engine-extensions-api.version>1.0.1</ovirt-engine-extensions-api.version>
 


### PR DESCRIPTION
Following important changes on api-metamodel has been done since 1.3.7:

* Change asciidoc link-generation
  https://github.com/oVirt/ovirt-engine-api-metamodel/pull/28

* Add RPM packaging

* Switch from log4j backend to java.util.logging backend

Following important changes on api-model has been done since 4.5.10:

* Image I/O Proxy is replaced by ovirt-imageio
  https://bugzilla.redhat.com/2042401

* Deprecate VmPool.display attribute
  https://bugzilla.redhat.com/2106349

* Updated documentation to SystemOptionService
  https://bugzilla.redhat.com/1974974

* Add TpmSupport to OperatingSystemInfo
  https://github.com/oVirt/ovirt-web-ui/issues/1596

* Change slashes to hyphens in xrefs
  https://github.com/oVirt/ovirt-engine-api-model/pull/80

Signed-off-by: Martin Perina <mperina@redhat.com>
