### PR TITLE
Turning procedures to functions

### DIFF
--- a/packaging/dbscripts/ad_groups_sp.sql
+++ b/packaging/dbscripts/ad_groups_sp.sql
@@ -11,7 +11,7 @@ CREATE OR REPLACE FUNCTION InsertGroup (
     v_external_id TEXT,
     v_namespace VARCHAR(2048)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO ad_groups (
         id,
@@ -29,7 +29,7 @@ BEGIN
         v_external_id,
         v_namespace
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateGroup (
@@ -42,7 +42,7 @@ CREATE OR REPLACE FUNCTION UpdateGroup (
     )
 RETURNS VOID
     --The [ad_groups] table doesn't have a timestamp column. Optimistic concurrency logic cannot be generated
-    AS $PROCEDURE$
+    AS $FUNCTION$
 BEGIN
     UPDATE ad_groups
     SET name = v_name,
@@ -51,11 +51,11 @@ BEGIN
         external_id = v_external_id,
         namespace = v_namespace
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteGroup (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM tags_user_group_map
@@ -64,35 +64,35 @@ BEGIN
     DELETE
     FROM ad_groups
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllGroups ()
-RETURNS SETOF ad_groups STABLE AS $PROCEDURE$
+RETURNS SETOF ad_groups STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM ad_groups;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGroupById (v_id UUID)
-RETURNS SETOF ad_groups STABLE AS $PROCEDURE$
+RETURNS SETOF ad_groups STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM ad_groups
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGroupByExternalId (
     v_domain VARCHAR(100),
     v_external_id TEXT
     )
-RETURNS SETOF ad_groups STABLE AS $PROCEDURE$
+RETURNS SETOF ad_groups STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -100,22 +100,22 @@ BEGIN
     FROM ad_groups
     WHERE domain = v_domain
         AND external_id = v_external_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGroupByName (v_name VARCHAR(256))
-RETURNS SETOF ad_groups STABLE AS $PROCEDURE$
+RETURNS SETOF ad_groups STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM ad_groups
     WHERE name = v_name;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGroupByNameAndDomain (v_name VARCHAR(256), v_domain VARCHAR(256))
-RETURNS SETOF ad_groups STABLE AS $PROCEDURE$
+RETURNS SETOF ad_groups STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -123,7 +123,7 @@ BEGIN
     FROM ad_groups
     WHERE name = v_name
       AND domain = v_domain;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/affinity_groups_sp.sql
+++ b/packaging/dbscripts/affinity_groups_sp.sql
@@ -1,22 +1,22 @@
 
 
--- Affinity Groups Stored Procedures script file
+-- Affinity Groups functions script file
 
 -- get All Affinity Groups
 CREATE OR REPLACE FUNCTION getAllFromAffinityGroups ()
-RETURNS SETOF affinity_groups_view STABLE AS $PROCEDURE$
+RETURNS SETOF affinity_groups_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT affinity_groups_view.*
     FROM affinity_groups_view;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 
 -- get All Affinity Groups with members by vm id
 CREATE OR REPLACE FUNCTION getAllAffinityGroupsByVmId (v_vm_id UUID)
-RETURNS SETOF affinity_groups_view STABLE AS $PROCEDURE$
+RETURNS SETOF affinity_groups_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -25,13 +25,13 @@ BEGIN
     INNER JOIN affinity_group_members
         ON v_vm_id = affinity_group_members.vm_id
             AND affinity_group_members.affinity_group_id = affinity_groups_view.id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 
 -- get All Affinity Groups with members from labels by vm id
 CREATE OR REPLACE FUNCTION getAllAffinityGroupsWithFlatLabelsByVmId (v_vm_id UUID)
-RETURNS SETOF affinity_groups_with_members_from_labels_view STABLE AS $PROCEDURE$
+RETURNS SETOF affinity_groups_with_members_from_labels_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -40,58 +40,58 @@ BEGIN
     INNER JOIN affinity_groups_members_flat_labels_view as members
         ON v_vm_id = members.vm_id
             AND members.affinity_group_id = groups_view.id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 
 -- get All Affinity Groups with members by cluster id
 CREATE OR REPLACE FUNCTION getAllAffinityGroupsByClusterId (v_cluster_id UUID)
-RETURNS SETOF affinity_groups_view STABLE AS $PROCEDURE$
+RETURNS SETOF affinity_groups_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM affinity_groups_view
     WHERE cluster_id = v_cluster_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 
 -- get All Affinity Groups with members from labels by cluster id
 CREATE OR REPLACE FUNCTION getAllAffinityGroupsWithFlatLabelsByClusterId (v_cluster_id UUID)
-RETURNS SETOF affinity_groups_with_members_from_labels_view STABLE AS $PROCEDURE$
+RETURNS SETOF affinity_groups_with_members_from_labels_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM affinity_groups_with_members_from_labels_view
     WHERE cluster_id = v_cluster_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 
 -- get Affinity Group with members by id
 CREATE OR REPLACE FUNCTION GetAffinityGroupByAffinityGroupId (v_id UUID)
-RETURNS SETOF affinity_groups_view STABLE AS $PROCEDURE$
+RETURNS SETOF affinity_groups_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM affinity_groups_view
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- get Affinity Group by name, used for name validation
 CREATE OR REPLACE FUNCTION GetAffinityGroupByName (v_name VARCHAR(255))
-RETURNS SETOF affinity_groups_view STABLE AS $PROCEDURE$
+RETURNS SETOF affinity_groups_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM affinity_groups_view
     WHERE name = v_name;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Insert Affinity Group with members
@@ -112,7 +112,7 @@ CREATE OR REPLACE FUNCTION InsertAffinityGroupWithMembers (
     v_vm_label_ids UUID[],
     v_host_label_ids UUID[]
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 DECLARE
     o uuid;
 BEGIN
@@ -163,17 +163,17 @@ BEGIN
         PERFORM InsertAffinityHostLabel(v_id, o);
     END LOOP;
 
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Delete Affinity Group (uses cascade to remove members)
 CREATE OR REPLACE FUNCTION DeleteAffinityGroup (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM affinity_groups
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Update Affinity Group (implemeted using Delete and Insert SPs)
@@ -194,7 +194,7 @@ CREATE OR REPLACE FUNCTION UpdateAffinityGroupWithMembers (
     v_vm_label_ids UUID[],
     v_host_label_ids UUID[]
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     PERFORM DeleteAffinityGroup(v_id);
 
@@ -214,12 +214,12 @@ BEGIN
         v_vds_ids,
         v_vm_label_ids,
         v_host_label_ids);
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Get All positive enforcing Affinity Groups which contain VMs running on given host id
 CREATE OR REPLACE FUNCTION getPositiveEnforcingAffinityGroupsByRunningVmsOnVdsId (v_vds_id UUID)
-RETURNS SETOF affinity_groups_with_members_from_labels_view STABLE AS $PROCEDURE$
+RETURNS SETOF affinity_groups_with_members_from_labels_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -232,7 +232,7 @@ BEGIN
             AND vm_dynamic.run_on_vds = v_vds_id
     WHERE (vm_enforcing AND vm_positive AND vms_affinity_enabled)
         OR (vds_enforcing AND vds_positive);
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Set affinity groups for a VM
@@ -240,7 +240,7 @@ CREATE OR REPLACE FUNCTION SetAffinityGroupsForVm (
     v_vm_id UUID,
     v_groups uuid[]
 )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     -- Remove existing entries for the VM
     DELETE FROM affinity_group_members
@@ -253,7 +253,7 @@ BEGIN
         vm_id
     )
     SELECT unnest(v_groups), v_vm_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Set affinity groups for a host
@@ -261,7 +261,7 @@ CREATE OR REPLACE FUNCTION SetAffinityGroupsForHost (
     v_host_id UUID,
     v_groups uuid[]
 )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     -- Remove existing entries for the host
     DELETE FROM affinity_group_members
@@ -274,7 +274,7 @@ BEGIN
         vds_id
     )
     SELECT unnest(v_groups), v_host_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Set a VM for affinity group
@@ -282,7 +282,7 @@ CREATE OR REPLACE FUNCTION InsertAffinityVm (
     v_affinity_group_id UUID,
     v_vm_id UUID
 )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO affinity_group_members(
         affinity_group_id,
@@ -292,7 +292,7 @@ BEGIN
         v_affinity_group_id,
         v_vm_id
     );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -301,12 +301,12 @@ CREATE OR REPLACE FUNCTION DeleteAffinityVm (
     v_affinity_group_id UUID,
     v_vm_id UUID
 )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE FROM affinity_group_members
     WHERE affinity_group_id = v_affinity_group_id
         AND vm_id = v_vm_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Set a host for affinity group
@@ -314,7 +314,7 @@ CREATE OR REPLACE FUNCTION InsertAffinityHost (
     v_affinity_group_id UUID,
     v_vds_id UUID
 )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO affinity_group_members(
         affinity_group_id,
@@ -324,7 +324,7 @@ BEGIN
         v_affinity_group_id,
         v_vds_id
     );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Delete a host for affinity group
@@ -332,12 +332,12 @@ CREATE OR REPLACE FUNCTION DeleteAffinityHost (
     v_affinity_group_id UUID,
     v_vds_id UUID
 )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE FROM affinity_group_members
     WHERE affinity_group_id = v_affinity_group_id
         AND vds_id = v_vds_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Set a VM label for affinity group
@@ -345,7 +345,7 @@ CREATE OR REPLACE FUNCTION InsertAffinityVmLabel (
     v_affinity_group_id UUID,
     v_vm_label_id UUID
 )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO affinity_group_members(
         affinity_group_id,
@@ -355,7 +355,7 @@ BEGIN
         v_affinity_group_id,
         v_vm_label_id
     );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Delete a VM label for affinity group
@@ -363,12 +363,12 @@ CREATE OR REPLACE FUNCTION DeleteAffinityVmLabel (
     v_affinity_group_id UUID,
     v_vm_label_id UUID
 )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE FROM affinity_group_members
     WHERE affinity_group_id = v_affinity_group_id
         AND vm_label_id = v_vm_label_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Set a host label for affinity group
@@ -376,7 +376,7 @@ CREATE OR REPLACE FUNCTION InsertAffinityHostLabel (
     v_affinity_group_id UUID,
     v_host_label_id UUID
 )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO affinity_group_members(
         affinity_group_id,
@@ -386,7 +386,7 @@ BEGIN
         v_affinity_group_id,
         v_host_label_id
     );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Delete a host label for affinity group
@@ -394,10 +394,10 @@ CREATE OR REPLACE FUNCTION DeleteAffinityHostLabel (
     v_affinity_group_id UUID,
     v_host_label_id UUID
 )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE FROM affinity_group_members
     WHERE affinity_group_id = v_affinity_group_id
         AND host_label_id = v_host_label_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;

--- a/packaging/dbscripts/all_disks_sp.sql
+++ b/packaging/dbscripts/all_disks_sp.sql
@@ -7,7 +7,7 @@ CREATE OR REPLACE FUNCTION GetAllFromDisks (
     v_user_id UUID,
     v_is_filtered BOOLEAN
     )
-RETURNS SETOF all_disks STABLE AS $PROCEDURE$
+RETURNS SETOF all_disks STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -22,7 +22,7 @@ BEGIN
                     AND entity_id = disk_id
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetDiskByDiskId (
@@ -30,7 +30,7 @@ CREATE OR REPLACE FUNCTION GetDiskByDiskId (
     v_user_id UUID,
     v_is_filtered boolean
     )
-RETURNS SETOF all_disks STABLE AS $PROCEDURE$
+RETURNS SETOF all_disks STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -46,7 +46,7 @@ BEGIN
                     AND entity_id = v_disk_id
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetDisksVmGuid (
@@ -55,7 +55,7 @@ CREATE OR REPLACE FUNCTION GetDisksVmGuid (
     v_user_id UUID,
     v_is_filtered BOOLEAN
     )
-RETURNS SETOF all_disks_for_vms STABLE AS $PROCEDURE$
+RETURNS SETOF all_disks_for_vms STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -75,7 +75,7 @@ BEGIN
                     AND entity_id = disk_id
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetImagesWithDamagedSnapshotForVm (
@@ -83,7 +83,7 @@ CREATE OR REPLACE FUNCTION GetImagesWithDamagedSnapshotForVm (
     v_user_id UUID,
     v_is_filtered BOOLEAN
     )
-RETURNS SETOF UUID STABLE AS $PROCEDURE$
+RETURNS SETOF UUID STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -106,19 +106,19 @@ BEGIN
                     AND i.vm_snapshot_id is not null
                     AND i.vm_snapshot_id != '00000000-0000-0000-0000-000000000000'::uuid
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetDisksVmGuids (
   v_vm_guids UUID[]
 )
-  RETURNS SETOF all_disks_for_vms STABLE AS $PROCEDURE$
+  RETURNS SETOF all_disks_for_vms STABLE AS $FUNCTION$
 BEGIN
   RETURN QUERY
   SELECT *
   FROM all_disks_for_vms
   WHERE vm_id = ANY(v_vm_guids);
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 DROP TYPE IF EXISTS disks_basic_rs CASCADE;
@@ -134,7 +134,7 @@ CREATE OR REPLACE FUNCTION GetDisksVmGuidBasicView (
     v_user_id UUID,
     v_is_filtered BOOLEAN
     )
-RETURNS SETOF disks_basic_rs STABLE AS $PROCEDURE$
+RETURNS SETOF disks_basic_rs STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -161,11 +161,11 @@ BEGIN
                     AND entity_id = disk_id
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVmBootActiveDisk (v_vm_guid UUID)
-RETURNS SETOF all_disks STABLE AS $PROCEDURE$
+RETURNS SETOF all_disks STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -179,7 +179,7 @@ BEGIN
         AND disk_vm_element.is_boot = TRUE
         AND vm_device.vm_id = v_vm_guid
         AND vm_device.snapshot_id IS NULL;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Returns all the attachable disks in the storage pool
@@ -191,7 +191,7 @@ CREATE OR REPLACE FUNCTION GetAllAttachableDisksByPoolId (
     v_user_id UUID,
     v_is_filtered BOOLEAN
     )
-RETURNS SETOF all_disks STABLE AS $PROCEDURE$
+RETURNS SETOF all_disks STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -231,7 +231,7 @@ BEGIN
                     AND entity_id = disk_id
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromDisksByDiskStorageType (
@@ -239,7 +239,7 @@ CREATE OR REPLACE FUNCTION GetAllFromDisksByDiskStorageType (
     v_user_id UUID,
     v_is_filtered BOOLEAN
     )
-RETURNS SETOF all_disks STABLE AS $PROCEDURE$
+RETURNS SETOF all_disks STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -255,14 +255,14 @@ BEGIN
                     AND entity_id = disk_id
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromDisksIncludingSnapshots (
     v_user_id UUID,
     v_is_filtered BOOLEAN
     )
-RETURNS SETOF all_disks_including_snapshots STABLE AS $PROCEDURE$
+RETURNS SETOF all_disks_including_snapshots STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -277,7 +277,7 @@ BEGIN
                     AND entity_id = disk_id
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetDiskAndSnapshotsByDiskId (
@@ -285,7 +285,7 @@ CREATE OR REPLACE FUNCTION GetDiskAndSnapshotsByDiskId (
     v_user_id UUID,
     v_is_filtered BOOLEAN
     )
-RETURNS SETOF all_disks_including_snapshots STABLE AS $PROCEDURE$
+RETURNS SETOF all_disks_including_snapshots STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -301,5 +301,5 @@ BEGIN
                     AND entity_id = v_disk_id
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;

--- a/packaging/dbscripts/async_tasks_sp.sql
+++ b/packaging/dbscripts/async_tasks_sp.sql
@@ -17,7 +17,7 @@ CREATE OR REPLACE FUNCTION Insertasync_tasks (
     v_storage_pool_id UUID,
     v_async_task_type INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO async_tasks (
         action_type,
@@ -47,7 +47,7 @@ BEGIN
         v_storage_pool_id,
         v_async_task_type
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Updateasync_tasks (
@@ -64,7 +64,7 @@ CREATE OR REPLACE FUNCTION Updateasync_tasks (
     )
 RETURNS VOID
     --The [async_tasks] table doesn't have a timestamp column. Optimistic concurrency logic cannot be generated
-    AS $PROCEDURE$
+    AS $FUNCTION$
 BEGIN
     UPDATE async_tasks
     SET action_type = v_action_type,
@@ -76,7 +76,7 @@ BEGIN
         vdsm_task_id = v_vdsm_task_id,
         storage_pool_id = v_storage_pool_id
     WHERE task_id = v_task_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION InsertOrUpdateAsyncTasks (
@@ -93,7 +93,7 @@ CREATE OR REPLACE FUNCTION InsertOrUpdateAsyncTasks (
     v_storage_pool_id UUID,
     v_async_task_type INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     IF NOT EXISTS (
             SELECT 1
@@ -127,7 +127,7 @@ BEGIN
                      v_storage_pool_id);
 END
 
-IF ;END;$PROCEDURE$
+IF ;END;$FUNCTION$
     LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION InsertAsyncTaskEntities (
@@ -135,7 +135,7 @@ CREATE OR REPLACE FUNCTION InsertAsyncTaskEntities (
     v_entity_id UUID,
     v_entity_type VARCHAR(128)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     IF NOT EXISTS (
             SELECT 1
@@ -155,33 +155,33 @@ BEGIN
             );
 END
 
-IF ;END;$PROCEDURE$
+IF ;END;$FUNCTION$
     LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAsyncTasksIdsByEntityId (v_entity_id UUID)
-RETURNS SETOF idUuidType STABLE AS $PROCEDURE$
+RETURNS SETOF idUuidType STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT async_task_id
     FROM async_tasks_entities
     WHERE entity_id = v_entity_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAsyncTaskEntitiesByTaskId (v_task_id UUID)
-RETURNS SETOF async_tasks_entities STABLE AS $PROCEDURE$
+RETURNS SETOF async_tasks_entities STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM async_tasks_entities
     WHERE async_task_id = v_task_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Deleteasync_tasks (v_task_id UUID)
-RETURNS INT AS $PROCEDURE$
+RETURNS INT AS $FUNCTION$
 DECLARE deleted_rows INT;
 
 BEGIN
@@ -192,11 +192,11 @@ BEGIN
     GET DIAGNOSTICS deleted_rows = ROW_COUNT;
 
     RETURN deleted_rows;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteAsyncTasksByVdsmTaskId (v_vdsm_task_id UUID)
-RETURNS INT AS $PROCEDURE$
+RETURNS INT AS $FUNCTION$
 DECLARE deleted_rows INT;
 
 BEGIN
@@ -207,43 +207,43 @@ BEGIN
     GET DIAGNOSTICS deleted_rows = ROW_COUNT;
 
     RETURN deleted_rows;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAsyncTasksByStoragePoolId (v_storage_pool_id UUID)
-RETURNS SETOF async_tasks STABLE AS $PROCEDURE$
+RETURNS SETOF async_tasks STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM async_tasks
     WHERE storage_pool_id = v_storage_pool_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromasync_tasks ()
-RETURNS SETOF async_tasks STABLE AS $PROCEDURE$
+RETURNS SETOF async_tasks STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM async_tasks;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Getasync_tasksBytask_id (v_task_id UUID)
-RETURNS SETOF async_tasks STABLE AS $PROCEDURE$
+RETURNS SETOF async_tasks STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM async_tasks
     WHERE task_id = v_task_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAsyncTasksByEntityId (v_entity_id UUID)
-RETURNS SETOF async_tasks STABLE AS $PROCEDURE$
+RETURNS SETOF async_tasks STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -252,18 +252,18 @@ BEGIN
     INNER JOIN async_tasks_entities
         ON async_task_id = task_id
     WHERE entity_id = v_entity_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAsyncTasksByVdsmTaskId (v_vdsm_task_id UUID)
-RETURNS SETOF async_tasks STABLE AS $PROCEDURE$
+RETURNS SETOF async_tasks STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM async_tasks
     WHERE vdsm_task_id = v_vdsm_task_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/audit_log_sp.sql
+++ b/packaging/dbscripts/audit_log_sp.sql
@@ -38,7 +38,7 @@ CREATE OR REPLACE FUNCTION InsertAuditLog (
     v_custom_event_id INT,
     v_event_flood_in_sec INT,
     v_custom_data TEXT
-    ) AS $PROCEDURE$
+    ) AS $FUNCTION$
 DECLARE v_min_alert_severity INT;
 
 BEGIN
@@ -206,20 +206,20 @@ BEGIN
             AND log_type = v_log_type;
         END IF;
     END IF;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteAuditLog (v_audit_log_id BIGINT)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE audit_log
     SET deleted = true
     WHERE audit_log_id = v_audit_log_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION ClearAllAuditLogEvents (v_severity INT)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
 
     UPDATE audit_log
@@ -230,11 +230,11 @@ BEGIN
            FOR UPDATE) AS s
     WHERE audit_log.audit_log_id = s.audit_log_id;
 
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DisplayAllAuditLogEvents (v_severity INT)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
 
     UPDATE audit_log
@@ -245,14 +245,14 @@ BEGIN
            FOR UPDATE) AS s
     WHERE audit_log.audit_log_id = s.audit_log_id;
 
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION SetAllAuditLogAlerts (
     v_severity INT,
     v_value BOOLEAN
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
 
 
@@ -264,7 +264,7 @@ BEGIN
            FOR UPDATE) AS s
     WHERE audit_log.audit_log_id = s.audit_log_id;
 
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Returns the events for which the user has direct permissions on
@@ -276,7 +276,7 @@ CREATE OR REPLACE FUNCTION GetAllFromAuditLog (
     v_user_id UUID,
     v_is_filtered BOOLEAN
     )
-RETURNS SETOF audit_log STABLE AS $PROCEDURE$
+RETURNS SETOF audit_log STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -335,18 +335,18 @@ BEGIN
                 )
             )
     ORDER BY audit_log_id DESC;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAuditLogByAuditLogId (v_audit_log_id BIGINT)
-RETURNS SETOF audit_log STABLE AS $PROCEDURE$
+RETURNS SETOF audit_log STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM audit_log
     WHERE audit_log_id = v_audit_log_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAuditLogByVMId (
@@ -354,7 +354,7 @@ CREATE OR REPLACE FUNCTION GetAuditLogByVMId (
     v_user_id UUID,
     v_is_filtered BOOLEAN
     )
-RETURNS SETOF audit_log STABLE AS $PROCEDURE$
+RETURNS SETOF audit_log STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -371,7 +371,7 @@ BEGIN
                     AND entity_id = vm_id
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAuditLogByVMTemplateId (
@@ -379,7 +379,7 @@ CREATE OR REPLACE FUNCTION GetAuditLogByVMTemplateId (
     v_user_id UUID,
     v_is_filtered BOOLEAN
     )
-RETURNS SETOF audit_log STABLE AS $PROCEDURE$
+RETURNS SETOF audit_log STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -396,24 +396,24 @@ BEGIN
                     AND entity_id = vm_template_id
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION RemoveAuditLogByBrickIdLogType (
     v_brick_id UUID,
     v_audit_log_type INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE audit_log
     SET deleted = true
     WHERE brick_id = v_brick_id
         AND log_type = v_audit_log_type;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAuditLogLaterThenDate (v_date TIMESTAMP WITH TIME ZONE)
-RETURNS SETOF audit_log STABLE AS $PROCEDURE$
+RETURNS SETOF audit_log STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -421,11 +421,11 @@ BEGIN
     FROM audit_log
     WHERE NOT deleted
         AND LOG_TIME >= v_date;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteAuditLogOlderThenDate (v_date TIMESTAMP WITH TIME ZONE)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 DECLARE v_id BIGINT;
 
 SWV_RowCount INT;
@@ -446,24 +446,24 @@ BEGIN
         FROM audit_log
         WHERE audit_log_id <= v_id;
     END IF;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteAuditAlertLogByVdsIDAndType (
     v_vds_id UUID,
     v_log_type INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE audit_log
     SET deleted = true
     WHERE vds_id = v_vds_id
         AND log_type = v_log_type;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteBackupRelatedAlerts ()
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE audit_log
     SET deleted = true
@@ -473,27 +473,27 @@ BEGIN
             9023,
             9026
             );-- (ENGINE_NO_FULL_BACKUP, ENGINE_NO_WARM_BACKUP, ENGINE_BACKUP_FAILED)
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteAuditAlertLogByVolumeIDAndType (
     v_gluster_volume_id UUID,
     v_log_type INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE audit_log
     SET deleted = true
     WHERE gluster_volume_id = v_gluster_volume_id
         AND log_type = v_log_type;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteAuditLogAlertsByVdsID (
     v_vds_id UUID,
     v_delete_config_alerts BOOLEAN = true
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 DECLARE v_min_alert_severity INT;
 
 v_no_config_alret_type INT;
@@ -523,7 +523,7 @@ BEGIN
                 AND v_no_max_alret_type;
 END
 
-IF ;END;$PROCEDURE$
+IF ;END;$FUNCTION$
     LANGUAGE plpgsql;
 
 /*
@@ -538,7 +538,7 @@ CREATE OR REPLACE FUNCTION get_seconds_to_wait_before_pm_operation (
     v_event VARCHAR(100),
     v_wait_for_sec INT
     )
-RETURNS INT STABLE AS $PROCEDURE$
+RETURNS INT STABLE AS $FUNCTION$
 DECLARE v_last_event_dt TIMESTAMP
 WITH TIME zone;
 DECLARE v_now_dt TIMESTAMP
@@ -566,14 +566,14 @@ BEGIN
         RETURN 0;
 END
 
-IF ;END;$PROCEDURE$
+IF ;END;$FUNCTION$
     LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAuditLogByOriginAndCustomEventId (
     v_origin VARCHAR(255),
     v_custom_event_id INT
     )
-RETURNS SETOF audit_log STABLE AS $PROCEDURE$
+RETURNS SETOF audit_log STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -581,14 +581,14 @@ BEGIN
     FROM audit_log
     WHERE origin = v_origin
         AND custom_event_id = v_custom_event_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAuditLogByVolumeIdAndType (
     v_gluster_volume_id UUID,
     v_log_type INT
     )
-RETURNS SETOF audit_log STABLE AS $PROCEDURE$
+RETURNS SETOF audit_log STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -596,7 +596,7 @@ BEGIN
     FROM audit_log
     WHERE gluster_volume_id = v_gluster_volume_id
         AND log_type = v_log_type;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/base_disks_sp.sql
+++ b/packaging/dbscripts/base_disks_sp.sql
@@ -17,7 +17,7 @@ CREATE OR REPLACE FUNCTION InsertBaseDisk (
     v_backup VARCHAR(32),
     v_backup_mode VARCHAR(32)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO base_disks (
         disk_id,
@@ -47,7 +47,7 @@ BEGIN
         v_backup,
         v_backup_mode
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateBaseDisk (
@@ -64,7 +64,7 @@ CREATE OR REPLACE FUNCTION UpdateBaseDisk (
     v_backup VARCHAR(32),
     v_backup_mode VARCHAR(32)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE base_disks
     SET wipe_after_delete = v_wipe_after_delete,
@@ -79,11 +79,11 @@ BEGIN
         backup = v_backup,
         backup_mode = v_backup_mode
     WHERE disk_id = v_disk_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteBaseDisk (v_disk_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 DECLARE v_val UUID;
 
 BEGIN
@@ -93,40 +93,40 @@ BEGIN
 
     -- Delete the disk's permissions
     PERFORM DeletePermissionsByEntityId(v_disk_id);
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromBaseDisks ()
-RETURNS SETOF base_disks STABLE AS $PROCEDURE$
+RETURNS SETOF base_disks STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM base_disks;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetBaseDiskByBaseDiskId (v_disk_id UUID)
-RETURNS SETOF base_disks STABLE AS $PROCEDURE$
+RETURNS SETOF base_disks STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM base_disks
     WHERE disk_id = v_disk_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 
 Create or replace FUNCTION GetBaseDisksByAlias(v_disk_alias varchar(255))
 RETURNS SETOF base_disks STABLE
-AS $procedure$
+AS $FUNCTION$
 BEGIN
     RETURN QUERY
     SELECT *
     FROM   base_disks
     WHERE  disk_alias = v_disk_alias;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/bookmarks_sp.sql
+++ b/packaging/dbscripts/bookmarks_sp.sql
@@ -8,7 +8,7 @@ CREATE OR REPLACE FUNCTION InsertBookmark (
     v_bookmark_name VARCHAR(40),
     v_bookmark_value VARCHAR(300)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO bookmarks (
         bookmark_Id,
@@ -20,7 +20,7 @@ BEGIN
         v_bookmark_name,
         v_bookmark_value
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateBookmark (
@@ -30,54 +30,54 @@ CREATE OR REPLACE FUNCTION UpdateBookmark (
     )
 RETURNS VOID
     --The [bookmarks] table doesn't have a timestamp column. Optimistic concurrency logic cannot be generated
-    AS $PROCEDURE$
+    AS $FUNCTION$
 BEGIN
     UPDATE bookmarks
     SET bookmark_name = v_bookmark_name,
         bookmark_value = v_bookmark_value
     WHERE bookmark_Id = v_bookmark_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteBookmark (v_bookmark_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM bookmarks
     WHERE bookmark_Id = v_bookmark_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromBookmarks ()
-RETURNS SETOF bookmarks STABLE AS $PROCEDURE$
+RETURNS SETOF bookmarks STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM bookmarks;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetBookmarkBybookmark_name (v_bookmark_name VARCHAR(40))
-RETURNS SETOF bookmarks STABLE AS $PROCEDURE$
+RETURNS SETOF bookmarks STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM bookmarks
     WHERE bookmark_name = v_bookmark_name;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetBookmarkBybookmark_id (v_bookmark_id UUID)
-RETURNS SETOF bookmarks STABLE AS $PROCEDURE$
+RETURNS SETOF bookmarks STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM bookmarks
     WHERE bookmark_Id = v_bookmark_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/business_entity_snapshot_sp.sql
+++ b/packaging/dbscripts/business_entity_snapshot_sp.sql
@@ -11,7 +11,7 @@ CREATE OR REPLACE FUNCTION insert_entity_snapshot (
     v_snapshot_type INT,
     v_insertion_order INT
     )
-RETURNS void AS $PROCEDURE$
+RETURNS void AS $FUNCTION$
 BEGIN
     BEGIN
         INSERT INTO business_entity_snapshot (
@@ -39,22 +39,22 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION get_entity_snapshot_by_id (v_id uuid)
-RETURNS SETOF business_entity_snapshot STABLE AS $PROCEDURE$
+RETURNS SETOF business_entity_snapshot STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT business_entity_snapshot.*
     FROM business_entity_snapshot
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION get_entity_snapshot_by_command_id (v_command_id uuid)
-RETURNS SETOF business_entity_snapshot STABLE AS $PROCEDURE$
+RETURNS SETOF business_entity_snapshot STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -62,7 +62,7 @@ BEGIN
     FROM business_entity_snapshot
     WHERE command_id = v_command_id
     ORDER BY insertion_order DESC;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 DROP TYPE IF EXISTS get_all_commands_rs CASCADE;
@@ -72,18 +72,18 @@ CREATE TYPE get_all_commands_rs AS (
         );
 
 CREATE OR REPLACE FUNCTION get_all_commands ()
-RETURNS SETOF get_all_commands_rs STABLE AS $PROCEDURE$
+RETURNS SETOF get_all_commands_rs STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT DISTINCT business_entity_snapshot.command_id,
         business_entity_snapshot.command_type
     FROM business_entity_snapshot;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION delete_entity_snapshot_by_command_id (v_command_id uuid)
-RETURNS void AS $PROCEDURE$
+RETURNS void AS $FUNCTION$
 BEGIN
     BEGIN
         DELETE
@@ -92,7 +92,7 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/cluster_features_sp.sql
+++ b/packaging/dbscripts/cluster_features_sp.sql
@@ -1,7 +1,7 @@
 
 
 /* ----------------------------------------------------------------
- Stored procedures for database operations on Cluster Features
+ Stored FUNCTIONs for database operations on Cluster Features
  related tables: cluster_features, supported_cluster_features, supported_host_features
 ----------------------------------------------------------------*/
 CREATE OR REPLACE FUNCTION InsertClusterFeature (
@@ -11,7 +11,7 @@ CREATE OR REPLACE FUNCTION InsertClusterFeature (
     v_category INT,
     v_description TEXT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO cluster_features (
         feature_id,
@@ -27,7 +27,7 @@ BEGIN
         v_category,
         v_description
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateClusterFeature (
@@ -37,7 +37,7 @@ CREATE OR REPLACE FUNCTION UpdateClusterFeature (
     v_category INT,
     v_description TEXT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE cluster_features
     SET feature_name = v_feature_name,
@@ -45,7 +45,7 @@ BEGIN
         description = v_description,
         category = v_category
     WHERE feature_id = v_feature_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- The logic to get the applicable set of features for a given category is as below-
@@ -71,7 +71,7 @@ CREATE OR REPLACE FUNCTION GetClusterFeaturesByVersionAndCategory (
     v_version VARCHAR(256),
     v_category INT
     )
-RETURNS SETOF cluster_features STABLE AS $PROCEDURE$
+RETURNS SETOF cluster_features STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -79,14 +79,14 @@ BEGIN
     FROM cluster_features
     WHERE cluster_features.version = v_version
         AND (cluster_features.category & v_category) > 0;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetSupportedClusterFeature (
     v_feature_id UUID,
     v_cluster_id UUID
     )
-RETURNS SETOF supported_cluster_features_view STABLE AS $PROCEDURE$
+RETURNS SETOF supported_cluster_features_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -94,17 +94,17 @@ BEGIN
     FROM supported_cluster_features_view
     WHERE feature_id = v_feature_id
         AND cluster_id = v_cluster_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllSupportedClusterFeatures ()
-RETURNS SETOF supported_cluster_features_view STABLE AS $PROCEDURE$
+RETURNS SETOF supported_cluster_features_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM supported_cluster_features_view;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION InsertSupportedClusterFeature (
@@ -112,7 +112,7 @@ CREATE OR REPLACE FUNCTION InsertSupportedClusterFeature (
     v_cluster_id UUID,
     v_is_enabled BOOLEAN
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO supported_cluster_features (
         cluster_id,
@@ -124,7 +124,7 @@ BEGIN
         v_feature_id,
         v_is_enabled
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateSupportedClusterFeature (
@@ -132,44 +132,44 @@ CREATE OR REPLACE FUNCTION UpdateSupportedClusterFeature (
     v_cluster_id UUID,
     v_is_enabled BOOLEAN
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE supported_cluster_features
     SET is_enabled = v_is_enabled
     WHERE cluster_id = v_cluster_id
         AND feature_id = v_feature_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteSupportedClusterFeature (
     v_feature_id UUID,
     v_cluster_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM supported_cluster_features
     WHERE cluster_id = v_cluster_id
         AND feature_id = v_feature_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetSupportedClusterFeaturesByClusterId (v_cluster_id UUID)
-RETURNS SETOF supported_cluster_features_view STABLE AS $PROCEDURE$
+RETURNS SETOF supported_cluster_features_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM supported_cluster_features_view
     WHERE cluster_id = v_cluster_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION InsertSupportedHostFeature (
     v_host_id UUID,
     v_feature_name VARCHAR(256)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO supported_host_features (
         host_id,
@@ -179,31 +179,31 @@ BEGIN
         v_host_id,
         v_feature_name
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetSupportedHostFeaturesByHostId (v_host_id UUID)
-RETURNS SETOF supported_host_features STABLE AS $PROCEDURE$
+RETURNS SETOF supported_host_features STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM supported_host_features
     WHERE host_id = v_host_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION RemoveSupportedHostFeature (
     v_host_id UUID,
     v_feature_name VARCHAR(256)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM supported_host_features
     WHERE host_id = v_host_id
         AND feature_name = v_feature_name;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/cluster_policy_sp.sql
+++ b/packaging/dbscripts/cluster_policy_sp.sql
@@ -6,25 +6,25 @@
 -- 'Policys' typo is intentional, naming convention for DefaultGenericDao is: "GetAllFrom{0}s",
 -- where {0} is the business entity (ClusterPolicy).
 CREATE OR REPLACE FUNCTION GetAllFromClusterPolicys ()
-RETURNS SETOF cluster_policies STABLE AS $PROCEDURE$
+RETURNS SETOF cluster_policies STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM cluster_policies;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- get cluster policy by id
 CREATE OR REPLACE FUNCTION GetClusterPolicyByClusterPolicyId (v_id UUID)
-RETURNS SETOF cluster_policies STABLE AS $PROCEDURE$
+RETURNS SETOF cluster_policies STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM cluster_policies
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Clsuter Policy Commands CRUD procs
@@ -37,7 +37,7 @@ CREATE OR REPLACE FUNCTION InsertClusterPolicy (
     v_is_default BOOLEAN,
     v_custom_properties TEXT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO cluster_policies (
         id,
@@ -55,7 +55,7 @@ BEGIN
         v_is_default,
         v_custom_properties
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Update
@@ -67,7 +67,7 @@ CREATE OR REPLACE FUNCTION UpdateClusterPolicy (
     v_is_default BOOLEAN,
     v_custom_properties TEXT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE cluster_policies
     SET name = v_name,
@@ -76,51 +76,51 @@ BEGIN
         is_default = v_is_default,
         custom_properties = v_custom_properties
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Delete
 CREATE OR REPLACE FUNCTION DeleteClusterPolicy (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM cluster_policies
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Cluster Policy Units
 -- Get all units per cluster policy id
 CREATE OR REPLACE FUNCTION GetAllFromClusterPolicyUnits ()
-RETURNS SETOF cluster_policy_units STABLE AS $PROCEDURE$
+RETURNS SETOF cluster_policy_units STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM cluster_policy_units;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Get all units per cluster policy id
 CREATE OR REPLACE FUNCTION GetClusterPolicyUnitsByClusterPolicyId (v_id UUID)
-RETURNS SETOF cluster_policy_units STABLE AS $PROCEDURE$
+RETURNS SETOF cluster_policy_units STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM cluster_policy_units
     WHERE cluster_policy_id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Delete all cluster policy units by cluster policy id
 CREATE OR REPLACE FUNCTION DeleteClusterPolicyUnitsByClusterPolicyId (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM cluster_policy_units
     WHERE cluster_policy_id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION InsertClusterPolicyUnit (
@@ -129,7 +129,7 @@ CREATE OR REPLACE FUNCTION InsertClusterPolicyUnit (
     v_filter_sequence INT,
     v_factor INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO cluster_policy_units (
         cluster_policy_id,
@@ -143,7 +143,7 @@ BEGIN
         v_filter_sequence,
         v_factor
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/clusters_sp.sql
+++ b/packaging/dbscripts/clusters_sp.sql
@@ -61,7 +61,7 @@ CREATE OR REPLACE FUNCTION InsertCluster (
     v_fips_mode SMALLINT,
     v_parallel_migrations SMALLINT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO cluster (
         cluster_id,
@@ -179,7 +179,7 @@ BEGIN
         v_fips_mode,
         v_parallel_migrations
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateCluster (
@@ -243,7 +243,7 @@ CREATE OR REPLACE FUNCTION UpdateCluster (
     )
 RETURNS VOID
     --The [cluster] table doesn't have a timestamp column. Optimistic concurrency logic cannot be generated
-    AS $PROCEDURE$
+    AS $FUNCTION$
 BEGIN
     UPDATE cluster
     SET description = v_description,
@@ -304,11 +304,11 @@ BEGIN
         fips_mode = v_fips_mode,
         parallel_migrations = v_parallel_migrations
     WHERE cluster_id = v_cluster_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteCluster (v_cluster_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 DECLARE v_val UUID;
 
 BEGIN
@@ -326,14 +326,14 @@ BEGIN
 
     -- delete VDS group permissions --
     PERFORM DeletePermissionsByEntityId(v_cluster_id);
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromCluster (
     v_user_id UUID,
     v_is_filtered BOOLEAN
     )
-RETURNS SETOF cluster_view STABLE AS $PROCEDURE$
+RETURNS SETOF cluster_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -348,7 +348,7 @@ BEGIN
                     AND entity_id = cluster_id
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetClusterByClusterId (
@@ -356,7 +356,7 @@ CREATE OR REPLACE FUNCTION GetClusterByClusterId (
     v_user_id UUID,
     v_is_filtered BOOLEAN
     )
-RETURNS SETOF cluster_view STABLE AS $PROCEDURE$
+RETURNS SETOF cluster_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -372,14 +372,14 @@ BEGIN
                     AND entity_id = v_cluster_id
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetClusterByClusterName (
     v_cluster_name VARCHAR(40),
     v_is_case_sensitive BOOLEAN
     )
-RETURNS SETOF cluster_view STABLE AS $PROCEDURE$
+RETURNS SETOF cluster_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -390,7 +390,7 @@ BEGIN
             NOT v_is_case_sensitive
             AND name ilike v_cluster_name
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetClusterForUserByClusterName (
@@ -398,7 +398,7 @@ CREATE OR REPLACE FUNCTION GetClusterForUserByClusterName (
     v_user_id UUID,
     v_is_filtered BOOLEAN
     )
-RETURNS SETOF cluster_view STABLE AS $PROCEDURE$
+RETURNS SETOF cluster_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -414,7 +414,7 @@ BEGIN
                     AND entity_id = cluster_id
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetClustersByStoragePoolId (
@@ -422,7 +422,7 @@ CREATE OR REPLACE FUNCTION GetClustersByStoragePoolId (
     v_user_id UUID,
     v_is_filtered BOOLEAN
     )
-RETURNS SETOF cluster_view STABLE AS $PROCEDURE$
+RETURNS SETOF cluster_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -438,12 +438,12 @@ BEGIN
                     AND entity_id = cluster_id
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 --This SP returns the VDS group if it has running vms
 CREATE OR REPLACE FUNCTION GetClusterWithRunningVms (v_cluster_id UUID)
-RETURNS SETOF cluster_view STABLE AS $PROCEDURE$
+RETURNS SETOF cluster_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -459,12 +459,12 @@ BEGIN
                     14
                     )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 --This SP returns all VDS groups where currently no migration is going on
 CREATE OR REPLACE FUNCTION GetClustersWithoutMigratingVms ()
-RETURNS SETOF cluster_view STABLE AS $PROCEDURE$
+RETURNS SETOF cluster_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -480,12 +480,12 @@ BEGIN
                     6
                     )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 --This SP returns if the VDS group does not have any hosts or VMs
 CREATE OR REPLACE FUNCTION GetIsClusterEmpty (v_cluster_id UUID)
-RETURNS BOOLEAN AS $PROCEDURE$
+RETURNS BOOLEAN AS $FUNCTION$
 BEGIN
     RETURN NOT EXISTS (
             SELECT 1
@@ -498,7 +498,7 @@ BEGIN
             FROM vds_static
             WHERE cluster_id = v_cluster_id
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 --This SP returns all cluster with permissions to run the given action by user
@@ -506,7 +506,7 @@ CREATE OR REPLACE FUNCTION fn_perms_get_clusters_with_permitted_action (
     v_user_id UUID,
     v_action_group_id INT
     )
-RETURNS SETOF cluster_view STABLE AS $PROCEDURE$
+RETURNS SETOF cluster_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -516,12 +516,12 @@ BEGIN
             SELECT 1
             FROM get_entity_permissions(v_user_id, v_action_group_id, cluster_view.cluster_id, 9)
             ) IS NOT NULL;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- This SP returns all cluster which have valid hosts attached to them
 CREATE OR REPLACE FUNCTION GetClustersHavingHosts ()
-RETURNS SETOF cluster_view STABLE AS $PROCEDURE$
+RETURNS SETOF cluster_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -532,7 +532,7 @@ BEGIN
             FROM vds_static
             WHERE cluster_id = cluster_view.cluster_id
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 --This SP updates the cluster emulated machine and the detection mode
@@ -541,13 +541,13 @@ CREATE OR REPLACE FUNCTION UpdateClusterEmulatedMachine (
     v_emulated_machine VARCHAR(40),
     v_detect_emulated_machine BOOLEAN
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE cluster
     SET emulated_machine = v_emulated_machine,
         detect_emulated_machine = v_detect_emulated_machine
     WHERE cluster_id = v_cluster_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 --This SP sets the cluster upgrade running flag to true if one is found with flag false. Returns true if update
@@ -557,7 +557,7 @@ CREATE OR REPLACE FUNCTION SetClusterUpgradeRunning (
     v_correlation_id VARCHAR(50),
     OUT v_updated BOOLEAN
     )
-AS $PROCEDURE$
+AS $FUNCTION$
 DECLARE c_id UUID;
 BEGIN
     SELECT cluster_id INTO c_id
@@ -575,7 +575,7 @@ BEGIN
     END IF;
 
     v_updated := FOUND;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 --This SP updates the cluster upgrade progress if the cluster one is found with upgrade running flag true.
@@ -585,7 +585,7 @@ CREATE OR REPLACE FUNCTION UpdateClusterUpgradeProgress (
     v_upgrade_percent_complete INT,
     OUT v_updated BOOLEAN
     )
-AS $PROCEDURE$
+AS $FUNCTION$
 DECLARE c_id UUID;
 BEGIN
     SELECT cluster_id INTO c_id
@@ -601,7 +601,7 @@ BEGIN
     END IF;
 
     v_updated := FOUND;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 --This SP clears the cluster upgrade running flag
@@ -609,7 +609,7 @@ CREATE OR REPLACE FUNCTION ClearClusterUpgradeRunning (
     v_cluster_id UUID,
     OUT v_updated BOOLEAN
     )
-AS $PROCEDURE$
+AS $FUNCTION$
 BEGIN
     UPDATE cluster
     SET upgrade_running = false,
@@ -617,45 +617,45 @@ BEGIN
     WHERE cluster_id = v_cluster_id;
 
     v_updated := FOUND;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 --This SP clears the cluster upgrade running flag for all rows
 CREATE OR REPLACE FUNCTION ClearAllClusterUpgradeRunning ()
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE cluster
     SET upgrade_running = false,
         upgrade_percent_complete = 0
     WHERE upgrade_running = true;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetTrustedClusters ()
-RETURNS SETOF cluster_view STABLE AS $PROCEDURE$
+RETURNS SETOF cluster_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT cluster_view.*
     FROM cluster_view
     WHERE trusted_service;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- returns all cluster attached to a specific cluster policy (given as a parameter to the SP)
 CREATE OR REPLACE FUNCTION GetClustersByClusterPolicyId (v_cluster_policy_id UUID)
-RETURNS SETOF cluster_view STABLE AS $PROCEDURE$
+RETURNS SETOF cluster_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT cluster_view.*
     FROM cluster_view
     WHERE cluster_policy_id = v_cluster_policy_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetNumberOfVmsInCluster (v_cluster_id UUID)
-RETURNS SETOF BIGINT STABLE AS $PROCEDURE$
+RETURNS SETOF BIGINT STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -663,7 +663,7 @@ BEGIN
     FROM vm_static vms
     WHERE vms.cluster_id = v_cluster_id
         AND vms.entity_type = 'VM';
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 DROP TYPE IF EXISTS host_vm_cluster_rs CASCADE;
@@ -675,7 +675,7 @@ CREATE TYPE host_vm_cluster_rs AS (
         );
 
 CREATE OR REPLACE FUNCTION GetHostsAndVmsForClusters (v_cluster_ids UUID [])
-RETURNS SETOF host_vm_cluster_rs STABLE AS $PROCEDURE$
+RETURNS SETOF host_vm_cluster_rs STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -700,7 +700,7 @@ BEGIN
     FROM cluster groups
     WHERE groups.cluster_id = ANY (v_cluster_ids)
     GROUP BY groups.cluster_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetClustersByServiceAndCompatibilityVersion (
@@ -708,7 +708,7 @@ CREATE OR REPLACE FUNCTION GetClustersByServiceAndCompatibilityVersion (
     v_virt_service BOOLEAN,
     v_compatibility_version VARCHAR(40)
     )
-RETURNS SETOF cluster_view STABLE AS $PROCEDURE$
+RETURNS SETOF cluster_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -717,35 +717,35 @@ BEGIN
     WHERE virt_service = v_virt_service
         AND gluster_service = v_gluster_service
         AND compatibility_version = v_compatibility_version;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 
 CREATE OR REPLACE FUNCTION GetAllClustersByMacPoolId (v_id UUID)
-RETURNS SETOF cluster_view STABLE AS $PROCEDURE$
+RETURNS SETOF cluster_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT cv.*
     FROM cluster_view cv
     WHERE cv.mac_pool_id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 
 CREATE OR REPLACE FUNCTION GetAllClustersByDefaultNetworkProviderId (v_id UUID)
-RETURNS SETOF cluster_view STABLE AS $PROCEDURE$
+RETURNS SETOF cluster_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT cv.*
     FROM cluster_view cv
     WHERE cv.default_network_provider_id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetClusterIdForHostByNameOrAddress (v_vds_name VARCHAR(255), v_host_address VARCHAR(39))
-RETURNS SETOF UUID STABLE AS $PROCEDURE$
+RETURNS SETOF UUID STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -756,5 +756,5 @@ BEGIN
             OR vds_interface.addr = v_host_address
             OR vds_interface.ipv6_address = v_host_address
         LIMIT 1;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;

--- a/packaging/dbscripts/command_entities_sp.sql
+++ b/packaging/dbscripts/command_entities_sp.sql
@@ -16,7 +16,7 @@ CREATE OR REPLACE FUNCTION InsertCommandEntity (
     v_return_value_class VARCHAR(256),
     v_data TEXT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 
 BEGIN
     INSERT INTO command_entities (
@@ -55,7 +55,7 @@ BEGIN
         v_return_value_class,
         v_data
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 
 LANGUAGE plpgsql;
 
@@ -76,7 +76,7 @@ CREATE OR REPLACE FUNCTION UpdateCommandEntity (
     v_return_value_class VARCHAR(256),
     v_data TEXT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 
 BEGIN
     UPDATE command_entities
@@ -95,7 +95,7 @@ BEGIN
         return_value_class = v_return_value_class,
         data = v_data
     WHERE command_id = v_command_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 
 LANGUAGE plpgsql;
 
@@ -103,13 +103,13 @@ CREATE OR REPLACE FUNCTION UpdateCommandEntityStatus (
     v_command_id uuid,
     v_status VARCHAR(20)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 
 BEGIN
     UPDATE command_entities
     SET status = v_status
     WHERE command_id = v_command_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 
 LANGUAGE plpgsql;
 
@@ -117,13 +117,13 @@ CREATE OR REPLACE FUNCTION UpdateCommandEntityExecuted (
     v_command_id uuid,
     v_executed boolean
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 
 BEGIN
     UPDATE command_entities
     SET executed = v_executed
     WHERE command_id = v_command_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 
 LANGUAGE plpgsql;
 
@@ -131,13 +131,13 @@ CREATE OR REPLACE FUNCTION UpdateCommandEntityNotified (
     v_command_id uuid,
     v_callback_notified boolean
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 
 BEGIN
     UPDATE command_entities
     SET callback_notified = v_callback_notified
     WHERE command_id = v_command_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 
 LANGUAGE plpgsql;
 
@@ -159,7 +159,7 @@ CREATE OR REPLACE FUNCTION InsertOrUpdateCommandEntity (
     v_return_value_class VARCHAR(256),
     v_data TEXT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 
 BEGIN
     IF NOT EXISTS (
@@ -203,11 +203,11 @@ BEGIN
                      v_data);
     END IF;
 
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetCommandEntityByCommandEntityId (v_command_id uuid)
-RETURNS SETOF command_entities AS $PROCEDURE$
+RETURNS SETOF command_entities AS $FUNCTION$
 
 BEGIN
     RETURN QUERY
@@ -215,24 +215,24 @@ BEGIN
     SELECT command_entities.*
     FROM command_entities
     WHERE command_id = v_command_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromCommandEntities ()
-RETURNS SETOF command_entities AS $PROCEDURE$
+RETURNS SETOF command_entities AS $FUNCTION$
 
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM command_entities;
-END;$PROCEDURE$
+END;$FUNCTION$
 
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetCommandEntitiesByParentCmdId (v_root_command_id uuid)
-RETURNS SETOF command_entities STABLE AS $PROCEDURE$
+RETURNS SETOF command_entities STABLE AS $FUNCTION$
 
 BEGIN
     RETURN QUERY
@@ -240,12 +240,12 @@ BEGIN
     SELECT command_entities.*
     FROM command_entities
     WHERE root_command_id = v_root_command_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteCommandEntity (v_command_id uuid)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 
 BEGIN
     BEGIN
@@ -255,12 +255,12 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteCommandEntitiesOlderThanDate (v_date TIMESTAMP WITH TIME ZONE)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 
 DECLARE v_id INT;
 
@@ -274,7 +274,7 @@ BEGIN
             SELECT command_id
             FROM async_tasks
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 
 LANGUAGE plpgsql;
 
@@ -283,7 +283,7 @@ CREATE OR REPLACE FUNCTION InsertCommandAssociatedEntities (
     v_entity_id UUID,
     v_entity_type VARCHAR(128)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 
 BEGIN
     INSERT INTO command_assoc_entities (
@@ -296,12 +296,12 @@ BEGIN
         v_entity_id,
         v_entity_type
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetCommandIdsByEntityId (v_entity_id UUID)
-RETURNS SETOF idUuidType STABLE AS $PROCEDURE$
+RETURNS SETOF idUuidType STABLE AS $FUNCTION$
 
 BEGIN
     RETURN QUERY
@@ -309,12 +309,12 @@ BEGIN
     SELECT command_id
     FROM command_assoc_entities
     WHERE entity_id = v_entity_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetCommandAssociatedEntities (v_command_id UUID)
-RETURNS SETOF command_assoc_entities STABLE AS $PROCEDURE$
+RETURNS SETOF command_assoc_entities STABLE AS $FUNCTION$
 
 BEGIN
     RETURN QUERY
@@ -322,7 +322,7 @@ BEGIN
     SELECT *
     FROM command_assoc_entities
     WHERE command_id = v_command_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 
 LANGUAGE plpgsql;
 

--- a/packaging/dbscripts/common_sp.sql
+++ b/packaging/dbscripts/common_sp.sql
@@ -9,14 +9,14 @@ CREATE OR REPLACE FUNCTION fn_db_add_column (
     v_column VARCHAR(128),
     v_column_def TEXT
     )
-RETURNS void AS $PROCEDURE$
+RETURNS void AS $FUNCTION$
 DECLARE v_sql TEXT;
 
 BEGIN
         v_sql := 'ALTER TABLE ' || v_table || ' ADD COLUMN IF NOT EXISTS ' || v_column || ' ' || v_column_def;
         EXECUTE v_sql;
 
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- delete a column from a table and all its dependencied
@@ -24,14 +24,14 @@ CREATE OR REPLACE FUNCTION fn_db_drop_column (
     v_table VARCHAR(128),
     v_column VARCHAR(128)
     )
-RETURNS void AS $PROCEDURE$
+RETURNS void AS $FUNCTION$
 DECLARE v_sql TEXT;
 
 BEGIN
         v_sql := 'ALTER TABLE ' || v_table || ' DROP COLUMN IF EXISTS ' || v_column;
         EXECUTE v_sql;
 
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Changes a column data type (if value conversion is supported)
@@ -41,14 +41,14 @@ CREATE OR REPLACE FUNCTION fn_db_change_column_type (
     v_type VARCHAR(128),
     v_new_type VARCHAR(128)
     )
-RETURNS void AS $PROCEDURE$
+RETURNS void AS $FUNCTION$
 DECLARE v_sql TEXT;
 
 BEGIN
     v_sql := 'ALTER TABLE ' || v_table || ' ALTER COLUMN ' || v_column || ' TYPE ' || v_new_type;
     EXECUTE v_sql;
 
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Changes a column to allow/disallow NULL values
@@ -58,7 +58,7 @@ CREATE OR REPLACE FUNCTION fn_db_change_column_null (
     v_allow_null BOOLEAN,
     v_type varchar
     )
-RETURNS void AS $PROCEDURE$
+RETURNS void AS $FUNCTION$
 DECLARE v_sql TEXT;
 
 BEGIN
@@ -94,7 +94,7 @@ BEGIN
 
     END IF;
 
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- rename a column for a given table
@@ -103,13 +103,13 @@ CREATE OR REPLACE FUNCTION fn_db_rename_column (
     v_column VARCHAR(128),
     v_new_name VARCHAR(128)
     )
-RETURNS void AS $PROCEDURE$
+RETURNS void AS $FUNCTION$
 DECLARE v_sql TEXT;
 
 BEGIN
     v_sql := 'ALTER TABLE ' || v_table || ' RENAME COLUMN ' || v_column || ' TO ' || v_new_name;
     EXECUTE v_sql;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- rename a table
@@ -117,13 +117,13 @@ CREATE OR REPLACE FUNCTION fn_db_rename_table (
     v_table VARCHAR(128),
     v_new_name VARCHAR(128)
     )
-RETURNS void AS $PROCEDURE$
+RETURNS void AS $FUNCTION$
 DECLARE v_sql TEXT;
 
 BEGIN
         v_sql := 'ALTER TABLE ' || v_table || ' RENAME TO ' || v_new_name;
         EXECUTE v_sql;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Adds a value to vdc_options (if not exists)
@@ -132,7 +132,7 @@ CREATE OR REPLACE FUNCTION fn_db_add_config_value (
     v_option_value TEXT,
     v_version VARCHAR(40)
     )
-RETURNS void AS $PROCEDURE$
+RETURNS void AS $FUNCTION$
 BEGIN
     IF (
             NOT EXISTS (
@@ -167,12 +167,12 @@ BEGIN
             END;
     END IF;
 
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Deletes a key from vdc_options if exists, for all its versions
 CREATE OR REPLACE FUNCTION fn_db_delete_config_value_all_versions (v_option_name VARCHAR(100))
-RETURNS void AS $PROCEDURE$
+RETURNS void AS $FUNCTION$
 BEGIN
     IF (
             EXISTS (
@@ -188,7 +188,7 @@ BEGIN
         END;
     END IF;
 
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Deletes a key from vdc_options (if exists)
@@ -196,7 +196,7 @@ CREATE OR REPLACE FUNCTION fn_db_delete_config_value (
     v_option_name VARCHAR(100),
     v_version TEXT
     )
-RETURNS void AS $PROCEDURE$
+RETURNS void AS $FUNCTION$
 BEGIN
     IF (
             EXISTS (
@@ -220,12 +220,12 @@ BEGIN
         END;
     END IF;
 
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Deletes a key from vdc_options by version/versions(comma separated)
 CREATE OR REPLACE FUNCTION fn_db_delete_config_for_version (v_version TEXT)
-RETURNS void AS $PROCEDURE$
+RETURNS void AS $FUNCTION$
 BEGIN
     DELETE
     FROM vdc_options
@@ -233,7 +233,7 @@ BEGIN
             SELECT ID
             FROM fnSplitter(v_version)
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Updates a value in vdc_options (if exists)
@@ -242,7 +242,7 @@ CREATE OR REPLACE FUNCTION fn_db_update_config_value (
     v_option_value TEXT,
     v_version VARCHAR(40)
     )
-RETURNS void AS $PROCEDURE$
+RETURNS void AS $FUNCTION$
 BEGIN
     IF (
             EXISTS (
@@ -261,7 +261,7 @@ BEGIN
         END;
     END IF;
 
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Updates a value in vdc_options (if exists) if default value wasn't changed
@@ -272,7 +272,7 @@ CREATE OR REPLACE FUNCTION fn_db_update_default_config_value (
     v_version VARCHAR(40),
     v_ignore_default_value_case boolean
     )
-RETURNS void AS $PROCEDURE$
+RETURNS void AS $FUNCTION$
 BEGIN
     IF (
             EXISTS (
@@ -304,7 +304,7 @@ BEGIN
             AND version = v_version;
     END;
     END IF;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
     --renames an existing config key name, custome option_value modifications are preserved
@@ -314,7 +314,7 @@ LANGUAGE plpgsql;
         v_new_option_name VARCHAR(100),
         v_version VARCHAR(40)
         )
-    RETURNS void AS $PROCEDURE$
+    RETURNS void AS $FUNCTION$
 
     DECLARE v_current_option_value TEXT;
 
@@ -339,7 +339,7 @@ LANGUAGE plpgsql;
                     AND version = v_version;
         END IF;
 
-    END;$PROCEDURE$
+    END;$FUNCTION$
     LANGUAGE plpgsql;
 
     CREATE
@@ -348,7 +348,7 @@ LANGUAGE plpgsql;
         v_constraint VARCHAR(128),
         v_constraint_sql TEXT
         )
-    RETURNS void AS $PROCEDURE$
+    RETURNS void AS $FUNCTION$
 
     BEGIN
         IF NOT EXISTS (
@@ -359,7 +359,7 @@ LANGUAGE plpgsql;
             EXECUTE 'ALTER TABLE ' || v_table || ' ADD CONSTRAINT ' || v_constraint || ' ' || v_constraint_sql;
         END IF;
 
-    END;$PROCEDURE$
+    END;$FUNCTION$
     LANGUAGE plpgsql;
 
     CREATE
@@ -367,12 +367,12 @@ LANGUAGE plpgsql;
         v_table VARCHAR(128),
         v_constraint VARCHAR(128)
         )
-    RETURNS void AS $PROCEDURE$
+    RETURNS void AS $FUNCTION$
 
     BEGIN
             EXECUTE 'ALTER TABLE ' || v_table || ' DROP CONSTRAINT IF EXISTS ' || v_constraint || ' CASCADE';
 
-    END;$PROCEDURE$
+    END;$FUNCTION$
     LANGUAGE plpgsql;
 
     --------------------------------------------------
@@ -380,19 +380,19 @@ LANGUAGE plpgsql;
     --------------------------------------------------
     CREATE
         OR replace FUNCTION CheckDBConnection ()
-    RETURNS SETOF INT IMMUTABLE AS $PROCEDURE$
+    RETURNS SETOF INT IMMUTABLE AS $FUNCTION$
 
     BEGIN
         RETURN QUERY
 
         SELECT 1;
-    END;$PROCEDURE$
+    END;$FUNCTION$
 
     LANGUAGE plpgsql;
 
     CREATE
         OR replace FUNCTION generate_drop_all_functions_syntax ()
-    RETURNS SETOF TEXT STABLE AS $PROCEDURE$
+    RETURNS SETOF TEXT STABLE AS $FUNCTION$
 
     BEGIN
         RETURN QUERY
@@ -410,13 +410,13 @@ LANGUAGE plpgsql;
                  probin NOT IN  (SELECT '$libdir/' || extname from pg_extension)
             )
         ORDER BY proname;
-    END;$PROCEDURE$
+    END;$FUNCTION$
 
     LANGUAGE plpgsql;
 
     CREATE
         OR replace FUNCTION generate_drop_all_views_syntax ()
-    RETURNS SETOF TEXT STABLE AS $PROCEDURE$
+    RETURNS SETOF TEXT STABLE AS $FUNCTION$
 
     BEGIN
         RETURN QUERY
@@ -426,13 +426,13 @@ LANGUAGE plpgsql;
         WHERE table_schema = 'public'
         AND table_name NOT ILIKE 'pg_%'
         ORDER BY table_name;
-    END;$PROCEDURE$
+    END;$FUNCTION$
 
     LANGUAGE plpgsql;
 
     CREATE
         OR replace FUNCTION generate_drop_all_tables_syntax ()
-    RETURNS SETOF TEXT STABLE AS $PROCEDURE$
+    RETURNS SETOF TEXT STABLE AS $FUNCTION$
 
     BEGIN
         RETURN QUERY
@@ -442,13 +442,13 @@ LANGUAGE plpgsql;
         WHERE table_schema = 'public'
             AND table_type = 'BASE TABLE'
         ORDER BY table_name;
-    END;$PROCEDURE$
+    END;$FUNCTION$
 
     LANGUAGE plpgsql;
 
     CREATE
         OR replace FUNCTION generate_drop_all_seq_syntax ()
-    RETURNS SETOF TEXT STABLE AS $PROCEDURE$
+    RETURNS SETOF TEXT STABLE AS $FUNCTION$
 
     BEGIN
         RETURN QUERY
@@ -457,13 +457,13 @@ LANGUAGE plpgsql;
         FROM information_schema.sequences
         WHERE sequence_schema = 'public'
         ORDER BY sequence_name;
-    END;$PROCEDURE$
+    END;$FUNCTION$
 
     LANGUAGE plpgsql;
 
     CREATE
         OR replace FUNCTION generate_drop_all_user_types_syntax ()
-    RETURNS SETOF TEXT STABLE AS $PROCEDURE$
+    RETURNS SETOF TEXT STABLE AS $FUNCTION$
 
     BEGIN
         RETURN QUERY
@@ -477,7 +477,7 @@ LANGUAGE plpgsql;
             AND c.relkind = 'c'::"char"
             AND n.nspname = 'public'
         ORDER BY c.relname::information_schema.sql_identifier;
-    END;$PROCEDURE$
+    END;$FUNCTION$
 
     LANGUAGE plpgsql;
 
@@ -486,7 +486,7 @@ LANGUAGE plpgsql;
         v_table VARCHAR(64),
         v_column VARCHAR(64)
         )
-    RETURNS INT STABLE AS $PROCEDURE$
+    RETURNS INT STABLE AS $FUNCTION$
 
     DECLARE retvalue INT;
 
@@ -503,7 +503,7 @@ LANGUAGE plpgsql;
                 );
 
         RETURN retvalue;
-    END;$PROCEDURE$
+    END;$FUNCTION$
 
     LANGUAGE plpgsql;
 
@@ -618,7 +618,7 @@ LANGUAGE plpgsql;
         v_role_id UUID,
         v_action_group_id INT
         )
-    RETURNS VOID AS $PROCEDURE$
+    RETURNS VOID AS $FUNCTION$
 
     BEGIN
         INSERT INTO roles_groups (
@@ -635,7 +635,7 @@ LANGUAGE plpgsql;
                 );
 
         RETURN;
-    END;$PROCEDURE$
+    END;$FUNCTION$
 
     LANGUAGE plpgsql;
 
@@ -875,7 +875,7 @@ CREATE OR REPLACE FUNCTION fn_db_add_column_to_object_white_list (
     v_object_name VARCHAR(128),
     v_column_name VARCHAR(128)
     )
-RETURNS void AS $PROCEDURE$
+RETURNS void AS $FUNCTION$
 BEGIN
     IF (
             NOT EXISTS (
@@ -906,13 +906,13 @@ BEGIN
 
     END;
     END IF;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
     -- Checks if a table given by its name exists in DB
     CREATE
         OR REPLACE FUNCTION fn_db_is_table_exists (v_table VARCHAR(64))
-    RETURNS boolean STABLE AS $PROCEDURE$
+    RETURNS boolean STABLE AS $FUNCTION$
 
     DECLARE retvalue boolean;
 
@@ -925,7 +925,7 @@ LANGUAGE plpgsql;
                 );
 
         RETURN retvalue;
-    END;$PROCEDURE$
+    END;$FUNCTION$
 
     LANGUAGE plpgsql;
 
@@ -940,7 +940,7 @@ LANGUAGE plpgsql;
         v_where_predicate TEXT,
         v_unique boolean
         )
-    RETURNS void AS $PROCEDURE$
+    RETURNS void AS $FUNCTION$
 
     DECLARE v_sql TEXT;
             unique_modifier varchar(6);
@@ -957,27 +957,27 @@ LANGUAGE plpgsql;
         END IF;
 
     EXECUTE v_sql;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 
 CREATE OR replace FUNCTION fn_db_drop_index (
         v_index_name VARCHAR(128)
         )
-    RETURNS void AS $PROCEDURE$
+    RETURNS void AS $FUNCTION$
 
     DECLARE v_sql TEXT;
 
     BEGIN
         v_sql := 'DROP INDEX ' || ' IF EXISTS ' || v_index_name || ';' ;
         EXECUTE v_sql;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 
 -- Unlocks a specific disk
 CREATE OR REPLACE FUNCTION fn_db_unlock_disk (v_id UUID)
-RETURNS void AS $PROCEDURE$
+RETURNS void AS $FUNCTION$
 DECLARE OK INT;
 
 LOCKED INT;
@@ -991,12 +991,12 @@ BEGIN
     SET imagestatus = OK
     WHERE imagestatus = LOCKED
         AND image_group_id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Unlocks a specific snapshot
 CREATE OR REPLACE FUNCTION fn_db_unlock_snapshot (v_id UUID)
-RETURNS void AS $PROCEDURE$
+RETURNS void AS $FUNCTION$
 DECLARE OK VARCHAR;
 
 LOCKED VARCHAR;
@@ -1010,7 +1010,7 @@ BEGIN
     SET status = OK
     WHERE status = LOCKED
         AND snapshot_id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Unlocks all VM/Template disks
@@ -1019,7 +1019,7 @@ CREATE OR REPLACE FUNCTION fn_db_unlock_entity (
     v_name VARCHAR(255),
     v_recursive boolean
     )
-RETURNS void AS $PROCEDURE$
+RETURNS void AS $FUNCTION$
 DECLARE DOWN INT;
 
 OK INT;
@@ -1093,12 +1093,12 @@ IF (v_recursive) THEN
         AND vm_id = v_id;
 END IF;
 
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Unlocks all locked entities
 CREATE OR REPLACE FUNCTION fn_db_unlock_all ()
-RETURNS void AS $PROCEDURE$
+RETURNS void AS $FUNCTION$
 DECLARE DOWN INT;
 
 OK INT;
@@ -1147,7 +1147,7 @@ BEGIN
     UPDATE snapshots
     SET status = SNAPSHOT_OK
     WHERE status ilike SNAPSHOT_LOCKED;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 /* Displays DC id , DC name, SPM Host id , SPM Host name and number of async tasks awaiting.
@@ -1176,7 +1176,7 @@ CREATE TYPE async_tasks_info_rs AS (
         );
 
 CREATE OR REPLACE FUNCTION fn_db_get_async_tasks ()
-RETURNS SETOF async_tasks_info_rs STABLE AS $PROCEDURE$
+RETURNS SETOF async_tasks_info_rs STABLE AS $FUNCTION$
 DECLARE v_record async_tasks_info_rs;
 
 -- selects storage_pool_id uuid found in async_tasks
@@ -1225,7 +1225,7 @@ CLOSE v_tasks_cursor;
 
 -- return full set of generated records
 RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Remove a value from a CSV string in vdc_options
@@ -1234,7 +1234,7 @@ CREATE OR REPLACE FUNCTION fn_db_remove_csv_config_value (
     v_value VARCHAR(4000),
     v_version VARCHAR(40)
     )
-RETURNS void AS $PROCEDURE$
+RETURNS void AS $FUNCTION$
 DECLARE v VARCHAR [];
 
 e VARCHAR;
@@ -1269,7 +1269,7 @@ LOOP;
     SET option_value = v_result
     WHERE option_name = v_option_name
         AND version = v_version;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- sets the v_val value for v_option_name in vdc_options for all versions before and up to v_version including v_version
@@ -1278,7 +1278,7 @@ CREATE OR REPLACE FUNCTION fn_db_remove_uuid_from_csv (
     v_csv_text TEXT,
     v_uuid uuid
     )
-RETURNS TEXT STABLE AS $PROCEDURE$
+RETURNS TEXT STABLE AS $FUNCTION$
 DECLARE v uuid [];
 
 e uuid;
@@ -1308,18 +1308,18 @@ BEGIN
     IF (v_result = '') THEN v_result := NULL;
     END IF;
     RETURN v_result;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION fn_db_get_versions()
-RETURNS VARCHAR []  AS $PROCEDURE$
+RETURNS VARCHAR []  AS $FUNCTION$
 
 BEGIN
 
 RETURN
 ARRAY ['4.2', '4.3', '4.4', '4.5', '4.6', '4.7'];
 
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- please note that versions must be insync with  org.ovirt.engine.core.compat.Version
@@ -1328,7 +1328,7 @@ CREATE OR REPLACE FUNCTION fn_db_add_config_value_for_versions_up_to (
     v_val VARCHAR(4000),
     v_version VARCHAR(40)
     )
-RETURNS void AS $PROCEDURE$
+RETURNS void AS $FUNCTION$
 DECLARE i INT;
 
 arr VARCHAR [] := fn_db_get_versions();
@@ -1338,7 +1338,7 @@ BEGIN
         EXIT WHEN arr [i] = v_version;
     END LOOP;
 
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION fn_db_update_config_value_for_versions_from_up_to (
@@ -1347,7 +1347,7 @@ CREATE OR REPLACE FUNCTION fn_db_update_config_value_for_versions_from_up_to (
     v_from_version VARCHAR(40),
     v_to_version VARCHAR(40)
     )
-RETURNS void AS $PROCEDURE$
+RETURNS void AS $FUNCTION$
 DECLARE i INT;
 
 arr VARCHAR [] := fn_db_get_versions();
@@ -1365,17 +1365,17 @@ BEGIN
         EXIT WHEN arr [i] = v_to_version;
     END LOOP;
 
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION fn_db_varchar_to_jsonb(v_text VARCHAR, v_default_value JSONB)
-RETURNS JSONB IMMUTABLE AS $PROCEDURE$
+RETURNS JSONB IMMUTABLE AS $FUNCTION$
 BEGIN
     RETURN v_text::jsonb;
     EXCEPTION
         WHEN SQLSTATE '22P02' THEN -- '22P02' stands for 'invalid_text_representation', 'invalid input syntax for type json' in this case
             RETURN v_default_value;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- If value in v_table.v_column is jsonb compatible it's left untouched, otherwise it's replaced by v_default_value
@@ -1385,7 +1385,7 @@ CREATE OR REPLACE FUNCTION fn_db_update_column_to_jsonb_compatible_values(
     v_column VARCHAR,
     v_default_value JSONB
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 DECLARE
     default_value_string VARCHAR;
 BEGIN
@@ -1407,7 +1407,7 @@ BEGIN
             EXECUTE 'UPDATE ' || v_table || ' SET ' || v_column || ' = (SELECT fn_db_varchar_to_jsonb(' || v_column || ', ' || default_value_string || '))';
         END;
     END IF;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Turns all given table columns to default to NULL an adjust existing values
@@ -1416,7 +1416,7 @@ CREATE OR REPLACE FUNCTION fn_db_change_table_string_columns_to_empty_string (
     v_table VARCHAR(128),
     v_column VARCHAR[]
     )
-RETURNS void AS $PROCEDURE$
+RETURNS void AS $FUNCTION$
 DECLARE
     v_sql TEXT;
     v_num integer := array_length(v_column, 1);
@@ -1445,5 +1445,5 @@ BEGIN
         END IF;
     v_index = v_index + 1;
     END LOOP;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;

--- a/packaging/dbscripts/cpu_profiles_sp.sql
+++ b/packaging/dbscripts/cpu_profiles_sp.sql
@@ -4,14 +4,14 @@
 --  Cpu Profiles
 ----------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION GetCpuProfileByCpuProfileId (v_id UUID)
-RETURNS SETOF cpu_profiles STABLE AS $PROCEDURE$
+RETURNS SETOF cpu_profiles STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM cpu_profiles
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION InsertCpuProfile (
@@ -21,7 +21,7 @@ CREATE OR REPLACE FUNCTION InsertCpuProfile (
     v_qos_id UUID,
     v_description TEXT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO cpu_profiles (
         id,
@@ -37,7 +37,7 @@ BEGIN
         v_qos_id,
         v_description
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateCpuProfile (
@@ -47,7 +47,7 @@ CREATE OR REPLACE FUNCTION UpdateCpuProfile (
     v_qos_id UUID,
     v_description TEXT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE cpu_profiles
     SET id = v_id,
@@ -57,11 +57,11 @@ BEGIN
         description = v_description,
         _update_date = LOCALTIMESTAMP
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteCpuProfile (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 DECLARE v_val UUID;
 
 BEGIN
@@ -71,17 +71,17 @@ BEGIN
 
     -- Delete the cpu profiles permissions
     PERFORM DeletePermissionsByEntityId(v_id);
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromCpuProfiles ()
-RETURNS SETOF cpu_profiles STABLE AS $PROCEDURE$
+RETURNS SETOF cpu_profiles STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM cpu_profiles;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetCpuProfilesByClusterId (
@@ -90,7 +90,7 @@ CREATE OR REPLACE FUNCTION GetCpuProfilesByClusterId (
     v_is_filtered boolean,
     v_action_group_id INTEGER
     )
-RETURNS SETOF cpu_profiles STABLE AS $PROCEDURE$
+RETURNS SETOF cpu_profiles STABLE AS $FUNCTION$
 BEGIN
     IF v_is_filtered
     THEN
@@ -111,18 +111,18 @@ BEGIN
         WHERE cluster_id = v_cluster_id
         ORDER BY _create_date;
     END IF;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetCpuProfilesByQosId (v_qos_id UUID)
-RETURNS SETOF cpu_profiles STABLE AS $PROCEDURE$
+RETURNS SETOF cpu_profiles STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM cpu_profiles
     WHERE qos_id = v_qos_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/create_functions.sql
+++ b/packaging/dbscripts/create_functions.sql
@@ -1033,7 +1033,7 @@ LANGUAGE plpgsql;
 -- addreses, in order to correct sorting.
 CREATE OR REPLACE FUNCTION fn_get_comparable_ip_list(TEXT)
 RETURNS inet [] IMMUTABLE STRICT
-AS $PROCEDURE$
+AS $FUNCTION$
 BEGIN
     CASE
         WHEN ($1 IS NULL)
@@ -1042,7 +1042,7 @@ BEGIN
         ELSE
             RETURN regexp_split_to_array(trim(both FROM $1), E'\\s+')::inet [];
     END CASE ;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Return csv list of dedicated hosts guids
@@ -1059,11 +1059,11 @@ LANGUAGE plpgsql;
 -- Computes number of vcpus for vm_static
 CREATE OR REPLACE FUNCTION fn_get_num_of_vcpus(vm_static)
 RETURNS INT IMMUTABLE
-AS $PROCEDURE$
+AS $FUNCTION$
 
 BEGIN
     RETURN $1. num_of_sockets * $1. cpu_per_socket * $1. threads_per_cpu;
-END;$PROCEDURE$
+END;$FUNCTION$
 
 LANGUAGE plpgsql;
 

--- a/packaging/dbscripts/custom_actions_sp.sql
+++ b/packaging/dbscripts/custom_actions_sp.sql
@@ -10,7 +10,7 @@ CREATE OR REPLACE FUNCTION Insertcustom_actions (
     v_path VARCHAR(300),
     v_tab INT,
     v_description VARCHAR(4000)
-    ) AS $PROCEDURE$
+    ) AS $FUNCTION$
 BEGIN
     INSERT INTO custom_actions (
         action_name,
@@ -26,7 +26,7 @@ BEGIN
         );
 
     v_action_id := CURRVAL('custom_actions_seq');
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Updatecustom_actions (
@@ -38,7 +38,7 @@ CREATE OR REPLACE FUNCTION Updatecustom_actions (
     )
 RETURNS VOID
     --The [custom_actions] table doesn't have a timestamp column. Optimistic concurrency logic cannot be generated
-    AS $PROCEDURE$
+    AS $FUNCTION$
 BEGIN
     UPDATE custom_actions
     SET action_name = v_action_name,
@@ -46,55 +46,55 @@ BEGIN
         tab = v_tab,
         description = v_description
     WHERE action_id = v_action_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Deletecustom_actions (v_action_id INT)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM custom_actions
     WHERE action_id = v_action_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromcustom_actions ()
-RETURNS SETOF custom_actions STABLE AS $PROCEDURE$
+RETURNS SETOF custom_actions STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM custom_actions;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Getcustom_actionsByaction_id (v_action_id INT)
-RETURNS SETOF custom_actions STABLE AS $PROCEDURE$
+RETURNS SETOF custom_actions STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM custom_actions
     WHERE action_id = v_action_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Getcustom_actionsByTab_id (v_tab INT)
-RETURNS SETOF custom_actions STABLE AS $PROCEDURE$
+RETURNS SETOF custom_actions STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM custom_actions
     WHERE tab = v_tab;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Getcustom_actionsByNameAndTab (
     v_action_name VARCHAR(50),
     v_tab INT
     )
-RETURNS SETOF custom_actions STABLE AS $PROCEDURE$
+RETURNS SETOF custom_actions STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -102,7 +102,7 @@ BEGIN
     FROM custom_actions
     WHERE tab = v_tab
         AND action_name = v_action_name;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/dbfunc-common.sh
+++ b/packaging/dbscripts/dbfunc-common.sh
@@ -185,7 +185,7 @@ _dbfunc_common_schema_upgrade() {
 		local updated=0
 		_dbfunc_common_validate_version_uniqueness
 		if [ -z "${DBFUNC_COMMON_MD5FILE}" ] || ! _dbfunc_common_is_view_or_sp_changed; then
-			dbfunc_output "upgrade script detected a change in Config, View or Stored Procedure..."
+			dbfunc_output "upgrade script detected a change in Config, View or Function..."
 			_dbfunc_common_run_pre_upgrade
 			updated=1
 		fi
@@ -284,7 +284,7 @@ Please fix numbering to interval 0$(( ${last} + 1)) to 0$(( ${last} + 10)) and r
 
 #drops views before upgrade or refresh operations
 _dbfunc_common_views_drop() {
-	# common stored procedures are executed first (for new added functions to be valid)
+	# common stored functions are executed first (for new added functions to be valid)
 	dbfunc_psql_die_v --file="${DBFUNC_COMMON_DBSCRIPTS_DIR}/common_sp.sql" > /dev/null
 	statement="$(
 		dbfunc_psql_die --command="select * from generate_drop_all_views_syntax();"
@@ -307,10 +307,10 @@ _dbfunc_common_sps_drop() {
 
 #refreshes sps
 _dbfunc_common_sps_refresh() {
-	dbfunc_output "Creating stored procedures..."
+	dbfunc_output "Creating stored functions..."
 	local file
 	find "${DBFUNC_COMMON_DBSCRIPTS_DIR}" -name '*sp.sql' | sort | while read file; do
-		dbfunc_output "Creating stored procedures from ${file}..."
+		dbfunc_output "Creating stored functions from ${file}..."
 		dbfunc_psql_die_v --file="${file}" > /dev/null
 	done || exit $?
 	dbfunc_psql_die_v --file="${DBFUNC_COMMON_DBSCRIPTS_DIR}/common_sp.sql" > /dev/null
@@ -326,7 +326,7 @@ _dbfunc_common_get_custom_user_permissions() {
 _dbfunc_common_run_pre_upgrade() {
 	#Dropping all views & sps
 	_dbfunc_common_schema_refresh_drop
-	# common stored procedures are executed first (for new added functions to be valid)
+	# common stored functions are executed first (for new added functions to be valid)
 	dbfunc_psql_die_v --file="${DBFUNC_COMMON_DBSCRIPTS_DIR}/common_sp.sql" > /dev/null
 	#update sequence numers
 	dbfunc_common_hook_sequence_numbers_update

--- a/packaging/dbscripts/disk_image_dynamic_sp.sql
+++ b/packaging/dbscripts/disk_image_dynamic_sp.sql
@@ -14,7 +14,7 @@ CREATE OR REPLACE FUNCTION Insertdisk_image_dynamic (
     v_write_latency_seconds NUMERIC(18, 9),
     v_flush_latency_seconds NUMERIC(18, 9)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO disk_image_dynamic (
         image_id,
@@ -38,7 +38,7 @@ BEGIN
         v_write_latency_seconds,
         v_flush_latency_seconds
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Updatedisk_image_dynamic (
@@ -54,7 +54,7 @@ CREATE OR REPLACE FUNCTION Updatedisk_image_dynamic (
     )
 RETURNS VOID
     --The [disk_image_dynamic] table doesn't have a timestamp column. Optimistic concurrency logic cannot be generated
-    AS $PROCEDURE$
+    AS $FUNCTION$
 BEGIN
     UPDATE disk_image_dynamic
     SET read_rate = v_read_rate,
@@ -67,7 +67,7 @@ BEGIN
         flush_latency_seconds = v_flush_latency_seconds,
         _update_date = LOCALTIMESTAMP
     WHERE image_id = v_image_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Updatedisk_image_dynamic_by_disk_id_and_vm_id (
@@ -84,7 +84,7 @@ CREATE OR REPLACE FUNCTION Updatedisk_image_dynamic_by_disk_id_and_vm_id (
     )
 RETURNS VOID
     --The [disk_image_dynamic] table doesn't have a timestamp column. Optimistic concurrency logic cannot be generated
-    AS $PROCEDURE$
+    AS $FUNCTION$
 BEGIN
     UPDATE disk_image_dynamic
     SET read_rate = v_read_rate,
@@ -109,37 +109,37 @@ BEGIN
                 AND vmd.device_id = v_image_group_id
                 AND vmd.snapshot_id IS NULL
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Deletedisk_image_dynamic (v_image_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM disk_image_dynamic
     WHERE image_id = v_image_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromdisk_image_dynamic ()
-RETURNS SETOF disk_image_dynamic STABLE AS $PROCEDURE$
+RETURNS SETOF disk_image_dynamic STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM disk_image_dynamic;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Getdisk_image_dynamicByimage_id (v_image_id UUID)
-RETURNS SETOF disk_image_dynamic STABLE AS $PROCEDURE$
+RETURNS SETOF disk_image_dynamic STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM disk_image_dynamic
     WHERE image_id = v_image_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 DROP TRIGGER
@@ -166,6 +166,6 @@ DELETE
     ON IMAGES
 FOR EACH ROW
 
-EXECUTE PROCEDURE fn_image_deleted();
+EXECUTE FUNCTION fn_image_deleted();
 
 

--- a/packaging/dbscripts/disk_images_sp.sql
+++ b/packaging/dbscripts/disk_images_sp.sql
@@ -12,12 +12,12 @@
 
 Create or replace FUNCTION GetImageByImageGuid(v_image_guid UUID)
 RETURNS SETOF vm_images_view STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
      RETURN QUERY SELECT *
      FROM vm_images_view
      WHERE image_guid = v_image_guid;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -25,7 +25,7 @@ LANGUAGE plpgsql;
 
 Create or replace FUNCTION GetAncestralImageByImageGuid(v_image_guid UUID, v_user_id UUID, v_is_filtered BOOLEAN)
 RETURNS SETOF images_storage_domain_view STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
      RETURN QUERY WITH RECURSIVE ancestor_image(image_guid, parentid) AS (
          SELECT image_guid, parentid
@@ -45,7 +45,7 @@ BEGIN
              FROM   user_disk_permissions_view
              WHERE  user_disk_permissions_view.user_id = v_user_id
              AND    user_disk_permissions_view.entity_id = i.image_group_id));
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -55,12 +55,12 @@ LANGUAGE plpgsql;
 
 Create or replace FUNCTION GetSnapshotByGuid(v_image_guid UUID)
 RETURNS SETOF images_storage_domain_view STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
      RETURN QUERY SELECT *
      FROM images_storage_domain_view images_storage_domain_view
      WHERE image_guid = v_image_guid;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -69,12 +69,12 @@ LANGUAGE plpgsql;
 
 Create or replace FUNCTION GetSnapshotsByStorageDomainId(v_storage_domain_id UUID)
 RETURNS SETOF images_storage_domain_view STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
      RETURN QUERY SELECT *
      FROM images_storage_domain_view
      WHERE storage_id = v_storage_domain_id;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -82,12 +82,12 @@ LANGUAGE plpgsql;
 
 Create or replace FUNCTION GetSnapshotByParentGuid(v_parent_guid UUID)
 RETURNS SETOF images_storage_domain_view STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
      RETURN QUERY SELECT *
      FROM images_storage_domain_view images_storage_domain_view
      WHERE ParentId = v_parent_guid;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -95,7 +95,7 @@ LANGUAGE plpgsql;
 
 Create or replace FUNCTION GetSnapshotByLeafGuid(v_image_guid UUID)
 RETURNS SETOF images_storage_domain_view STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
      RETURN QUERY WITH RECURSIVE image_list AS (
           SELECT *
@@ -110,7 +110,7 @@ BEGIN
       )
       SELECT *
       FROM image_list;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -118,31 +118,31 @@ LANGUAGE plpgsql;
 
 Create or replace FUNCTION GetVmImageByImageGuid(v_image_guid UUID)
 RETURNS SETOF vm_images_view STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
      RETURN QUERY SELECT *
      FROM vm_images_view
      WHERE image_guid = v_image_guid;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
 
 Create or replace FUNCTION GetSnapshotsByVmSnapshotId(v_vm_snapshot_id UUID)
 RETURNS SETOF images_storage_domain_view STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
      RETURN QUERY SELECT *
      FROM images_storage_domain_view images_storage_domain_view
      WHERE vm_snapshot_id = v_vm_snapshot_id;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
 
 Create or replace FUNCTION GetAttachedDiskSnapshotsToVm(v_vm_guid UUID, v_is_plugged BOOLEAN)
 RETURNS SETOF images_storage_domain_view
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
      RETURN QUERY SELECT images_storage_domain_view.*
      FROM images_storage_domain_view
@@ -150,7 +150,7 @@ BEGIN
      WHERE vm_device.vm_id = v_vm_guid AND (v_is_plugged IS NULL OR vm_device.is_plugged = v_is_plugged)
           AND vm_device.snapshot_id IS NOT NULL
           AND vm_device.snapshot_id = images_storage_domain_view.vm_snapshot_id;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -158,12 +158,12 @@ LANGUAGE plpgsql;
 
 Create or replace FUNCTION GetSnapshotsByImageGroupId(v_image_group_id UUID)
 RETURNS SETOF images_storage_domain_view STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
      RETURN QUERY SELECT *
      FROM images_storage_domain_view images_storage_domain_view
      WHERE image_group_id = v_image_group_id;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -171,30 +171,30 @@ LANGUAGE plpgsql;
 
 Create or replace FUNCTION GetDiskSnapshotForVmSnapshot(v_image_group_id UUID, v_vm_snapshot_id UUID)
 RETURNS SETOF images_storage_domain_view
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
      RETURN QUERY SELECT *
      FROM images_storage_domain_view
      WHERE image_group_id = v_image_group_id
          AND vm_snapshot_id = v_vm_snapshot_id;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
 Create or replace FUNCTION GetAllForStorageDomain(v_storage_domain_id UUID)
 RETURNS SETOF images_storage_domain_view STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
      RETURN QUERY SELECT images_storage_domain_view.*
      FROM  images_storage_domain_view
      WHERE active AND images_storage_domain_view.storage_id = v_storage_domain_id;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
 Create or replace FUNCTION GetImagesWhichHaveNoDisk(v_vm_id UUID)
 RETURNS SETOF images_storage_domain_view STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
      RETURN QUERY SELECT i.*
      FROM   images_storage_domain_view i
@@ -204,35 +204,35 @@ BEGIN
          SELECT 1
          FROM   base_disks d
          WHERE  d.disk_id = i.image_group_id);
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
 CREATE OR REPLACE FUNCTION GetAllForDiskProfiles(v_disk_profile_ids UUID[])
 RETURNS SETOF images_storage_domain_view STABLE
-AS $procedure$
+AS $FUNCTION$
 BEGIN
     RETURN QUERY SELECT images_storage_domain_view.*
         FROM images_storage_domain_view
         WHERE images_storage_domain_view.disk_profile_id = ANY(v_disk_profile_ids);
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
 CREATE OR REPLACE FUNCTION GetSnapshotsByParentsGuid(v_parent_guids uuid[])
 RETURNS SETOF images_storage_domain_view STABLE
-AS $procedure$
+AS $FUNCTION$
 BEGIN
      RETURN QUERY SELECT *
      FROM images_storage_domain_view
      WHERE parentid = ANY(v_parent_guids);
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
 CREATE OR REPLACE FUNCTION GetDiskImageByDiskAndImageIds(v_disk_id UUID, v_image_id UUID, v_user_id UUID, v_is_filtered BOOLEAN)
 RETURNS SETOF images_storage_domain_view STABLE
-AS $procedure$
+AS $FUNCTION$
 BEGIN
      RETURN QUERY SELECT *
      FROM images_storage_domain_view
@@ -243,17 +243,17 @@ BEGIN
              FROM   user_disk_permissions_view
              WHERE  user_id = v_user_id
              AND    entity_id = images_storage_domain_view.image_group_id));
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllMetadataAndMemoryDisksForStorageDomain(v_storage_domain_id UUID)
 RETURNS SETOF UUID
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
     RETURN QUERY SELECT isdv.disk_id
     FROM images_storage_domain_view isdv
     INNER JOIN snapshots s
     ON (s.memory_dump_disk_id = isdv.disk_id OR s.memory_metadata_disk_id = isdv.disk_id)
     AND isdv.storage_id = v_storage_domain_id;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;

--- a/packaging/dbscripts/disk_lun_map_sp.sql
+++ b/packaging/dbscripts/disk_lun_map_sp.sql
@@ -7,7 +7,7 @@ CREATE OR REPLACE FUNCTION InsertDiskLunMap (
     v_disk_id UUID,
     v_lun_id VARCHAR(255)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO disk_lun_map (
         disk_id,
@@ -17,37 +17,37 @@ BEGIN
         v_disk_id,
         v_lun_id
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteDiskLunMap (
     v_disk_id UUID,
     v_lun_id VARCHAR(255)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM disk_lun_map
     WHERE disk_id = v_disk_id
         AND lun_id = v_lun_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromDiskLunMaps ()
-RETURNS SETOF disk_lun_map STABLE AS $PROCEDURE$
+RETURNS SETOF disk_lun_map STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM disk_lun_map;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetDiskLunMapByDiskLunMapId (
     v_disk_id UUID,
     v_lun_id VARCHAR(255)
     )
-RETURNS SETOF disk_lun_map STABLE AS $PROCEDURE$
+RETURNS SETOF disk_lun_map STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -55,33 +55,33 @@ BEGIN
     FROM disk_lun_map
     WHERE disk_id = v_disk_id
         AND lun_id = v_lun_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetDiskLunMapByLunId (v_lun_id VARCHAR(255))
-RETURNS SETOF disk_lun_map STABLE AS $PROCEDURE$
+RETURNS SETOF disk_lun_map STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM disk_lun_map
     WHERE lun_id = v_lun_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetDiskLunMapByDiskId (v_disk_id UUID)
-RETURNS SETOF disk_lun_map STABLE AS $PROCEDURE$
+RETURNS SETOF disk_lun_map STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM disk_lun_map
     WHERE disk_id = v_disk_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetDiskLunMapsForVmsInPool (v_storage_pool_id UUID)
-RETURNS SETOF disk_lun_map STABLE AS $PROCEDURE$
+RETURNS SETOF disk_lun_map STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -98,5 +98,5 @@ BEGIN
             ON cluster.storage_pool_id = storage_pool.id
         WHERE disk_lun_map.disk_id = disk_vm_element.disk_id
             AND storage_pool.id = v_storage_pool_id);
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;

--- a/packaging/dbscripts/disk_profiles_sp.sql
+++ b/packaging/dbscripts/disk_profiles_sp.sql
@@ -4,14 +4,14 @@
 --  Disk Profiles
 ----------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION GetDiskProfileByDiskProfileId (v_id UUID)
-RETURNS SETOF disk_profiles STABLE AS $PROCEDURE$
+RETURNS SETOF disk_profiles STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM disk_profiles
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION InsertDiskProfile (
@@ -21,7 +21,7 @@ CREATE OR REPLACE FUNCTION InsertDiskProfile (
     v_qos_id UUID,
     v_description TEXT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO disk_profiles (
         id,
@@ -37,7 +37,7 @@ BEGIN
         v_qos_id,
         v_description
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateDiskProfile (
@@ -47,7 +47,7 @@ CREATE OR REPLACE FUNCTION UpdateDiskProfile (
     v_qos_id UUID,
     v_description TEXT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE disk_profiles
     SET id = v_id,
@@ -57,11 +57,11 @@ BEGIN
         description = v_description,
         _update_date = LOCALTIMESTAMP
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteDiskProfile (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 DECLARE v_val UUID;
 
 BEGIN
@@ -71,17 +71,17 @@ BEGIN
 
     -- Delete the disk profiles permissions
     PERFORM DeletePermissionsByEntityId(v_id);
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromDiskProfiles ()
-RETURNS SETOF disk_profiles STABLE AS $PROCEDURE$
+RETURNS SETOF disk_profiles STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM disk_profiles;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetDiskProfilesByStorageDomainId (
@@ -89,7 +89,7 @@ CREATE OR REPLACE FUNCTION GetDiskProfilesByStorageDomainId (
     v_user_id UUID,
     v_is_filtered boolean
     )
-RETURNS SETOF disk_profiles STABLE AS $PROCEDURE$
+RETURNS SETOF disk_profiles STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -105,27 +105,27 @@ BEGIN
                     AND entity_id = disk_profiles.id
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION nullifyQosForStorageDomain (v_storage_domain_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE disk_profiles
     SET qos_id = NULL
     WHERE storage_domain_id = v_storage_domain_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetDiskProfilesByQosId (v_qos_id UUID)
-RETURNS SETOF disk_profiles STABLE AS $PROCEDURE$
+RETURNS SETOF disk_profiles STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM disk_profiles
     WHERE qos_id = v_qos_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/disk_vm_element_sp.sql
+++ b/packaging/dbscripts/disk_vm_element_sp.sql
@@ -6,7 +6,7 @@ Create or replace FUNCTION InsertDiskVmElement(
     v_disk_interface VARCHAR(32),
     v_is_using_scsi_reservation boolean)
 RETURNS VOID
-AS $procedure$
+AS $FUNCTION$
 BEGIN
     INSERT INTO disk_vm_element (
         disk_id,
@@ -22,7 +22,7 @@ BEGIN
         v_pass_discard,
         v_disk_interface,
         v_is_using_scsi_reservation);
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -34,7 +34,7 @@ CREATE OR REPLACE FUNCTION UpdateDiskVmElement(
     v_pass_discard boolean,
     v_disk_interface VARCHAR(32),
     v_is_using_scsi_reservation boolean)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE disk_vm_element
     SET disk_id = v_disk_id,
@@ -45,7 +45,7 @@ BEGIN
         is_using_scsi_reservation = v_is_using_scsi_reservation
     WHERE disk_id = v_disk_id
         AND vm_id = v_vm_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -53,24 +53,24 @@ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION DeleteDiskVmElement(
     v_disk_id UUID,
     v_vm_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM disk_vm_element
     WHERE disk_id = v_disk_id
         AND vm_id = v_vm_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 
 
 CREATE OR REPLACE FUNCTION GetAllFromDiskVmElements()
-RETURNS SETOF disk_vm_element_extended STABLE AS $PROCEDURE$
+RETURNS SETOF disk_vm_element_extended STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
     SELECT *
     FROM disk_vm_element_extended;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -80,7 +80,7 @@ CREATE OR REPLACE FUNCTION GetDiskVmElementByDiskVmElementId(
     v_vm_id UUID,
     v_user_id UUID,
     v_is_filtered boolean)
-RETURNS SETOF disk_vm_element_extended STABLE AS $PROCEDURE$
+RETURNS SETOF disk_vm_element_extended STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
     SELECT *
@@ -96,20 +96,20 @@ BEGIN
                     AND entity_id = v_vm_id
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 
 
 CREATE OR REPLACE FUNCTION GetDiskVmElementsByDiskVmElementsIds(
     v_disks_ids UUID[])
-RETURNS SETOF disk_vm_element_extended STABLE AS $PROCEDURE$
+RETURNS SETOF disk_vm_element_extended STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
     SELECT *
     FROM disk_vm_element_extended
     WHERE disk_id = ANY(v_disks_ids);
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -118,7 +118,7 @@ CREATE OR REPLACE FUNCTION GetDiskVmElementsForVm(
     v_vm_id UUID,
     v_user_id UUID,
     v_is_filtered boolean)
-RETURNS SETOF disk_vm_element_extended STABLE AS $PROCEDURE$
+RETURNS SETOF disk_vm_element_extended STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
     SELECT *
@@ -133,18 +133,18 @@ BEGIN
                     AND entity_id = v_vm_id
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 
 
 CREATE OR REPLACE FUNCTION GetDiskVmElementsPluggedToVm(
     v_vm_id UUID)
-RETURNS SETOF disk_vm_element_extended STABLE AS $PROCEDURE$
+RETURNS SETOF disk_vm_element_extended STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
     SELECT *
     FROM disk_vm_element_extended
     WHERE vm_id = v_vm_id AND is_plugged = true;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;

--- a/packaging/dbscripts/dwh_history_timekeeping_sp.sql
+++ b/packaging/dbscripts/dwh_history_timekeeping_sp.sql
@@ -8,24 +8,24 @@ CREATE OR REPLACE FUNCTION UpdateDwhHistoryTimekeeping (
     v_var_value VARCHAR(255),
     v_var_datetime TIMESTAMP WITH TIME ZONE
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE dwh_history_timekeeping
     SET var_value = v_var_value,
         var_datetime = v_var_datetime
     WHERE var_name = v_var_name;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetDwhHistoryTimekeepingByVarName (v_var_name VARCHAR(50))
-RETURNS SETOF dwh_history_timekeeping STABLE AS $PROCEDURE$
+RETURNS SETOF dwh_history_timekeeping STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM dwh_history_timekeeping
     WHERE var_name = v_var_name;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/dwh_translation_tables_sp.sql
+++ b/packaging/dbscripts/dwh_translation_tables_sp.sql
@@ -1,17 +1,17 @@
 
 
 CREATE OR REPLACE FUNCTION clear_osinfo ()
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     TRUNCATE dwh_osinfo;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION insert_osinfo (
     v_os_id INT,
     v_os_name VARCHAR(255)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO dwh_osinfo (
         os_id,
@@ -25,7 +25,7 @@ BEGIN
     UPDATE dwh_history_timekeeping
     SET var_datetime = now()
     WHERE var_name = 'lastOsinfoUpdate';
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/engine_backup_log_sp.sql
+++ b/packaging/dbscripts/engine_backup_log_sp.sql
@@ -14,7 +14,7 @@ CREATE OR REPLACE FUNCTION LogEngineBackupEvent (
     v_fqdn VARCHAR(255),
     v_log_path TEXT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     IF v_status = - 1 THEN
         INSERT INTO engine_backup_log (
@@ -104,11 +104,11 @@ BEGIN
         );
     END IF;
 
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetLastSuccessfulEngineBackup (v_scope VARCHAR(64))
-RETURNS SETOF engine_backup_log STABLE AS $PROCEDURE$
+RETURNS SETOF engine_backup_log STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -118,7 +118,7 @@ BEGIN
         AND is_passed
     ORDER BY scope,
         done_at DESC LIMIT 1;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/engine_sessions_sp.sql
+++ b/packaging/dbscripts/engine_sessions_sp.sql
@@ -13,7 +13,7 @@ CREATE OR REPLACE FUNCTION InsertEngineSession (
     v_group_ids VARCHAR(2048),
     v_role_ids VARCHAR(2048)
     )
-RETURNS INT AS $PROCEDURE$
+RETURNS INT AS $FUNCTION$
 BEGIN
     INSERT INTO engine_sessions (
         engine_session_id,
@@ -35,33 +35,33 @@ BEGIN
         );
 
     v_id := CURRVAL('engine_session_seq');
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetEngineSession (v_id INT)
-RETURNS SETOF engine_sessions STABLE AS $PROCEDURE$
+RETURNS SETOF engine_sessions STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM engine_sessions
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetEngineSessionBySessionId (v_engine_session_id TEXT)
-RETURNS SETOF engine_sessions STABLE AS $PROCEDURE$
+RETURNS SETOF engine_sessions STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM engine_sessions
     WHERE engine_session_id = v_engine_session_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteEngineSession (v_id INT)
-RETURNS INT AS $PROCEDURE$
+RETURNS INT AS $FUNCTION$
 DECLARE deleted_rows INT;
 
 BEGIN
@@ -72,11 +72,11 @@ BEGIN
     GET DIAGNOSTICS deleted_rows = ROW_COUNT;
 
     RETURN deleted_rows;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteAllFromEngineSessions ()
-RETURNS INT AS $PROCEDURE$
+RETURNS INT AS $FUNCTION$
 DECLARE deleted_rows INT;
 
 BEGIN
@@ -86,7 +86,7 @@ BEGIN
     GET DIAGNOSTICS deleted_rows = ROW_COUNT;
 
     RETURN deleted_rows;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/event_sp.sql
+++ b/packaging/dbscripts/event_sp.sql
@@ -12,7 +12,7 @@ CREATE OR REPLACE FUNCTION insertevent_notification_hist (
     v_sent_at TIMESTAMP WITH TIME ZONE,
     v_status BOOLEAN
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO event_notification_hist (
         audit_log_id,
@@ -30,7 +30,7 @@ BEGIN
         v_sent_at,
         v_status
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ----------------------------------------------------------------
@@ -43,7 +43,7 @@ CREATE OR REPLACE FUNCTION Insertevent_subscriber (
     v_subscriber_id UUID,
     v_tag_name VARCHAR(50)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     IF NOT EXISTS (
             SELECT *
@@ -69,22 +69,22 @@ BEGIN
             );
     END IF;
 
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Getevent_subscriberBysubscriber_id (v_subscriber_id UUID)
-RETURNS SETOF event_subscriber STABLE AS $PROCEDURE$
+RETURNS SETOF event_subscriber STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM event_subscriber
     WHERE subscriber_id = v_subscriber_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Getevent_subscription (v_subscriber_id UUID, v_event_up_name VARCHAR(100))
-RETURNS SETOF event_subscriber STABLE AS $PROCEDURE$
+RETURNS SETOF event_subscriber STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -92,7 +92,7 @@ BEGIN
     FROM event_subscriber
     WHERE subscriber_id = v_subscriber_id
         AND event_up_name = v_event_up_name;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Deleteevent_subscriber (
@@ -101,7 +101,7 @@ CREATE OR REPLACE FUNCTION Deleteevent_subscriber (
     v_subscriber_id UUID,
     v_tag_name VARCHAR(50)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     IF (v_tag_name IS NULL) THEN
         DELETE
@@ -118,19 +118,19 @@ BEGIN
             AND tag_name = v_tag_name;
     END IF;
 
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ----------------------------------------------------------------
 -- [dbo].[event_notification_hist] Table
 ----------------------------------------------------------------
 CREATE OR REPLACE FUNCTION Deleteevent_notification_hist (v_sent_at TIMESTAMP)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM event_notification_hist
     WHERE sent_at < v_sent_at;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/external_variable_sp.sql
+++ b/packaging/dbscripts/external_variable_sp.sql
@@ -7,7 +7,7 @@ CREATE OR REPLACE FUNCTION InsertExternalVariable (
     v_var_name VARCHAR(100),
     v_var_value VARCHAR(4000)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO external_variable (
         var_name,
@@ -17,14 +17,14 @@ BEGIN
         v_var_name,
         v_var_value
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateExternalVariable (
     v_var_name VARCHAR(100),
     v_var_value VARCHAR(4000)
     )
-RETURNS BOOLEAN AS $PROCEDURE$
+RETURNS BOOLEAN AS $FUNCTION$
 BEGIN
     UPDATE external_variable
     SET var_value = v_var_value,
@@ -32,7 +32,7 @@ BEGIN
     WHERE var_name = v_var_name;
 
     RETURN found;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- UpsertExternalVariable is used in fence_kdump listener
@@ -40,7 +40,7 @@ CREATE OR REPLACE FUNCTION UpsertExternalVariable (
     v_var_name VARCHAR(100),
     v_var_value VARCHAR(4000)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 DECLARE record_found BOOLEAN;
 
 BEGIN
@@ -50,22 +50,22 @@ BEGIN
     IF NOT record_found THEN
         PERFORM InsertExternalVariable(v_var_name, v_var_value);
     END IF;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteExternalVariable (v_var_name VARCHAR(100))
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 
 BEGIN
     DELETE
     FROM external_variable
     WHERE var_name = v_var_name;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetExternalVariableByName (v_var_name VARCHAR(100))
 RETURNS SETOF external_variable STABLE
-AS $PROCEDURE$
+AS $FUNCTION$
 
 BEGIN
     RETURN QUERY
@@ -73,7 +73,7 @@ BEGIN
     SELECT external_variable.*
     FROM external_variable
     WHERE var_name = v_var_name;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/fence_agents_sp.sql
+++ b/packaging/dbscripts/fence_agents_sp.sql
@@ -1,43 +1,43 @@
 
 
 CREATE OR REPLACE FUNCTION GetFenceAgentsByVdsId (v_vds_guid UUID)
-RETURNS SETOF fence_agents STABLE AS $PROCEDURE$
+RETURNS SETOF fence_agents STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT fence_agents.*
     FROM fence_agents
     WHERE vds_id = v_vds_guid;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetFenceAgentById (v_guid UUID)
-RETURNS SETOF fence_agents STABLE AS $PROCEDURE$
+RETURNS SETOF fence_agents STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT fence_agents.*
     FROM fence_agents
     WHERE id = v_guid;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteFenceAgent (v_guid UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM fence_agents
     WHERE id = v_guid;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteFenceAgentsByVdsId (v_vds_guid UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM fence_agents
     WHERE vds_id = v_vds_guid;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateFenceAgent (
@@ -52,7 +52,7 @@ CREATE OR REPLACE FUNCTION UpdateFenceAgent (
     v_encrypt_options BOOLEAN,
     v_port INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE fence_agents
     SET vds_id = v_vds_id,
@@ -65,7 +65,7 @@ BEGIN
         options = v_options,
         encrypt_options = v_encrypt_options
     WHERE id = v_guid;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION InsertFenceAgent (
@@ -80,7 +80,7 @@ CREATE OR REPLACE FUNCTION InsertFenceAgent (
     v_encrypt_options BOOLEAN,
     v_port INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO fence_agents (
         id,
@@ -106,7 +106,7 @@ BEGIN
         v_encrypt_options,
         v_port
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/gluster_georep_sp.sql
+++ b/packaging/dbscripts/gluster_georep_sp.sql
@@ -1,7 +1,7 @@
 
 
 /* ----------------------------------------------------------------
- Stored procedures for database operations on Gluster Geo-replication
+ Stored FUNCTIONs for database operations on Gluster Geo-replication
  related tables:
       - gluster_georep_session
       - gluster_georep_config
@@ -18,7 +18,7 @@ CREATE OR REPLACE FUNCTION InsertGlusterGeoRepSession (
     v_status VARCHAR(50),
     v_user_name VARCHAR(255)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO gluster_georep_session (
         session_id,
@@ -42,7 +42,7 @@ BEGIN
         v_status,
         v_user_name
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION InsertGlusterGeoRepSessionConfig (
@@ -50,7 +50,7 @@ CREATE OR REPLACE FUNCTION InsertGlusterGeoRepSessionConfig (
     v_config_key VARCHAR(50),
     v_config_value VARCHAR(50)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO gluster_georep_config (
         session_id,
@@ -62,7 +62,7 @@ BEGIN
         v_config_key,
         v_config_value
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION InsertGlusterGeoRepSessionDetail (
@@ -82,7 +82,7 @@ CREATE OR REPLACE FUNCTION InsertGlusterGeoRepSessionDetail (
     v_checkpoint_completed_time TIMESTAMP,
     v_is_checkpoint_completed BOOLEAN
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO gluster_georep_session_details (
         session_id,
@@ -118,7 +118,7 @@ BEGIN
         v_checkpoint_completed_time,
         v_is_checkpoint_completed
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateGlusterGeoRepSessionDetail (
@@ -138,7 +138,7 @@ CREATE OR REPLACE FUNCTION UpdateGlusterGeoRepSessionDetail (
     v_checkpoint_completed_time TIMESTAMP,
     v_is_checkpoint_completed BOOLEAN
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE gluster_georep_session_details
     SET slave_host_name = v_slave_host_name,
@@ -157,7 +157,7 @@ BEGIN
         _update_date = LOCALTIMESTAMP
     WHERE session_id = v_session_id
         AND master_brick_id = v_master_brick_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateGlusterGeoRepSessionConfig (
@@ -165,29 +165,29 @@ CREATE OR REPLACE FUNCTION UpdateGlusterGeoRepSessionConfig (
     v_config_key VARCHAR(50),
     v_config_value VARCHAR(50)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE gluster_georep_config
     SET config_value = v_config_value,
         _update_date = LOCALTIMESTAMP
     WHERE session_id = v_session_id
         AND config_key = v_config_key;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlusterGeoRepSessionById (v_session_id UUID)
-RETURNS SETOF gluster_georep_sessions_view STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_georep_sessions_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM gluster_georep_sessions_view
     WHERE session_id = v_session_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlusterGeoRepSessionsByVolumeId (v_master_volume_id UUID)
-RETURNS SETOF gluster_georep_sessions_view STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_georep_sessions_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -195,11 +195,11 @@ BEGIN
     FROM gluster_georep_sessions_view
     WHERE master_volume_id = v_master_volume_id
     ORDER BY slave_volume_name ASC;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlusterGeoRepSessionsByClusterId (v_cluster_id UUID)
-RETURNS SETOF gluster_georep_sessions_view STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_georep_sessions_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -207,18 +207,18 @@ BEGIN
     FROM gluster_georep_sessions_view
     WHERE cluster_id = v_cluster_id
     ORDER BY slave_volume_name ASC;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlusterGeoRepSessionByKey (v_session_key VARCHAR(150))
-RETURNS SETOF gluster_georep_sessions_view STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_georep_sessions_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM gluster_georep_sessions_view
     WHERE session_key = v_session_key;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlusterGeoRepSessionBySlaveHostAndVolume (
@@ -226,7 +226,7 @@ CREATE OR REPLACE FUNCTION GetGlusterGeoRepSessionBySlaveHostAndVolume (
     v_slave_host_uuid UUID,
     v_slave_volume_name VARCHAR(150)
     )
-RETURNS SETOF gluster_georep_sessions_view STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_georep_sessions_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -235,7 +235,7 @@ BEGIN
     WHERE master_volume_id = v_master_volume_id
         AND slave_host_uuid = v_slave_host_uuid
         AND slave_volume_name = v_slave_volume_name;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlusterGeoRepSessionBySlaveHostNameAndVolume (
@@ -243,7 +243,7 @@ CREATE OR REPLACE FUNCTION GetGlusterGeoRepSessionBySlaveHostNameAndVolume (
     v_slave_host_name VARCHAR(150),
     v_slave_volume_name VARCHAR(150)
     )
-RETURNS SETOF gluster_georep_sessions_view STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_georep_sessions_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -252,7 +252,7 @@ BEGIN
     WHERE master_volume_id = v_master_volume_id
         AND slave_host_name = v_slave_host_name
         AND slave_volume_name = v_slave_volume_name;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateGlusterGeoRepSession (
@@ -261,7 +261,7 @@ CREATE OR REPLACE FUNCTION UpdateGlusterGeoRepSession (
     v_slave_host_uuid UUID,
     v_slave_volume_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE gluster_georep_session
     SET status = v_status,
@@ -269,11 +269,11 @@ BEGIN
         slave_volume_id = v_slave_volume_id,
         _update_date = LOCALTIMESTAMP
     WHERE session_id = v_session_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlusterGeoRepSessionDetails (v_session_id UUID)
-RETURNS SETOF gluster_georep_session_details STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_georep_session_details STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -281,14 +281,14 @@ BEGIN
     FROM gluster_georep_session_details
     WHERE session_id = v_session_id
     ORDER BY slave_host_name ASC;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlusterGeoRepSessionDetailsForBrick (
     v_session_id UUID,
     v_master_brick_id UUID
     )
-RETURNS SETOF gluster_georep_session_details STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_georep_session_details STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -296,11 +296,11 @@ BEGIN
     FROM gluster_georep_session_details
     WHERE session_id = v_session_id
         AND master_brick_id = v_master_brick_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlusterGeoRepSessionConfig (v_session_id UUID)
-RETURNS SETOF gluster_geo_rep_config_view STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_geo_rep_config_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -308,11 +308,11 @@ BEGIN
     FROM gluster_geo_rep_config_view
     WHERE session_id = v_session_id
     ORDER BY config_key ASC;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlusterGeoRepSessionUnSetConfig (v_session_id UUID)
-RETURNS SETOF gluster_config_master STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_config_master STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -324,14 +324,14 @@ BEGIN
             FROM gluster_georep_config
             WHERE gluster_georep_config.session_id = v_session_id
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlusterGeoRepSessionConfigByKey (
     v_session_id UUID,
     v_config_key VARCHAR(50)
     )
-RETURNS SETOF gluster_geo_rep_config_view STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_geo_rep_config_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -339,37 +339,37 @@ BEGIN
     FROM gluster_geo_rep_config_view
     WHERE session_id = v_session_id
         AND config_key = v_config_key;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllGlusterGeoRepSessions ()
-RETURNS SETOF gluster_georep_sessions_view STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_georep_sessions_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM gluster_georep_sessions_view;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteGlusterGeoRepSession (v_session_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM gluster_georep_session
     WHERE session_id = v_session_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGeoRepSessionBySlaveVolume (v_slave_volume_id UUID)
-RETURNS SETOF gluster_georep_sessions_view STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_georep_sessions_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM gluster_georep_sessions_view
     WHERE slave_volume_id = v_slave_volume_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/gluster_global_volume_options_sp.sql
+++ b/packaging/dbscripts/gluster_global_volume_options_sp.sql
@@ -5,7 +5,7 @@ CREATE OR REPLACE FUNCTION InsertGlusterGlobalVolumeOption (
     v_option_key VARCHAR(8192),
     v_option_val VARCHAR(8192)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO gluster_global_volume_options (
         id,
@@ -19,18 +19,18 @@ BEGIN
         v_option_key,
         v_option_val
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlobalOptionsByGlusterClusterGuid (v_cluster_id UUID)
-RETURNS SETOF gluster_global_volume_options STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_global_volume_options STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM gluster_global_volume_options
     WHERE cluster_id = v_cluster_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateGlusterGlobalVolumeOption (
@@ -38,11 +38,11 @@ CREATE OR REPLACE FUNCTION UpdateGlusterGlobalVolumeOption (
     v_option_key VARCHAR(8192),
     v_option_val VARCHAR(8192)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE gluster_global_volume_options
     SET option_val = v_option_val
     WHERE cluster_id = v_cluster_id
         AND option_key = v_option_key;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;

--- a/packaging/dbscripts/gluster_hooks_sp.sql
+++ b/packaging/dbscripts/gluster_hooks_sp.sql
@@ -1,7 +1,7 @@
 
 
 /* ----------------------------------------------------------------
- Stored procedures for database operations on Gluster Hooks
+ Stored FUNCTIONs for database operations on Gluster Hooks
  related tables:
       - gluster_hooks
       - gluster_server_hooks
@@ -18,7 +18,7 @@ CREATE OR REPLACE FUNCTION InsertGlusterHook (
     v_content TEXT,
     v_conflict_status INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO gluster_hooks (
         id,
@@ -44,14 +44,14 @@ BEGIN
         v_content,
         v_conflict_status
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlusterHookById (
     v_id UUID,
     v_includeContent BOOLEAN = false
     )
-RETURNS SETOF gluster_hooks STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_hooks STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -73,22 +73,22 @@ BEGIN
         _update_date
     FROM gluster_hooks
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlusterHookContentById (v_id UUID)
-RETURNS SETOF TEXT STABLE AS $PROCEDURE$
+RETURNS SETOF TEXT STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT content
     FROM gluster_hooks
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlusterHooksByClusterId (v_cluster_id UUID)
-RETURNS SETOF gluster_hooks STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_hooks STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -108,18 +108,18 @@ BEGIN
     WHERE cluster_id = v_cluster_id
     ORDER BY gluster_command ASC,
         stage ASC;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlusterServerHooksById (v_id UUID)
-RETURNS SETOF gluster_server_hooks_view STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_server_hooks_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM gluster_server_hooks_view
     WHERE hook_id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlusterHook (
@@ -129,7 +129,7 @@ CREATE OR REPLACE FUNCTION GetGlusterHook (
     v_name VARCHAR(1000),
     v_includeContent BOOLEAN = false
     )
-RETURNS SETOF gluster_hooks STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_hooks STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -154,16 +154,16 @@ BEGIN
         AND gluster_command = v_gluster_command
         AND stage = v_stage
         AND name = v_name;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteGlusterHookById (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM gluster_hooks
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteGlusterHook (
@@ -172,7 +172,7 @@ CREATE OR REPLACE FUNCTION DeleteGlusterHook (
     v_stage VARCHAR(100),
     v_name VARCHAR(1000)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM gluster_hooks
@@ -180,20 +180,20 @@ BEGIN
         AND gluster_command = v_gluster_command
         AND stage = v_stage
         AND name = v_name;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteAllGlusterHooks (v_cluster_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM gluster_hooks
     WHERE cluster_id = v_cluster_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteGlusterHooksByIds (v_ids TEXT)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM gluster_hooks
@@ -201,33 +201,33 @@ BEGIN
             SELECT *
             FROM fnSplitterUuid(v_ids)
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateGlusterHookConflictStatus (
     v_id UUID,
     v_conflict_status INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE gluster_hooks
     SET conflict_status = v_conflict_status,
         _update_date = LOCALTIMESTAMP
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateGlusterHookContentType (
     v_id UUID,
     v_content_type VARCHAR(100)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE gluster_hooks
     SET content_type = v_content_type,
         _update_date = LOCALTIMESTAMP
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateGlusterHookContent (
@@ -235,14 +235,14 @@ CREATE OR REPLACE FUNCTION UpdateGlusterHookContent (
     v_checksum VARCHAR(256),
     v_content TEXT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE gluster_hooks
     SET checksum = v_checksum,
         content = v_content,
         _update_date = LOCALTIMESTAMP
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateGlusterHook (
@@ -253,7 +253,7 @@ CREATE OR REPLACE FUNCTION UpdateGlusterHook (
     v_content TEXT,
     v_conflict_status INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE gluster_hooks
     SET hook_status = v_hook_status,
@@ -263,20 +263,20 @@ BEGIN
         conflict_status = v_conflict_status,
         _update_date = LOCALTIMESTAMP
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateGlusterHookStatus (
     v_id UUID,
     v_hook_status VARCHAR(50)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE gluster_hooks
     SET hook_status = v_hook_status,
         _update_date = LOCALTIMESTAMP
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION InsertGlusterServerHook (
@@ -286,7 +286,7 @@ CREATE OR REPLACE FUNCTION InsertGlusterServerHook (
     v_content_type VARCHAR(50),
     v_checksum VARCHAR(256)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO gluster_server_hooks (
         hook_id,
@@ -306,14 +306,14 @@ BEGIN
     UPDATE gluster_hooks
     SET _update_date = LOCALTIMESTAMP
     WHERE id = v_hook_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlusterServerHook (
     v_hook_id UUID,
     v_server_id UUID
     )
-RETURNS SETOF gluster_server_hooks_view STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_server_hooks_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -321,7 +321,7 @@ BEGIN
     FROM gluster_server_hooks_view
     WHERE hook_id = v_hook_id
         AND server_id = v_server_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateGlusterServerHook (
@@ -331,7 +331,7 @@ CREATE OR REPLACE FUNCTION UpdateGlusterServerHook (
     v_content_type VARCHAR(50),
     v_checksum VARCHAR(256)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE gluster_server_hooks
     SET hook_status = v_hook_status,
@@ -344,7 +344,7 @@ BEGIN
     UPDATE gluster_hooks
     SET _update_date = LOCALTIMESTAMP
     WHERE id = v_hook_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateGlusterServerHookStatus (
@@ -352,7 +352,7 @@ CREATE OR REPLACE FUNCTION UpdateGlusterServerHookStatus (
     v_server_id UUID,
     v_hook_status VARCHAR(100)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE gluster_server_hooks
     SET hook_status = v_hook_status,
@@ -363,7 +363,7 @@ BEGIN
     UPDATE gluster_hooks
     SET _update_date = LOCALTIMESTAMP
     WHERE id = v_hook_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateGlusterServerHookChecksum (
@@ -371,18 +371,18 @@ CREATE OR REPLACE FUNCTION UpdateGlusterServerHookChecksum (
     v_server_id UUID,
     v_checksum VARCHAR(100)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE gluster_server_hooks
     SET checksum = v_checksum,
         _update_date = LOCALTIMESTAMP
     WHERE hook_id = v_hook_id
         AND server_id = v_server_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteGlusterServerHookById (v_hook_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM gluster_server_hooks
@@ -391,11 +391,11 @@ BEGIN
     UPDATE gluster_hooks
     SET _update_date = LOCALTIMESTAMP
     WHERE id = v_hook_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteGlusterServerHooksByIds (v_ids TEXT)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM gluster_server_hooks
@@ -410,14 +410,14 @@ BEGIN
             SELECT *
             FROM fnSplitterUuid(v_ids)
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteGlusterServerHook (
     v_hook_id UUID,
     v_server_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM gluster_server_hooks
@@ -427,7 +427,7 @@ BEGIN
     UPDATE gluster_hooks
     SET _update_date = LOCALTIMESTAMP
     WHERE id = v_hook_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/gluster_job_details_sp.sql
+++ b/packaging/dbscripts/gluster_job_details_sp.sql
@@ -11,7 +11,7 @@ CREATE OR REPLACE FUNCTION InsertSchedulerJob (
     v_end_date DATE DEFAULT NULL,
     v_timezone VARCHAR(300) DEFAULT NULL
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO gluster_scheduler_job_details (
         job_id,
@@ -31,38 +31,38 @@ BEGIN
         v_end_date,
         v_timezone
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 
 CREATE OR REPLACE FUNCTION GetAllGlusterSchedulerJobs ()
-RETURNS SETOF gluster_scheduler_job_details STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_scheduler_job_details STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM gluster_scheduler_job_details;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlusterJobById (v_job_id uuid)
-RETURNS SETOF gluster_scheduler_job_details STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_scheduler_job_details STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM gluster_scheduler_job_details
     WHERE job_id = v_job_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteGlusterJob (v_job_id uuid )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM gluster_scheduler_job_details
     WHERE job_id = v_job_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION InsertJobParams (
@@ -71,7 +71,7 @@ CREATE OR REPLACE FUNCTION InsertJobParams (
     v_params_class_name VARCHAR(300),
     v_params_class_value VARCHAR(300)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO gluster_scheduler_job_params (
         id,
@@ -85,27 +85,27 @@ BEGIN
         v_params_class_name,
         v_params_class_value
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlusterJobParamsByJobId (v_job_id uuid)
-RETURNS SETOF gluster_scheduler_job_params STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_scheduler_job_params STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM gluster_scheduler_job_params
     WHERE job_id = v_job_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteGlusterJobParams (v_job_id uuid)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM gluster_scheduler_job_params
     WHERE job_id = v_job_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/gluster_server_sp.sql
+++ b/packaging/dbscripts/gluster_server_sp.sql
@@ -1,14 +1,14 @@
 
 
 /*--------------------------------------------------------------
-Stored procedures for database operations on gluster_server table
+Stored FUNCTIONs for database operations on gluster_server table
 --------------------------------------------------------------*/
 CREATE OR REPLACE FUNCTION InsertGlusterServer (
     v_server_id UUID,
     v_gluster_server_uuid UUID,
     v_peer_status VARCHAR(20)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO gluster_server (
         server_id,
@@ -20,95 +20,95 @@ BEGIN
         v_gluster_server_uuid,
         v_peer_status
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlusterServerByServerId (v_server_id UUID)
-RETURNS SETOF gluster_server STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_server STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM gluster_server
     WHERE server_id = v_server_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlusterServerByGlusterServerUUID (v_gluster_server_uuid UUID)
-RETURNS SETOF gluster_server STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_server STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM gluster_server
     WHERE gluster_server_uuid = v_gluster_server_uuid;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteGlusterServer (v_server_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM gluster_server
     WHERE server_id = v_server_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteGlusterServerByGlusterServerUUID (v_gluster_server_uuid UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM gluster_server
     WHERE gluster_server_uuid = v_gluster_server_uuid;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateGlusterServer (
     v_server_id UUID,
     v_gluster_server_uuid UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE gluster_server
     SET gluster_server_uuid = v_gluster_server_uuid
     WHERE server_id = v_server_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateGlusterServerKnownAddresses (
     v_server_id UUID,
     v_known_addresses VARCHAR(250)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE gluster_server
     SET known_addresses = v_known_addresses
     WHERE server_id = v_server_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateGlusterServerPeerStatus (
     v_server_id UUID,
     v_peer_status VARCHAR(50)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE gluster_server
     SET peer_status = v_peer_status
     WHERE server_id = v_server_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION AddGlusterServerKnownAddress (
     v_server_id UUID,
     v_known_address VARCHAR(250)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE gluster_server
     SET known_addresses = coalesce(known_addresses || ',', '') || v_known_address
     WHERE server_id = v_server_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/gluster_services_sp.sql
+++ b/packaging/dbscripts/gluster_services_sp.sql
@@ -1,7 +1,7 @@
 
 
 /* ----------------------------------------------------------------
- Stored procedures for database operations on Services
+ Stored FUNCTIONs for database operations on Services
  related tables:
       - gluster_service_types
       - gluster_services
@@ -10,37 +10,37 @@
 ----------------------------------------------------------------*/
 -- Fetch all gluster service types
 CREATE OR REPLACE FUNCTION GetGlusterServiceTypes ()
-RETURNS SETOF gluster_service_types STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_service_types STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM gluster_service_types;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Fetch services of a given type
 CREATE OR REPLACE FUNCTION GetGlusterServicesByType (v_service_type VARCHAR(100))
-RETURNS SETOF gluster_services STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_services STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM gluster_services
     WHERE service_type = v_service_type;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Fetch services of given cluster
 CREATE OR REPLACE FUNCTION GetGlusterClusterServicesByClusterId (v_cluster_id UUID)
-RETURNS SETOF gluster_cluster_services STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_cluster_services STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM gluster_cluster_services
     WHERE cluster_id = v_cluster_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Fetch cluster-wide service given cluster id and service type
@@ -48,7 +48,7 @@ CREATE OR REPLACE FUNCTION GetGlusterClusterServicesByClusterIdAndServiceType (
     v_cluster_id UUID,
     v_service_type VARCHAR(100)
     )
-RETURNS SETOF gluster_cluster_services STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_cluster_services STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -56,24 +56,24 @@ BEGIN
     FROM gluster_cluster_services
     WHERE cluster_id = v_cluster_id
         AND service_type = v_service_type;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Fetch services of given server
 CREATE OR REPLACE FUNCTION GetGlusterServerServicesByServerId (v_server_id UUID)
-RETURNS SETOF gluster_server_services_view STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_server_services_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM gluster_server_services_view
     WHERE server_id = v_server_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Fetch services from all servers of given cluster
 CREATE OR REPLACE FUNCTION GetGlusterServerServicesByClusterId (v_cluster_id UUID)
-RETURNS SETOF gluster_server_services_view STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_server_services_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -82,7 +82,7 @@ BEGIN
         vds_static v
     WHERE s.server_id = v.vds_id
         AND v.cluster_id = v_cluster_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Fetch services of given cluster
@@ -90,7 +90,7 @@ CREATE OR REPLACE FUNCTION GetGlusterServerServicesByClusterIdAndServiceType (
     v_cluster_id UUID,
     v_service_type VARCHAR(100)
     )
-RETURNS SETOF gluster_server_services_view STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_server_services_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -100,7 +100,7 @@ BEGIN
     WHERE s.server_id = v.vds_id
         AND v.cluster_id = v_cluster_id
         AND s.service_type = v_service_type;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Fetch services of given server
@@ -108,7 +108,7 @@ CREATE OR REPLACE FUNCTION GetGlusterServerServicesByServerIdAndServiceType (
     v_server_id UUID,
     v_service_type VARCHAR(100)
     )
-RETURNS SETOF gluster_server_services_view STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_server_services_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -116,42 +116,42 @@ BEGIN
     FROM gluster_server_services_view
     WHERE server_id = v_server_id
         AND service_type = v_service_type;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Fetch a service by it's ID
 CREATE OR REPLACE FUNCTION GetGlusterServiceByGlusterServiceId (v_id UUID)
-RETURNS SETOF gluster_services STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_services STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM gluster_services
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Fetch a server service by it's ID
 CREATE OR REPLACE FUNCTION GetGlusterServerServiceByGlusterServerServiceId (v_id UUID)
-RETURNS SETOF gluster_server_services_view STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_server_services_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM gluster_server_services_view
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Fetch all server services
 CREATE OR REPLACE FUNCTION GetAllFromGlusterServerServices ()
-RETURNS SETOF gluster_server_services_view STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_server_services_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM gluster_server_services_view;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Fetch a service by it's name
@@ -159,7 +159,7 @@ CREATE OR REPLACE FUNCTION GetGlusterServiceByTypeAndName (
     v_service_type VARCHAR(100),
     v_service_name VARCHAR(100)
     )
-RETURNS SETOF gluster_services STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_services STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -167,18 +167,18 @@ BEGIN
     FROM gluster_services
     WHERE service_type = v_service_type
         AND service_name = v_service_name;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Fetch all services
 CREATE OR REPLACE FUNCTION GetAllFromGlusterServices ()
-RETURNS SETOF gluster_services STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_services STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM gluster_services;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Insert a cluster-wide service type
@@ -187,7 +187,7 @@ CREATE OR REPLACE FUNCTION InsertGlusterClusterService (
     v_service_type VARCHAR(100),
     v_status VARCHAR(32)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO gluster_cluster_services (
         cluster_id,
@@ -199,7 +199,7 @@ BEGIN
         v_service_type,
         v_status
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Insert a server specific service
@@ -211,7 +211,7 @@ CREATE OR REPLACE FUNCTION InsertGlusterServerService (
     v_status VARCHAR(32),
     v_message VARCHAR(1000)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO gluster_server_services (
         id,
@@ -229,7 +229,7 @@ BEGIN
         v_status,
         v_message
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Update status of a cluster-wide service type
@@ -238,14 +238,14 @@ CREATE OR REPLACE FUNCTION UpdateGlusterClusterService (
     v_service_type VARCHAR(100),
     v_status VARCHAR(32)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE gluster_cluster_services
     SET status = v_status,
         _update_date = LOCALTIMESTAMP
     WHERE cluster_id = v_cluster_id
         AND service_type = v_service_type;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Update a server specific service
@@ -255,7 +255,7 @@ CREATE OR REPLACE FUNCTION UpdateGlusterServerService (
     v_status VARCHAR(32),
     v_message VARCHAR(1000)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE gluster_server_services
     SET pid = v_pid,
@@ -263,7 +263,7 @@ BEGIN
         message = v_message,
         _update_date = LOCALTIMESTAMP
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Update a server specific service by server id and service id
@@ -274,7 +274,7 @@ CREATE OR REPLACE FUNCTION UpdateGlusterServerServiceByServerIdAndServiceType (
     v_status VARCHAR(32),
     v_message VARCHAR(1000)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE gluster_server_services
     SET pid = v_pid,
@@ -283,17 +283,17 @@ BEGIN
         _update_date = LOCALTIMESTAMP
     WHERE server_id = v_server_id
         AND service_id = v_service_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Delete a server specific service
 CREATE OR REPLACE FUNCTION DeleteGlusterServerService (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM gluster_server_services
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/gluster_volume_snapshot_schedule_sp.sql
+++ b/packaging/dbscripts/gluster_volume_snapshot_schedule_sp.sql
@@ -1,7 +1,7 @@
 
 
 /* ----------------------------------------------------------------
- Stored procedures for database operations on Gluster Volume Snapshot
+ Stored FUNCTIONs for database operations on Gluster Volume Snapshot
  related tables:
       - gluster_volume_snapshot_schedules
 ----------------------------------------------------------------*/
@@ -18,7 +18,7 @@ CREATE OR REPLACE FUNCTION InsertGlusterVolumeSnapshotSchedule (
     v_days VARCHAR(256),
     v_end_by TIMESTAMP WITH TIME ZONE
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO gluster_volume_snapshot_schedules (
         volume_id,
@@ -50,22 +50,22 @@ BEGIN
     UPDATE gluster_volumes
     SET snapshot_scheduled = true
     WHERE id = v_volume_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlusterVolumeSnapshotScheduleByVolumeId (v_volume_id UUID)
-RETURNS SETOF gluster_volume_snapshot_schedules_view STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_volume_snapshot_schedules_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM gluster_volume_snapshot_schedules_view
     WHERE volume_id = v_volume_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteGlusterVolumeSnapshotScheduleByVolumeId (v_volume_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM gluster_volume_snapshot_schedules
@@ -74,7 +74,7 @@ BEGIN
     UPDATE gluster_volumes
     SET snapshot_scheduled = false
     WHERE id = v_volume_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateGlusterVolumeSnapshotScheduleByVolumeId (
@@ -90,7 +90,7 @@ CREATE OR REPLACE FUNCTION UpdateGlusterVolumeSnapshotScheduleByVolumeId (
     v_days VARCHAR(256),
     v_end_by TIMESTAMP WITH TIME ZONE
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE gluster_volume_snapshot_schedules
     SET job_id = v_job_id,
@@ -109,7 +109,7 @@ BEGIN
     UPDATE gluster_volumes
     SET snapshot_scheduled = true
     WHERE id = v_volume_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/gluster_volume_snapshot_sp.sql
+++ b/packaging/dbscripts/gluster_volume_snapshot_sp.sql
@@ -1,7 +1,7 @@
 
 
 /* ----------------------------------------------------------------
- Stored procedures for database operations on Gluster Volume Snapshot
+ Stored FUNCTIONs for database operations on Gluster Volume Snapshot
  related tables:
       - gluster_volume_snapshots
       - gluster_volume_snapshot_config
@@ -14,7 +14,7 @@ CREATE OR REPLACE FUNCTION InsertGlusterVolumeSnapshot (
     v_status VARCHAR(32),
     v__create_date TIMESTAMP WITH TIME ZONE
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO gluster_volume_snapshots (
         snapshot_id,
@@ -34,47 +34,47 @@ BEGIN
         );
 
     PERFORM UpdateSnapshotCountInc(v_volume_id, 1);
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlusterVolumeSnapshotById (v_snapshot_id UUID)
-RETURNS SETOF gluster_volume_snapshots_view STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_volume_snapshots_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM gluster_volume_snapshots_view
     WHERE snapshot_id = v_snapshot_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlusterVolumeSnapshotsByVolumeId (v_volume_id UUID)
-RETURNS SETOF gluster_volume_snapshots_view STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_volume_snapshots_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM gluster_volume_snapshots_view
     WHERE volume_id = v_volume_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlusterVolumeSnapshotsByClusterId (v_cluster_id UUID)
-RETURNS SETOF gluster_volume_snapshots_view STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_volume_snapshots_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM gluster_volume_snapshots_view
     WHERE cluster_id = v_cluster_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlusterVolumeSnapshotByName (
     v_volume_id UUID,
     v_snapshot_name VARCHAR(1000)
     )
-RETURNS SETOF gluster_volume_snapshots_view STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_volume_snapshots_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -82,11 +82,11 @@ BEGIN
     FROM gluster_volume_snapshots_view
     WHERE volume_id = v_volume_id
         AND snapshot_name = v_snapshot_name;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteGlusterVolumeSnapshotByGuid (v_snapshot_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 DECLARE ref_volume_id UUID;
 
 BEGIN
@@ -100,11 +100,11 @@ BEGIN
     WHERE snapshot_id = v_snapshot_id;
 
     PERFORM UpdateSnapshotCountDec(ref_volume_id, 1);
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteGlusterVolumeSnapshotsByVolumeId (v_volume_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM gluster_volume_snapshots
@@ -113,14 +113,14 @@ BEGIN
     UPDATE gluster_volumes
     SET snapshot_count = 0
     WHERE id = v_volume_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteGlusterVolumeSnapshotByName (
     v_volume_id UUID,
     v_snapshot_name VARCHAR(1000)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM gluster_volume_snapshots
@@ -128,11 +128,11 @@ BEGIN
         AND snapshot_name = v_snapshot_name;
 
     PERFORM UpdateSnapshotCountDec(v_volume_id, 1);
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteGlusterVolumesSnapshotByIds (v_snapshot_ids VARCHAR(5000))
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 DECLARE v_volume_id UUID;
 
 v_snapshot_count INT;
@@ -171,20 +171,20 @@ WHERE snapshot_id IN (
         SELECT *
         FROM fnSplitterUuid(v_snapshot_ids)
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateGlusterVolumeSnapshotStatus (
     v_snapshot_id UUID,
     v_status VARCHAR(32)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE gluster_volume_snapshots
     SET status = v_status,
         _update_date = LOCALTIMESTAMP
     WHERE snapshot_id = v_snapshot_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateGlusterVolumeSnapshotStatusByName (
@@ -192,14 +192,14 @@ CREATE OR REPLACE FUNCTION UpdateGlusterVolumeSnapshotStatusByName (
     v_snapshot_name VARCHAR(1000),
     v_status VARCHAR(32)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE gluster_volume_snapshots
     SET status = v_status,
         _update_date = LOCALTIMESTAMP
     WHERE volume_id = v_volume_id
         AND snapshot_name = v_snapshot_name;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION InsertGlusterVolumeSnapshotConfig (
@@ -208,7 +208,7 @@ CREATE OR REPLACE FUNCTION InsertGlusterVolumeSnapshotConfig (
     v_param_name VARCHAR(128),
     v_param_value VARCHAR(128)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO gluster_volume_snapshot_config (
         cluster_id,
@@ -222,25 +222,25 @@ BEGIN
         v_param_name,
         v_param_value
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlusterVolumeSnapshotConfigByClusterId (v_cluster_id UUID)
-RETURNS SETOF gluster_volume_snapshot_config STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_volume_snapshot_config STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM gluster_volume_snapshot_config
     WHERE cluster_id = v_cluster_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlusterVolumeSnapshotConfigByVolumeId (
     v_cluster_id UUID,
     v_volume_id UUID
     )
-RETURNS SETOF gluster_volume_snapshot_config STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_volume_snapshot_config STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -248,14 +248,14 @@ BEGIN
     FROM gluster_volume_snapshot_config
     WHERE cluster_id = v_cluster_id
         AND volume_id = v_volume_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlusterVolumeSnapshotConfigByClusterIdAndName (
     v_cluster_id UUID,
     v_param_name VARCHAR(128)
     )
-RETURNS SETOF gluster_volume_snapshot_config STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_volume_snapshot_config STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -264,7 +264,7 @@ BEGIN
     WHERE cluster_id = v_cluster_id
         AND volume_id IS NULL
         AND param_name = v_param_name;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlusterVolumeSnapshotConfigByVolumeIdAndName (
@@ -272,7 +272,7 @@ CREATE OR REPLACE FUNCTION GetGlusterVolumeSnapshotConfigByVolumeIdAndName (
     v_volume_id UUID,
     v_param_name VARCHAR(128)
     )
-RETURNS SETOF gluster_volume_snapshot_config STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_volume_snapshot_config STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -281,7 +281,7 @@ BEGIN
     WHERE cluster_id = v_cluster_id
         AND volume_id = v_volume_id
         AND param_name = v_param_name;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateConfigByClusterIdAndName (
@@ -289,7 +289,7 @@ CREATE OR REPLACE FUNCTION UpdateConfigByClusterIdAndName (
     v_param_name VARCHAR(128),
     v_param_value VARCHAR(128)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE gluster_volume_snapshot_config
     SET param_value = v_param_value,
@@ -297,7 +297,7 @@ BEGIN
     WHERE cluster_id = v_cluster_id
         AND volume_id IS NULL
         AND param_name = v_param_name;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateConfigByVolumeIdIdAndName (
@@ -306,7 +306,7 @@ CREATE OR REPLACE FUNCTION UpdateConfigByVolumeIdIdAndName (
     v_param_name VARCHAR(128),
     v_param_value VARCHAR(128)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE gluster_volume_snapshot_config
     SET param_value = v_param_value,
@@ -314,31 +314,31 @@ BEGIN
     WHERE cluster_id = v_cluster_id
         AND volume_id = v_volume_id
         AND param_name = v_param_name;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateSnapshotCountInc (
     v_volume_id UUID,
     v_num INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE gluster_volumes
     SET snapshot_count = snapshot_count + v_num
     WHERE id = v_volume_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateSnapshotCountDec (
     v_volume_id UUID,
     v_num INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE gluster_volumes
     SET snapshot_count = snapshot_count - v_num
     WHERE id = v_volume_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/gluster_volumes_sp.sql
+++ b/packaging/dbscripts/gluster_volumes_sp.sql
@@ -1,7 +1,7 @@
 
 
 /* ----------------------------------------------------------------
- Stored procedures for database operations on Gluster Volume
+ Stored FUNCTIONs for database operations on Gluster Volume
  related tables:
       - gluster_volumes
       - gluster_volume_bricks
@@ -21,7 +21,7 @@ CREATE OR REPLACE FUNCTION InsertGlusterVolume (
     v_redundancy_count INT,
     v_is_arbiter boolean
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO gluster_volumes (
         id,
@@ -47,7 +47,7 @@ BEGIN
         v_redundancy_count,
         v_is_arbiter
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION InsertGlusterVolumeDetails (
@@ -58,7 +58,7 @@ CREATE OR REPLACE FUNCTION InsertGlusterVolumeDetails (
     v_confirmed_free_space BIGINT,
     v_vdo_savings INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO gluster_volume_details (
         volume_id,
@@ -78,7 +78,7 @@ BEGIN
         v_vdo_savings,
         LOCALTIMESTAMP
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION InsertGlusterVolumeBrick (
@@ -91,7 +91,7 @@ CREATE OR REPLACE FUNCTION InsertGlusterVolumeBrick (
     v_network_id UUID,
     v_is_arbiter boolean
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO gluster_volume_bricks (
         id,
@@ -113,7 +113,7 @@ BEGIN
         v_network_id,
         v_is_arbiter
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION InsertGlusterVolumeBrickDetails (
@@ -125,7 +125,7 @@ CREATE OR REPLACE FUNCTION InsertGlusterVolumeBrickDetails (
     v_confirmed_total_space BIGINT,
     v_vdo_savings INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO gluster_volume_brick_details (
         brick_id,
@@ -147,7 +147,7 @@ BEGIN
         v_vdo_savings,
         LOCALTIMESTAMP
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION InsertGlusterVolumeOption (
@@ -156,7 +156,7 @@ CREATE OR REPLACE FUNCTION InsertGlusterVolumeOption (
     v_option_key VARCHAR(8192),
     v_option_val VARCHAR(8192)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO gluster_volume_options (
         id,
@@ -170,14 +170,14 @@ BEGIN
         v_option_key,
         v_option_val
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION InsertGlusterVolumeAccessProtocol (
     v_volume_id UUID,
     v_access_protocol VARCHAR(32)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO gluster_volume_access_protocols (
         volume_id,
@@ -187,14 +187,14 @@ BEGIN
         v_volume_id,
         v_access_protocol
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION InsertGlusterVolumeTransportType (
     v_volume_id UUID,
     v_transport_type VARCHAR(32)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO gluster_volume_transport_types (
         volume_id,
@@ -204,29 +204,29 @@ BEGIN
         v_volume_id,
         v_transport_type
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlusterVolumesByClusterGuid (v_cluster_id UUID)
-RETURNS SETOF gluster_volumes_view STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_volumes_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM gluster_volumes_view
     WHERE cluster_id = v_cluster_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlusterVolumesSupportedAsStorageDomain ()
-RETURNS SETOF gluster_volumes_view STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_volumes_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
     SELECT *
     FROM gluster_volumes_view
     WHERE vol_type IN ('REPLICATE', 'DISTRIBUTE', 'DISTRIBUTED_REPLICATE')
     AND replica_count IN (0, 3);
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlusterVolumesByOption (
@@ -235,7 +235,7 @@ CREATE OR REPLACE FUNCTION GetGlusterVolumesByOption (
     v_option_key VARCHAR(8192),
     v_option_val VARCHAR(8192)
     )
-RETURNS SETOF gluster_volumes_view STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_volumes_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -249,7 +249,7 @@ BEGIN
             WHERE option_key = v_option_key
                 AND option_val = v_option_val
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlusterVolumesByStatusTypesAndOption (
@@ -259,7 +259,7 @@ CREATE OR REPLACE FUNCTION GetGlusterVolumesByStatusTypesAndOption (
     v_option_key VARCHAR(8192),
     v_option_val VARCHAR(8192)
     )
-RETURNS SETOF gluster_volumes_view STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_volumes_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -277,7 +277,7 @@ BEGIN
             WHERE option_key = v_option_key
                 AND option_val = v_option_val
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlusterVolumesByStatusAndTypes (
@@ -285,7 +285,7 @@ CREATE OR REPLACE FUNCTION GetGlusterVolumesByStatusAndTypes (
     v_status VARCHAR(32),
     v_vol_types TEXT
     )
-RETURNS SETOF gluster_volumes_view STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_volumes_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -297,25 +297,25 @@ BEGIN
             SELECT ID
             FROM fnSplitter(v_vol_types)
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlusterVolumeById (v_volume_id UUID)
-RETURNS SETOF gluster_volumes_view STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_volumes_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM gluster_volumes_view
     WHERE id = v_volume_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlusterVolumeByName (
     v_cluster_id UUID,
     v_vol_name VARCHAR(1000)
     )
-RETURNS SETOF gluster_volumes_view STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_volumes_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -323,44 +323,44 @@ BEGIN
     FROM gluster_volumes_view
     WHERE cluster_id = v_cluster_id
         AND vol_name = v_vol_name;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlusterVolumeByGlusterTaskId (v_task_id UUID)
-RETURNS SETOF gluster_volumes_view STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_volumes_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM gluster_volumes_view
     WHERE task_id = v_task_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlusterVolumeDetailsById (v_volume_id UUID)
-RETURNS SETOF gluster_volume_details STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_volume_details STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM gluster_volume_details
     WHERE volume_id = v_volume_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlusterBrickById (v_id UUID)
-RETURNS SETOF gluster_volume_bricks_view STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_volume_bricks_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM gluster_volume_bricks_view
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetBricksByGlusterVolumeGuid (v_volume_id UUID)
-RETURNS SETOF gluster_volume_bricks_view STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_volume_bricks_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -368,11 +368,11 @@ BEGIN
     FROM gluster_volume_bricks_view
     WHERE volume_id = v_volume_id
     ORDER BY brick_order;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlusterVolumeBricksByServerGuid (v_server_id UUID)
-RETURNS SETOF gluster_volume_bricks_view STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_volume_bricks_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -380,14 +380,14 @@ BEGIN
     FROM gluster_volume_bricks_view
     WHERE server_id = v_server_id
     ORDER BY brick_order;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetBrickByServerIdAndDirectory (
     v_server_id UUID,
     v_brick_dir VARCHAR(4096)
     )
-RETURNS SETOF gluster_volume_bricks_view STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_volume_bricks_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -395,11 +395,11 @@ BEGIN
     FROM gluster_volume_bricks_view
     WHERE server_id = v_server_id
         AND brick_dir = v_brick_dir;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetBricksByTaskId (v_task_id UUID)
-RETURNS SETOF gluster_volume_bricks_view STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_volume_bricks_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -407,55 +407,55 @@ BEGIN
     FROM gluster_volume_bricks_view
     WHERE task_id = v_task_id
     ORDER BY brick_order;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetBrickDetailsById (v_brick_id UUID)
-RETURNS SETOF gluster_volume_brick_details STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_volume_brick_details STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM gluster_volume_brick_details
     WHERE brick_id = v_brick_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlusterOptionById (v_id UUID)
-RETURNS SETOF gluster_volume_options STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_volume_options STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM gluster_volume_options
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetOptionsByGlusterVolumeGuid (v_volume_id UUID)
-RETURNS SETOF gluster_volume_options STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_volume_options STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM gluster_volume_options
     WHERE volume_id = v_volume_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAccessProtocolsByGlusterVolumeGuid (v_volume_id UUID)
-RETURNS SETOF gluster_volume_access_protocols STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_volume_access_protocols STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM gluster_volume_access_protocols
     WHERE volume_id = v_volume_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetGlusterTaskByGlusterVolumeGuid (v_volume_id UUID)
-RETURNS SETOF gluster_volume_task_steps STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_volume_task_steps STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -472,31 +472,31 @@ BEGIN
                 )
             )
     ORDER BY job_start_time DESC LIMIT 1;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetTransportTypesByGlusterVolumeGuid (v_volume_id UUID)
-RETURNS SETOF gluster_volume_transport_types STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_volume_transport_types STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM gluster_volume_transport_types
     WHERE volume_id = v_volume_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteGlusterVolumeByGuid (v_volume_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM gluster_volumes
     WHERE id = v_volume_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteGlusterVolumesByGuids (v_volume_ids VARCHAR(5000))
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM gluster_volumes
@@ -504,42 +504,42 @@ BEGIN
             SELECT *
             FROM fnSplitterUuid(v_volume_ids)
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteGlusterVolumeByName (
     v_cluster_id UUID,
     v_vol_name VARCHAR(1000)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM gluster_volumes
     WHERE cluster_id = v_cluster_id
         AND vol_name = v_vol_name;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteGlusterVolumesByClusterId (v_cluster_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM gluster_volumes
     WHERE cluster_id = v_cluster_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteGlusterVolumeBrick (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM gluster_volume_bricks
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteGlusterVolumeBricks (v_ids VARCHAR(5000))
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM gluster_volume_bricks
@@ -547,20 +547,20 @@ BEGIN
             SELECT *
             FROM fnSplitterUuid(v_ids)
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteGlusterVolumeOption (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM gluster_volume_options
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteGlusterVolumeOptions (v_ids VARCHAR(5000))
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM gluster_volume_options
@@ -568,33 +568,33 @@ BEGIN
             SELECT *
             FROM fnSplitterUuid(v_ids)
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteGlusterVolumeAccessProtocol (
     v_volume_id UUID,
     v_access_protocol VARCHAR(32)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM gluster_volume_access_protocols
     WHERE volume_id = v_volume_id
         AND access_protocol = v_access_protocol;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteGlusterVolumeTransportType (
     v_volume_id UUID,
     v_transport_type VARCHAR(32)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM gluster_volume_transport_types
     WHERE volume_id = v_volume_id
         AND transport_type = v_transport_type;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateGlusterVolume (
@@ -609,7 +609,7 @@ CREATE OR REPLACE FUNCTION UpdateGlusterVolume (
     v_redundancy_count INT,
     v_is_arbiter boolean
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE gluster_volumes
     SET cluster_id = v_cluster_id,
@@ -623,7 +623,7 @@ BEGIN
         is_arbiter = v_is_arbiter,
         _update_date = LOCALTIMESTAMP
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateGlusterVolumeDetails (
@@ -634,7 +634,7 @@ CREATE OR REPLACE FUNCTION UpdateGlusterVolumeDetails (
     v_confirmed_free_space BIGINT,
     v_vdo_savings INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE gluster_volume_details
     SET total_space = v_total_space,
@@ -644,7 +644,7 @@ BEGIN
         vdo_savings = v_vdo_savings,
         _update_date = LOCALTIMESTAMP
     WHERE volume_id = v_volume_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateGlusterVolumeBrick (
@@ -656,7 +656,7 @@ CREATE OR REPLACE FUNCTION UpdateGlusterVolumeBrick (
     v_new_network_id UUID,
     v_is_arbiter boolean
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE FROM gluster_volume_brick_details
     WHERE brick_id = v_id;
@@ -669,7 +669,7 @@ BEGIN
         is_arbiter = v_is_arbiter,
         _update_date = LOCALTIMESTAMP
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateGlusterVolumeBrickDetails (
@@ -681,7 +681,7 @@ CREATE OR REPLACE FUNCTION UpdateGlusterVolumeBrickDetails (
     v_confirmed_total_space BIGINT,
     v_vdo_savings INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE gluster_volume_brick_details
     SET total_space = v_total_space,
@@ -692,85 +692,85 @@ BEGIN
         vdo_savings = v_vdo_savings,
         _update_date = LOCALTIMESTAMP
     WHERE brick_id = v_brick_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateGlusterVolumeBrickStatus (
     v_id UUID,
     v_status VARCHAR(32)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE gluster_volume_bricks
     SET status = v_status,
         _update_date = LOCALTIMESTAMP
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateGlusterVolumeBrickOrder (
     v_id UUID,
     v_brick_order INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE gluster_volume_bricks
     SET brick_order = v_brick_order,
         _update_date = LOCALTIMESTAMP
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateGlusterVolumeBrickNetworkId (
     v_id UUID,
     v_network_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE gluster_volume_bricks
     SET network_id = v_network_id,
         _update_date = LOCALTIMESTAMP
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateGlusterVolumeStatus (
     v_volume_id UUID,
     v_status VARCHAR(32)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE gluster_volumes
     SET status = v_status,
         _update_date = LOCALTIMESTAMP
     WHERE id = v_volume_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateGlusterVolumeAsyncTask (
     v_volume_id UUID,
     v_task_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE gluster_volumes
     SET task_id = v_task_id,
         _update_date = LOCALTIMESTAMP
     WHERE id = v_volume_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateGlusterVolumeBrickAsyncTask (
     v_id UUID,
     v_task_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE gluster_volume_bricks
     SET task_id = v_task_id,
         _update_date = LOCALTIMESTAMP
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateGlusterBrickTaskByServerIdBrickDir (
@@ -778,14 +778,14 @@ CREATE OR REPLACE FUNCTION UpdateGlusterBrickTaskByServerIdBrickDir (
     v_brick_dir VARCHAR(200),
     v_task_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE gluster_volume_bricks
     SET task_id = v_task_id,
         _update_date = LOCALTIMESTAMP
     WHERE server_id = v_server_id
         AND brick_dir = v_brick_dir;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateGlusterVolumeBrickUnSyncedEntries (
@@ -793,14 +793,14 @@ CREATE OR REPLACE FUNCTION UpdateGlusterVolumeBrickUnSyncedEntries (
     v_unsynced_entries integer,
     v_unsynced_entries_history text
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE gluster_volume_bricks
     SET unsynced_entries = v_unsynced_entries,
         unsynced_entries_history = v_unsynced_entries_history,
         _update_date = LOCALTIMESTAMP
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateGlusterVolumeStatusByName (
@@ -808,46 +808,46 @@ CREATE OR REPLACE FUNCTION UpdateGlusterVolumeStatusByName (
     v_vol_name VARCHAR(1000),
     v_status VARCHAR(32)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE gluster_volumes
     SET status = v_status,
         _update_date = LOCALTIMESTAMP
     WHERE cluster_id = v_cluster_id
         AND vol_name = v_vol_name;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateGlusterVolumeOption (
     v_id UUID,
     v_option_val VARCHAR(8192)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE gluster_volume_options
     SET option_val = v_option_val
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateReplicaCount (
     v_volume_id UUID,
     v_replica_count INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE gluster_volumes
     SET replica_count = v_replica_count,
         _update_date = LOCALTIMESTAMP
     WHERE id = v_volume_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetBricksByClusterIdAndNetworkId (
     v_cluster_id UUID,
     v_network_id UUID
     )
-RETURNS SETOF gluster_volume_bricks_view STABLE AS $PROCEDURE$
+RETURNS SETOF gluster_volume_bricks_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -855,7 +855,7 @@ BEGIN
     FROM gluster_volume_bricks_view
     WHERE network_id = v_network_id
         AND cluster_id = v_cluster_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/host_device_sp.sql
+++ b/packaging/dbscripts/host_device_sp.sql
@@ -20,7 +20,7 @@ CREATE OR REPLACE FUNCTION InsertHostDevice (
     v_block_path TEXT,
     v_hostdev_spec_params TEXT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     SET CONSTRAINTS ALL DEFERRED;
 
@@ -64,7 +64,7 @@ BEGIN
         v_block_path,
         v_hostdev_spec_params
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateHostDevice (
@@ -87,7 +87,7 @@ CREATE OR REPLACE FUNCTION UpdateHostDevice (
     v_block_path TEXT,
     v_hostdev_spec_params TEXT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     SET CONSTRAINTS ALL DEFERRED;
 
@@ -112,14 +112,14 @@ BEGIN
         hostdev_spec_params = v_hostdev_spec_params
     WHERE host_id = v_host_id
         AND device_name = v_device_name;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteHostDevice (
     v_host_id UUID,
     v_device_name VARCHAR(255)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     SET CONSTRAINTS ALL DEFERRED;
 
@@ -127,25 +127,25 @@ BEGIN
     FROM host_device
     WHERE host_id = v_host_id
         AND device_name = v_device_name;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetHostDevicesByHostId (v_host_id UUID)
-RETURNS SETOF host_device STABLE AS $PROCEDURE$
+RETURNS SETOF host_device STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM host_device
     WHERE host_id = v_host_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetHostDevicesByHostIdAndIommuGroup (
     v_host_id UUID,
     v_iommu_group INT
     )
-RETURNS SETOF host_device STABLE AS $PROCEDURE$
+RETURNS SETOF host_device STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -153,14 +153,14 @@ BEGIN
     FROM host_device
     WHERE host_id = v_host_id
         AND iommu_group = v_iommu_group;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetHostDeviceByHostIdAndDeviceName (
     v_host_id UUID,
     v_device_name VARCHAR(255)
     )
-RETURNS SETOF host_device STABLE AS $PROCEDURE$
+RETURNS SETOF host_device STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -168,46 +168,46 @@ BEGIN
     FROM host_device
     WHERE host_id = v_host_id
         AND device_name = v_device_name;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromHostDevices ()
-RETURNS SETOF host_device STABLE AS $PROCEDURE$
+RETURNS SETOF host_device STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM host_device;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVmExtendedHostDevicesByVmId (v_vm_id UUID)
-RETURNS SETOF vm_host_device_view STABLE AS $PROCEDURE$
+RETURNS SETOF vm_host_device_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT vm_host_device_view.*
     FROM vm_host_device_view
     WHERE vm_host_device_view.configured_vm_id = v_vm_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetExtendedHostDevicesByHostId (v_host_id UUID)
-RETURNS SETOF host_device_view STABLE AS $PROCEDURE$
+RETURNS SETOF host_device_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT host_device_view.*
     FROM host_device_view
     WHERE host_device_view.host_id = v_host_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION CheckVmHostDeviceAvailability (
     v_vm_id UUID,
     v_host_id UUID
     )
-RETURNS BOOLEAN STABLE AS $PROCEDURE$
+RETURNS BOOLEAN STABLE AS $FUNCTION$
 BEGIN
     RETURN NOT EXISTS (
             SELECT 1
@@ -221,14 +221,14 @@ BEGIN
                         AND vm_id <> v_vm_id
                     )
             );-- device free or already belonging to the vm
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION MarkHostDevicesUsedByVmId (
     v_vm_id UUID,
     v_host_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE host_device
     SET vm_id = v_vm_id
@@ -239,7 +239,7 @@ BEGIN
             WHERE vm_id = v_vm_id
                 AND type = 'hostdev'
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION SetVmIdOnHostDevice (
@@ -247,37 +247,37 @@ CREATE OR REPLACE FUNCTION SetVmIdOnHostDevice (
     v_device_name VARCHAR(255),
     v_vm_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE host_device
     SET vm_id = v_vm_id
     WHERE host_id = v_host_id
         AND device_name = v_device_name;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION FreeHostDevicesUsedByVmId (v_vm_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE host_device
     SET vm_id = NULL
     WHERE vm_id = v_vm_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION CleanDownVms ()
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE host_device
     SET vm_id = NULL
     FROM vm_dynamic
     WHERE host_device.vm_id = vm_dynamic.vm_guid
         AND vm_dynamic.status = 0;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVmDevicesAttachedToHost (v_host_id UUID)
-RETURNS SETOF vm_device AS $PROCEDURE$
+RETURNS SETOF vm_device AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -287,11 +287,11 @@ BEGIN
         ON vm_device.vm_id = vm_host_pinning_map.vm_id
             AND vm_host_pinning_map.vds_id = v_host_id
     WHERE vm_device.type = 'hostdev';
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetUsedScsiDevicesByHostId (v_host_id UUID)
-RETURNS SETOF host_device_view STABLE AS $PROCEDURE$
+RETURNS SETOF host_device_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -301,5 +301,5 @@ BEGIN
         INNER JOIN host_device_view hdv1
             ON hdv1.device_name = hdv.parent_device_name
         WHERE hdv1.host_id = v_host_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;

--- a/packaging/dbscripts/image_storage_domain_map_sp.sql
+++ b/packaging/dbscripts/image_storage_domain_map_sp.sql
@@ -9,7 +9,7 @@ CREATE OR REPLACE FUNCTION Insertimage_storage_domain_map (
     v_quota_id UUID,
     v_disk_profile_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO image_storage_domain_map (
         image_id,
@@ -23,51 +23,51 @@ BEGIN
         v_quota_id,
         v_disk_profile_id
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Deleteimage_storage_domain_map (
     v_image_id UUID,
     v_storage_domain_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM image_storage_domain_map
     WHERE image_id = v_image_id
         AND storage_domain_id = v_storage_domain_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Deleteimage_storage_domain_map_by_image_id (v_image_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM image_storage_domain_map
     WHERE image_id = v_image_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Getimage_storage_domain_mapByimage_id (v_image_id UUID)
-RETURNS SETOF image_storage_domain_map STABLE AS $PROCEDURE$
+RETURNS SETOF image_storage_domain_map STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM image_storage_domain_map
     WHERE image_id = v_image_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Getimage_storage_domain_mapBystorage_domain_id (v_storage_domain_id UUID)
-RETURNS SETOF image_storage_domain_map STABLE AS $PROCEDURE$
+RETURNS SETOF image_storage_domain_map STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM image_storage_domain_map
     WHERE storage_domain_id = v_storage_domain_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateQuotaForImageAndSnapshots (
@@ -75,7 +75,7 @@ CREATE OR REPLACE FUNCTION UpdateQuotaForImageAndSnapshots (
     v_storage_domain_id UUID,
     v_quota_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE image_storage_domain_map AS isdm
     SET quota_id = v_quota_id
@@ -83,7 +83,7 @@ BEGIN
     WHERE i.image_group_id = v_disk_id
         AND i.image_guid = isdm.image_id
         AND storage_domain_id = v_storage_domain_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateDiskProfileByImageGroupId (
@@ -91,7 +91,7 @@ CREATE OR REPLACE FUNCTION UpdateDiskProfileByImageGroupId (
     v_storage_domain_id UUID,
     v_disk_profile_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE image_storage_domain_map AS isdm
     SET disk_profile_id = v_disk_profile_id
@@ -99,7 +99,7 @@ BEGIN
     WHERE i.image_group_id = v_image_group_id
         AND i.image_guid = isdm.image_id
         AND storage_domain_id = v_storage_domain_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/image_transfers_sp.sql
+++ b/packaging/dbscripts/image_transfers_sp.sql
@@ -4,18 +4,18 @@
 
 CREATE OR REPLACE FUNCTION GetAllFromImageUploads()
 RETURNS SETOF image_transfers STABLE
-AS $PROCEDURE$
+AS $FUNCTION$
 BEGIN
     RETURN QUERY
     SELECT image_transfers.*
     FROM image_transfers;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 
 CREATE OR REPLACE FUNCTION GetImageUploadsByCommandId(v_command_id UUID, v_user_id UUID, v_is_filtered BOOLEAN)
 RETURNS SETOF image_transfers STABLE
-AS $PROCEDURE$
+AS $FUNCTION$
 BEGIN
     RETURN QUERY
     SELECT image_transfers.*
@@ -25,36 +25,36 @@ BEGIN
                                   FROM      user_disk_permissions_view
                                   WHERE     user_disk_permissions_view.user_id = v_user_id AND
                                             user_disk_permissions_view.entity_id = image_transfers.disk_id ));
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 
 CREATE OR REPLACE FUNCTION GetImageUploadsByDiskId(v_disk_id UUID)
 RETURNS SETOF image_transfers STABLE
-AS $PROCEDURE$
+AS $FUNCTION$
 BEGIN
     RETURN QUERY
     SELECT image_transfers.*
     FROM image_transfers
     WHERE image_transfers.disk_id = v_disk_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 
 CREATE OR REPLACE FUNCTION GetImageTransfersByVdsId(v_vds_id UUID)
 RETURNS SETOF image_transfers STABLE
-AS $PROCEDURE$
+AS $FUNCTION$
 BEGIN
     RETURN QUERY
     SELECT image_transfers.*
     FROM image_transfers
     WHERE image_transfers.vds_id = v_vds_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetImageTransfersByStorageId(v_storage_id UUID)
 RETURNS SETOF image_transfers STABLE
-AS $PROCEDURE$
+AS $FUNCTION$
 BEGIN
     RETURN QUERY
     SELECT image_transfers.*
@@ -62,18 +62,18 @@ BEGIN
     INNER JOIN images ON images.image_group_id = image_transfers.disk_id
     INNER JOIN image_storage_domain_map ON image_storage_domain_map.image_id = images.image_guid
     WHERE image_storage_domain_map.storage_domain_id = v_storage_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetImageTransfersByBackupId(v_backup_id UUID)
 RETURNS SETOF image_transfers STABLE
-AS $PROCEDURE$
+AS $FUNCTION$
 BEGIN
     RETURN QUERY
     SELECT image_transfers.*
     FROM image_transfers
     WHERE image_transfers.backup_id = v_backup_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateImageUploads(
@@ -100,7 +100,7 @@ CREATE OR REPLACE FUNCTION UpdateImageUploads(
     v_shallow BOOLEAN
     )
 RETURNS VOID
-AS $PROCEDURE$
+AS $FUNCTION$
 BEGIN
     UPDATE image_transfers
     SET command_id = v_command_id,
@@ -125,18 +125,18 @@ BEGIN
         client_type = v_client_type,
         shallow = v_shallow
     WHERE command_id = v_command_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 
 CREATE OR REPLACE FUNCTION DeleteImageUploads(v_command_id UUID)
 RETURNS VOID
-AS $PROCEDURE$
+AS $FUNCTION$
 BEGIN
     DELETE
     FROM image_transfers
     WHERE command_id = v_command_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -164,7 +164,7 @@ CREATE OR REPLACE FUNCTION InsertImageUploads(
     v_shallow BOOLEAN
     )
 RETURNS VOID
-AS $PROCEDURE$
+AS $FUNCTION$
 BEGIN
     INSERT INTO image_transfers(
         command_id,
@@ -212,7 +212,7 @@ BEGIN
         v_client_type,
         v_shallow
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -223,7 +223,7 @@ CREATE OR REPLACE FUNCTION DeleteCompletedImageTransfersOlderThanDate (
     v_succeeded_end_time TIMESTAMP WITH TIME ZONE,
     v_failed_end_time TIMESTAMP WITH TIME ZONE
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM image_transfers
@@ -237,5 +237,5 @@ BEGIN
                 AND phase = 10
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;

--- a/packaging/dbscripts/images_sp.sql
+++ b/packaging/dbscripts/images_sp.sql
@@ -19,7 +19,7 @@ CREATE OR REPLACE FUNCTION InsertImage (
     v_volume_classification SMALLINT,
     v_sequence_number INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO images (
         creation_date,
@@ -53,43 +53,43 @@ BEGIN
         v_volume_classification,
         v_sequence_number
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateImageStatus (
     v_image_id UUID,
     v_status INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE images
     SET imageStatus = v_status
     WHERE image_guid = v_image_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateStatusOfImagesByImageGroupId (
     v_image_group_id UUID,
     v_status INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE images
     SET imageStatus = v_status
     WHERE image_group_id = v_image_group_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateImageVmSnapshotId (
     v_image_id UUID,
     v_vm_snapshot_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE images
     SET vm_snapshot_id = v_vm_snapshot_id
     WHERE image_guid = v_image_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateImageSize (
@@ -97,13 +97,13 @@ CREATE OR REPLACE FUNCTION UpdateImageSize (
     v_size BIGINT,
     v_lastModified TIMESTAMP WITH TIME ZONE
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE images
     SET size = v_size,
         lastModified = v_lastModified
     WHERE image_guid = v_image_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateImage (
@@ -123,7 +123,7 @@ CREATE OR REPLACE FUNCTION UpdateImage (
     v_qcow_compat INT,
     v_sequence_number INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE images
     SET creation_date = v_creation_date,
@@ -142,44 +142,44 @@ BEGIN
         _update_date = LOCALTIMESTAMP,
         sequence_number = v_sequence_number
     WHERE image_guid = v_image_guid;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteImage (v_image_guid UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 DECLARE v_val UUID;
 
 BEGIN
     DELETE
     FROM images
     WHERE image_guid = v_image_guid;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromImages ()
-RETURNS SETOF images STABLE AS $PROCEDURE$
+RETURNS SETOF images STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM images;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetImageByImageId (v_image_guid UUID)
-RETURNS SETOF images STABLE AS $PROCEDURE$
+RETURNS SETOF images STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM images
     WHERE image_guid = v_image_guid;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 
 CREATE OR REPLACE FUNCTION GetIsoDisksByStoragePool (v_storage_pool_id UUID)
-RETURNS SETOF repo_file_meta_data STABLE AS $PROCEDURE$
+RETURNS SETOF repo_file_meta_data STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
     SELECT repo_domain_id,
@@ -193,7 +193,7 @@ BEGIN
     WHERE storage_pool_id = v_storage_pool_id
         AND status = 3  -- The status of an active storage domain is 3
     ORDER BY repo_image_name;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/inst_sp.sql
+++ b/packaging/dbscripts/inst_sp.sql
@@ -1,8 +1,8 @@
 
 
--- The following stored procedures are relevant to oVirt Installer only
+-- The following stored FUNCTIONs are relevant to oVirt Installer only
 CREATE OR REPLACE FUNCTION inst_update_default_storage_pool_type (v_is_local boolean)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE storage_pool
     SET is_local = v_is_local,
@@ -13,7 +13,7 @@ BEGIN
             FROM storage_domains
             WHERE storage_domains.storage_pool_name = 'Default'
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- This function calls insert_server_connections, insertstorage_domain_static,insertstorage_domain_dynamic
@@ -26,7 +26,7 @@ CREATE OR REPLACE FUNCTION inst_add_iso_storage_domain (
     v_available INT,
     v_used INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 DECLARE
 
 BEGIN
@@ -47,7 +47,7 @@ BEGIN
     exception when others then RAISE EXCEPTION 'NUM:%, DETAILS:%',
         SQLSTATE,
         SQLERRM;
-    END;$PROCEDURE$
+    END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Updates service types(gluster and virt) in cluster table
@@ -56,13 +56,13 @@ CREATE OR REPLACE FUNCTION inst_update_service_type (
     v_virt_service boolean,
     v_gluster_service boolean
     )
-RETURNS void AS $PROCEDURE$
+RETURNS void AS $FUNCTION$
 BEGIN
     UPDATE cluster
     SET virt_service = v_virt_service,
         gluster_service = v_gluster_service
     WHERE cluster_id = v_cluster_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Adds a new glance provider, according to the specified arguments
@@ -78,7 +78,7 @@ CREATE OR REPLACE FUNCTION inst_add_glance_provider (
     v_auth_url TEXT DEFAULT NULL,
     v_tenant_name VARCHAR(128) DEFAULT NULL
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     -- Adding the Glance provider
     INSERT INTO providers (
@@ -146,7 +146,7 @@ BEGIN
             FROM storage_domain_dynamic
             WHERE id = v_storage_domain_id
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/iscsi_bonds_sp.sql
+++ b/packaging/dbscripts/iscsi_bonds_sp.sql
@@ -4,50 +4,50 @@
 -- [iscsi_bonds] Table
 --
 CREATE OR REPLACE FUNCTION GetIscsiBondByIscsiBondId (v_id UUID)
-RETURNS SETOF iscsi_bonds STABLE AS $PROCEDURE$
+RETURNS SETOF iscsi_bonds STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT iscsi_bonds.*
     FROM iscsi_bonds
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromIscsiBonds ()
-RETURNS SETOF iscsi_bonds STABLE AS $PROCEDURE$
+RETURNS SETOF iscsi_bonds STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT iscsi_bonds.*
     FROM iscsi_bonds;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetIscsiBondsByStoragePoolId (v_storage_pool_id UUID)
-RETURNS SETOF iscsi_bonds STABLE AS $PROCEDURE$
+RETURNS SETOF iscsi_bonds STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT iscsi_bonds.*
     FROM iscsi_bonds
     WHERE storage_pool_id = v_storage_pool_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetNetworksByIscsiBondId (v_iscsi_bond_id UUID)
-RETURNS SETOF UUID STABLE AS $PROCEDURE$
+RETURNS SETOF UUID STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT iscsi_bonds_networks_map.network_id
     FROM iscsi_bonds_networks_map
     WHERE iscsi_bond_id = v_iscsi_bond_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetIscsiBondsByNetworkId (v_network_id UUID)
-RETURNS SETOF iscsi_bonds STABLE AS $PROCEDURE$
+RETURNS SETOF iscsi_bonds STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -56,7 +56,7 @@ BEGIN
         iscsi_bonds
     WHERE iscsi_bonds.id = iscsi_bonds_networks_map.iscsi_bond_id
         AND network_id = v_network_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION InsertIscsiBond (
@@ -65,7 +65,7 @@ CREATE OR REPLACE FUNCTION InsertIscsiBond (
     v_description VARCHAR(4000),
     v_storage_pool_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO iscsi_bonds (
         id,
@@ -79,7 +79,7 @@ BEGIN
         v_description,
         v_storage_pool_id
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateIscsiBond (
@@ -87,31 +87,31 @@ CREATE OR REPLACE FUNCTION UpdateIscsiBond (
     v_name VARCHAR(50),
     v_description VARCHAR(4000)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE iscsi_bonds
     SET name = v_name,
         description = v_description
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteIscsiBond (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 DECLARE v_val UUID;
 
 BEGIN
     DELETE
     FROM iscsi_bonds
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION AddNetworkToIscsiBond (
     v_iscsi_bond_id UUID,
     v_network_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO iscsi_bonds_networks_map (
         iscsi_bond_id,
@@ -121,27 +121,27 @@ BEGIN
         v_iscsi_bond_id,
         v_network_id
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION RemoveNetworkFromIscsiBond (
     v_iscsi_bond_id UUID,
     v_network_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM iscsi_bonds_networks_map
     WHERE iscsi_bond_id = v_iscsi_bond_id
         AND network_id = v_network_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION AddConnectionToIscsiBond (
     v_iscsi_bond_id UUID,
     v_connection_id VARCHAR(50)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO iscsi_bonds_storage_connections_map (
         iscsi_bond_id,
@@ -151,31 +151,31 @@ BEGIN
         v_iscsi_bond_id,
         v_connection_id
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION RemoveConnectionFromIscsiBond (
     v_iscsi_bond_id UUID,
     v_connection_id VARCHAR(50)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM iscsi_bonds_storage_connections_map
     WHERE iscsi_bond_id = v_iscsi_bond_id
         AND connection_id = v_connection_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetConnectionsByIscsiBondId (v_iscsi_bond_id UUID)
-RETURNS SETOF VARCHAR(50) STABLE AS $PROCEDURE$
+RETURNS SETOF VARCHAR(50) STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT iscsi_bonds_storage_connections_map.connection_id
     FROM iscsi_bonds_storage_connections_map
     WHERE iscsi_bond_id = v_iscsi_bond_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/job_sp.sql
+++ b/packaging/dbscripts/job_sp.sql
@@ -18,7 +18,7 @@ CREATE OR REPLACE FUNCTION InsertJob (
     v_is_external boolean,
     v_is_auto_cleared boolean
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO job (
         job_id,
@@ -50,28 +50,28 @@ BEGIN
         v_is_external,
         v_is_auto_cleared
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ----------------------------------------------------
 -- Retrieves Job entity by its job-id from Job table
 ----------------------------------------------------
 CREATE OR REPLACE FUNCTION GetJobByJobId (v_job_id UUID)
-RETURNS SETOF job STABLE AS $PROCEDURE$
+RETURNS SETOF job STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT job.*
     FROM JOB
     WHERE job_id = v_job_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 --------------------------------------------
 -- Retrieves All Job entitise from Job table
 --------------------------------------------
 CREATE OR REPLACE FUNCTION GetAllJobs ()
-RETURNS SETOF job STABLE AS $PROCEDURE$
+RETURNS SETOF job STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -79,7 +79,7 @@ BEGIN
     FROM JOB
     WHERE status != 'UNKNOWN'
     ORDER BY start_time DESC;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -----------------------------------------------------
@@ -89,7 +89,7 @@ CREATE OR REPLACE FUNCTION GetJobsByOffsetAndPageSize (
     v_position INT,
     v_page_size INT
     )
-RETURNS SETOF job STABLE AS $PROCEDURE$
+RETURNS SETOF job STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY(SELECT job.* FROM JOB WHERE status = 'STARTED' ORDER BY last_update_time DESC)
 
@@ -104,21 +104,21 @@ BEGIN
                 )
         ORDER BY last_update_time DESC
         ) OFFSET v_position LIMIT v_page_size;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -----------------------------------------------
 -- Retrieves All Job entities by Correlation-ID
 -----------------------------------------------
 CREATE OR REPLACE FUNCTION GetJobsByCorrelationId (v_correlation_id VARCHAR(50))
-RETURNS SETOF job STABLE AS $PROCEDURE$
+RETURNS SETOF job STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT job.*
     FROM JOB
     WHERE correlation_id = v_correlation_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -----------------------------------------------------------------
@@ -128,14 +128,14 @@ CREATE OR REPLACE FUNCTION GetJobsByEngineSessionSeqIdAndStatus (
     v_engine_session_seq_id BIGINT,
     v_status VARCHAR(32)
     )
-RETURNS SETOF job STABLE AS $PROCEDURE$
+RETURNS SETOF job STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
     SELECT job.*
     FROM JOB
     WHERE engine_session_seq_id = v_engine_session_seq_id
         AND status = v_status;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ----------------------------------
@@ -156,7 +156,7 @@ CREATE OR REPLACE FUNCTION UpdateJob (
     v_is_external boolean,
     v_is_auto_cleared boolean
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE job
     SET action_type = v_action_type,
@@ -172,7 +172,7 @@ BEGIN
         is_external = v_is_external,
         is_auto_cleared = v_is_auto_cleared
     WHERE job_id = v_job_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -------------------------------------------------------
@@ -182,12 +182,12 @@ CREATE OR REPLACE FUNCTION UpdateJobLastUpdateTime (
     v_job_id UUID,
     v_last_update_time TIMESTAMP WITH TIME ZONE
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE job
     SET last_update_time = v_last_update_time
     WHERE job_id = v_job_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 --------------------------------------------
@@ -197,26 +197,26 @@ CREATE OR REPLACE FUNCTION DeleteJobOlderThanDateWithStatus (
     v_end_time TIMESTAMP WITH TIME ZONE,
     v_status TEXT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM job
     WHERE is_auto_cleared
         AND end_time < v_end_time
         AND status = ANY (string_to_array(v_status, ',')::VARCHAR []);
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -------------------------------
 -- Deletes Job entity by Job-Id
 -------------------------------
 CREATE OR REPLACE FUNCTION DeleteJob (v_job_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM job
     WHERE job_id = v_job_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ---------------------------------------------------------------
@@ -227,7 +227,7 @@ CREATE OR REPLACE FUNCTION InsertJobSubjectEntity (
     v_entity_id UUID,
     v_entity_type VARCHAR(32)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO job_subject_entity (
         job_id,
@@ -239,35 +239,35 @@ BEGIN
         v_entity_id,
         v_entity_type
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ---------------------------------------------
 -- Gets Job Subject Entity of a Job By Job-id
 ---------------------------------------------
 CREATE OR REPLACE FUNCTION GetJobSubjectEntityByJobId (v_job_id UUID)
-RETURNS SETOF job_subject_entity STABLE AS $PROCEDURE$
+RETURNS SETOF job_subject_entity STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT job_subject_entity.*
     FROM job_subject_entity
     WHERE job_id = v_job_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ------------------------------------------------
 -- Gets Job Subject Entity of a Job By entity-id
 ------------------------------------------------
 CREATE OR REPLACE FUNCTION GetAllJobIdsByEntityId (v_entity_id UUID)
-RETURNS SETOF UUID STABLE AS $PROCEDURE$
+RETURNS SETOF UUID STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT job_subject_entity.job_id
     FROM job_subject_entity
     WHERE entity_id = v_entity_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 --------------------------------------
@@ -289,7 +289,7 @@ CREATE OR REPLACE FUNCTION InsertStep (
     v_external_system_type VARCHAR(32),
     v_is_external boolean
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO step (
         step_id,
@@ -323,7 +323,7 @@ BEGIN
         v_external_system_type,
         v_is_external
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ------------------------------------
@@ -344,7 +344,7 @@ CREATE OR REPLACE FUNCTION UpdateStep (
     v_external_id UUID,
     v_external_system_type VARCHAR(32)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE step
     SET parent_step_id = v_parent_step_id,
@@ -360,7 +360,7 @@ BEGIN
         external_id = v_external_id,
         external_system_type = v_external_system_type
     WHERE step_id = v_step_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 --------------------------------------
@@ -371,13 +371,13 @@ CREATE OR REPLACE FUNCTION UpdateStepStatusAndEndTime (
     v_status VARCHAR(32),
     v_end_time TIMESTAMP WITH TIME ZONE
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE step
     SET status = v_status,
         end_time = v_end_time
     WHERE step_id = v_step_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ------------------------------------------------------
@@ -388,34 +388,34 @@ CREATE OR REPLACE FUNCTION UpdateStepExternalIdAndType (
     v_external_id UUID,
     v_external_system_type VARCHAR(32)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE step
     SET external_id = v_external_id,
         external_system_type = v_external_system_type
     WHERE step_id = v_step_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ----------------------------------------------
 -- Gets Step entity from Step table by Step-Id
 ----------------------------------------------
 CREATE OR REPLACE FUNCTION GetStepByStepId (v_step_id UUID)
-RETURNS SETOF step STABLE AS $PROCEDURE$
+RETURNS SETOF step STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT step.*
     FROM step
     WHERE step_id = v_step_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ----------------------------------------------------
 -- Gets Step entities list from Step table by Job-Id
 ----------------------------------------------------
 CREATE OR REPLACE FUNCTION GetStepsByJobId (v_job_id UUID)
-RETURNS SETOF step STABLE AS $PROCEDURE$
+RETURNS SETOF step STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -424,14 +424,14 @@ BEGIN
     WHERE job_id = v_job_id
     ORDER BY parent_step_id nulls first,
         step_number;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ------------------------------------------------------------
 -- Gets Step entities list from Step table by parent-step-id
 ------------------------------------------------------------
 CREATE OR REPLACE FUNCTION GetStepsByParentStepId (v_parent_step_id UUID)
-RETURNS SETOF step STABLE AS $PROCEDURE$
+RETURNS SETOF step STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -439,32 +439,32 @@ BEGIN
     FROM step
     WHERE parent_step_id = v_parent_step_id
     ORDER BY step_number;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ---------------------------------------------
 -- Gets Step entity from Step table by Job-Id
 ---------------------------------------------
 CREATE OR REPLACE FUNCTION GetAllSteps ()
-RETURNS SETOF step STABLE AS $PROCEDURE$
+RETURNS SETOF step STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT step.*
     FROM step;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ---------------------------------
 -- Deletes Step entity by Step-Id
 ---------------------------------
 CREATE OR REPLACE FUNCTION DeleteStep (v_step_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM step
     WHERE step_id = v_step_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ---------------------------------------------------------------
@@ -476,7 +476,7 @@ CREATE OR REPLACE FUNCTION InsertStepSubjectEntity (
     v_entity_type VARCHAR(32),
     v_step_entity_weight SMALLINT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO step_subject_entity (
         step_id,
@@ -490,7 +490,7 @@ BEGIN
         v_entity_type,
         v_step_entity_weight
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -498,25 +498,25 @@ CREATE OR REPLACE FUNCTION DeleteStepSubjectEntity (
     v_step_id UUID,
     v_entity_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE FROM step_subject_entity sse
     WHERE sse.step_id = v_step_id
     AND sse.entity_id = v_entity_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -----------------------------------------------------
 -- Get Step Subject Entities of a step by the step id
 -----------------------------------------------------
 CREATE OR REPLACE FUNCTION GetStepSubjectEntitiesByStepId (v_step_id UUID)
-RETURNS SETOF step_subject_entity STABLE AS $PROCEDURE$
+RETURNS SETOF step_subject_entity STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
     SELECT *
     FROM step_subject_entity
     WHERE step_id = v_step_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ----------------------------------------------
@@ -527,7 +527,7 @@ CREATE OR REPLACE FUNCTION updateJobStepsCompleted (
     v_status VARCHAR(32),
     v_end_time TIMESTAMP WITH TIME ZONE
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE step
     SET status = v_status,
@@ -535,7 +535,7 @@ BEGIN
     WHERE job_id = v_job_id
         AND status = 'STARTED'
         AND status != v_status;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ----------------------------------------------
@@ -545,19 +545,19 @@ CREATE OR REPLACE FUNCTION updateStepProgress (
     v_step_id UUID,
     v_progress SMALLINT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE step
     SET progress = v_progress
     WHERE step_id = v_step_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -------------------------------------------
 -- Updates Job and Step statuses to UNKNOWN
 -------------------------------------------
 CREATE OR REPLACE FUNCTION UpdateStartedExecutionEntitiesToUnknown (v_end_time TIMESTAMP WITH TIME ZONE)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE job
     SET status = 'UNKNOWN',
@@ -579,14 +579,14 @@ BEGIN
             FROM step step
             WHERE step.external_id IS NOT NULL
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ------------------------------------------------
 -- Cleanup Jobs of async commands without task
 ------------------------------------------------
 CREATE OR REPLACE FUNCTION DeleteRunningJobsOfTasklessCommands ()
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM job
@@ -618,7 +618,7 @@ BEGIN
                     AND step_type = 'MIGRATE_VM'
                     )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 --------------------------------------------
@@ -628,7 +628,7 @@ CREATE OR REPLACE FUNCTION DeleteCompletedJobsOlderThanDate (
     v_succeeded_end_time TIMESTAMP WITH TIME ZONE,
     v_failed_end_time TIMESTAMP WITH TIME ZONE
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM job
@@ -649,14 +649,14 @@ BEGIN
                     )
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -------------------------------------
 -- Checks if a Job has step for tasks
 -------------------------------------
 CREATE OR REPLACE FUNCTION CheckIfJobHasTasks (v_job_id UUID)
-RETURNS SETOF booleanResultType STABLE AS $PROCEDURE$
+RETURNS SETOF booleanResultType STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -670,14 +670,14 @@ BEGIN
                     'GLUSTER'
                     )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ----------------------------------------------------
 -- Gets Step entities list from Step table by external id
 ----------------------------------------------------
 CREATE OR REPLACE FUNCTION GetStepsByExternalTaskId (v_external_id UUID)
-RETURNS SETOF step STABLE AS $PROCEDURE$
+RETURNS SETOF step STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -686,7 +686,7 @@ BEGIN
     WHERE external_id = v_external_id
     ORDER BY parent_step_id nulls first,
         step_number;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ----------------------------------------------------
@@ -697,7 +697,7 @@ CREATE OR REPLACE FUNCTION GetExternalIdsFromSteps (
     v_status VARCHAR(32),
     v_external_system_type VARCHAR(32)
     )
-RETURNS SETOF UUID STABLE AS $PROCEDURE$
+RETURNS SETOF UUID STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -707,7 +707,7 @@ BEGIN
         ON step.job_id = job.job_id
     WHERE job.status = v_status
         AND step.external_system_type = v_external_system_type;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -716,7 +716,7 @@ CREATE OR REPLACE FUNCTION GetStepsForEntityByStatus (
     v_entity_id UUID,
     v_entity_type VARCHAR(32)
     )
-RETURNS SETOF step STABLE AS $PROCEDURE$
+RETURNS SETOF step STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
     SELECT s.*
@@ -726,7 +726,7 @@ BEGIN
     WHERE sse.entity_id = v_entity_id
         AND sse.entity_type = v_entity_type
         AND s.status = v_status;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/labels_sp.sql
+++ b/packaging/dbscripts/labels_sp.sql
@@ -6,7 +6,7 @@ CREATE OR REPLACE FUNCTION CreateLabel (
     v_vms uuid[],
     v_hosts uuid[]
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 DECLARE
    o uuid;
 BEGIN
@@ -48,7 +48,7 @@ BEGIN
             o
             );
     END LOOP;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateLabel (
@@ -61,7 +61,7 @@ CREATE OR REPLACE FUNCTION UpdateLabel (
     )
 RETURNS VOID
     --The [tags] table doesn't have a timestamp column. Optimistic concurrency logic cannot be generated
-    AS $PROCEDURE$
+    AS $FUNCTION$
 DECLARE
    o uuid;
 BEGIN
@@ -99,53 +99,53 @@ BEGIN
             o
             );
     END LOOP;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteLabel (v_label_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 
 BEGIN
     DELETE
     FROM labels
     WHERE label_id = v_label_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllLabels ()
-RETURNS SETOF labels_map_view STABLE AS $PROCEDURE$
+RETURNS SETOF labels_map_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT labels_map_view.*
     FROM labels_map_view;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetLabelById (v_label_id UUID)
-RETURNS SETOF labels_map_view STABLE AS $PROCEDURE$
+RETURNS SETOF labels_map_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT labels_map_view.*
     FROM labels_map_view
     WHERE label_id = v_label_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetLabelByIds (v_label_ids UUID[])
-RETURNS SETOF labels_map_view STABLE AS $PROCEDURE$
+RETURNS SETOF labels_map_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT labels_map_view.*
     FROM labels_map_view
     WHERE label_id = ANY(v_label_ids);
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllLabelsForCluster (v_cluster_id UUID)
-RETURNS SETOF labels_map_view STABLE AS $PROCEDURE$
+RETURNS SETOF labels_map_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -159,22 +159,22 @@ BEGIN
         WHERE vds_static.cluster_id = v_cluster_id OR
             vm_static.cluster_id = v_cluster_id
     );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetLabelByName (v_label_name varchar(50))
-RETURNS SETOF labels_map_view STABLE AS $PROCEDURE$
+RETURNS SETOF labels_map_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT labels_map_view.*
     FROM labels_map_view
     WHERE label_name = v_label_name;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetLabelsByReferencedIds (v_entity_ids UUID[])
-RETURNS SETOF labels_map_view STABLE AS $PROCEDURE$
+RETURNS SETOF labels_map_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -182,14 +182,14 @@ BEGIN
     FROM labels_map_view
     WHERE vm_ids::uuid[] && v_entity_ids
         OR vds_ids::uuid[] && v_entity_ids;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION AddVmToLabels (
     v_vm_id UUID,
     v_labels uuid[]
 )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 DECLARE
     o uuid;
 BEGIN
@@ -198,14 +198,14 @@ BEGIN
         vm_id
     )
     SELECT unnest(v_labels), v_vm_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION AddHostToLabels (
     v_host_id UUID,
     v_labels uuid[]
 )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 DECLARE
     o uuid;
 BEGIN
@@ -214,14 +214,14 @@ BEGIN
         vds_id
     )
     SELECT unnest(v_labels), v_host_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateLabelsForVm (
     v_vm_id UUID,
     v_labels uuid[]
 )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     -- Remove existing entries for the VM
     DELETE FROM labels_map
@@ -230,14 +230,14 @@ BEGIN
     -- Add the current entries for the VM
     PERFORM
         AddVmToLabels(v_vm_id, v_labels);
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateLabelsForHost (
     v_host_id UUID,
     v_labels uuid[]
 )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     -- Remove existing entries for the host
     DELETE FROM labels_map
@@ -246,7 +246,7 @@ BEGIN
     -- Add the current entries for the host
     PERFORM
         AddHostToLabels(v_host_id, v_labels);
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 DROP TYPE IF EXISTS entity_name_map_rs CASCADE;
@@ -256,7 +256,7 @@ CREATE TYPE entity_name_map_rs AS (
         );
 
 CREATE OR REPLACE FUNCTION GetEntitiesNameMap ()
-RETURNS SETOF entity_name_map_rs STABLE AS $PROCEDURE$
+RETURNS SETOF entity_name_map_rs STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -267,5 +267,5 @@ BEGIN
             ON vm_static.vm_guid = labels_map.vm_id
         LEFT JOIN vds_static
             ON vds_static.vds_id = labels_map.vds_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;

--- a/packaging/dbscripts/libvirt_secrets_sp.sql
+++ b/packaging/dbscripts/libvirt_secrets_sp.sql
@@ -4,14 +4,14 @@
 --  Libvirt Secrets Table
 ----------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION GetLibvirtSecretByLibvirtSecretId (v_secret_id UUID)
-RETURNS SETOF libvirt_secrets STABLE AS $PROCEDURE$
+RETURNS SETOF libvirt_secrets STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM libvirt_secrets
     WHERE secret_id = v_secret_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION InsertLibvirtSecret (
@@ -22,7 +22,7 @@ CREATE OR REPLACE FUNCTION InsertLibvirtSecret (
     v_provider_id UUID,
     v__create_date TIMESTAMP WITH TIME ZONE
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO libvirt_secrets (
         secret_id,
@@ -40,7 +40,7 @@ BEGIN
         v_provider_id,
         v__create_date
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateLibvirtSecret (
@@ -50,7 +50,7 @@ CREATE OR REPLACE FUNCTION UpdateLibvirtSecret (
     v_secret_description TEXT,
     v_provider_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE libvirt_secrets
     SET secret_id = v_secret_id,
@@ -60,41 +60,41 @@ BEGIN
         provider_id = v_provider_id,
         _update_date = LOCALTIMESTAMP
     WHERE secret_id = v_secret_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteLibvirtSecret (v_secret_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM libvirt_secrets
     WHERE secret_id = v_secret_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromLibvirtSecrets ()
-RETURNS SETOF libvirt_secrets STABLE AS $PROCEDURE$
+RETURNS SETOF libvirt_secrets STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM libvirt_secrets;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllLibvirtSecretsByProviderId (v_provider_id UUID)
-RETURNS SETOF libvirt_secrets STABLE AS $PROCEDURE$
+RETURNS SETOF libvirt_secrets STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM libvirt_secrets
     WHERE provider_id = v_provider_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetLibvirtSecretsByPoolIdOnActiveDomains (v_storage_pool_id UUID)
-RETURNS SETOF libvirt_secrets STABLE AS $PROCEDURE$
+RETURNS SETOF libvirt_secrets STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -106,7 +106,7 @@ BEGIN
         ON storage_domain_static.id = storage_pool_iso_map.storage_id
     WHERE storage_pool_iso_map.storage_pool_id = v_storage_pool_id
         AND storage_pool_iso_map.status = 3;-- Active
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/mac_pools_sp.sql
+++ b/packaging/dbscripts/mac_pools_sp.sql
@@ -6,7 +6,7 @@ CREATE OR REPLACE FUNCTION InsertMacPool (
     v_allow_duplicate_mac_addresses BOOLEAN,
     v_description VARCHAR(4000)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO mac_pools (
         id,
@@ -20,7 +20,7 @@ BEGIN
         v_allow_duplicate_mac_addresses,
         v_description
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateMacPool (
@@ -29,7 +29,7 @@ CREATE OR REPLACE FUNCTION UpdateMacPool (
     v_allow_duplicate_mac_addresses BOOLEAN,
     v_description VARCHAR(4000)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE mac_pools
     SET id = v_id,
@@ -37,42 +37,42 @@ BEGIN
         allow_duplicate_mac_addresses = v_allow_duplicate_mac_addresses,
         description = v_description
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteMacPool (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM mac_pools
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetMacPoolByMacPoolId (v_id UUID)
-RETURNS SETOF mac_pools STABLE AS $PROCEDURE$
+RETURNS SETOF mac_pools STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM mac_pools
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetDefaultMacPool ()
-RETURNS SETOF mac_pools STABLE AS $PROCEDURE$
+RETURNS SETOF mac_pools STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM mac_pools
     WHERE default_pool IS true;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetMacPoolByClusterId (v_cluster_id UUID)
-RETURNS SETOF mac_pools STABLE AS $PROCEDURE$
+RETURNS SETOF mac_pools STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -81,21 +81,21 @@ BEGIN
     INNER JOIN cluster c
         ON c.mac_pool_id = mp.id
     WHERE c.cluster_id = v_cluster_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromMacPools ()
-RETURNS SETOF mac_pools STABLE AS $PROCEDURE$
+RETURNS SETOF mac_pools STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM mac_pools;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllMacsByMacPoolId (v_id UUID)
-RETURNS SETOF VARCHAR STABLE AS $PROCEDURE$
+RETURNS SETOF VARCHAR STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -109,16 +109,16 @@ BEGIN
             WHERE c.mac_pool_id = v_id
                 AND vm_static.vm_guid = vm_interface.vm_guid
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
--- Procedures for MAC ranges
+-- Functions for MAC ranges
 CREATE OR REPLACE FUNCTION InsertMacPoolRange (
     v_mac_pool_id UUID,
     v_from_mac VARCHAR(17),
     v_to_mac VARCHAR(17)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO mac_pool_ranges (
         mac_pool_id,
@@ -130,27 +130,27 @@ BEGIN
         v_from_mac,
         v_to_mac
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteMacPoolRangesByMacPoolId (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM mac_pool_ranges
     WHERE mac_pool_id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllMacPoolRangesByMacPoolId (v_id UUID)
-RETURNS SETOF mac_pool_ranges STABLE AS $PROCEDURE$
+RETURNS SETOF mac_pool_ranges STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM mac_pool_ranges
     WHERE mac_pool_id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/multi_level_administration_sp.sql
+++ b/packaging/dbscripts/multi_level_administration_sp.sql
@@ -11,7 +11,7 @@ CREATE OR REPLACE FUNCTION InsertPermission (
     v_object_id UUID,
     v_object_type_id INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO permissions (
         ad_element_id,
@@ -27,11 +27,11 @@ BEGIN
         v_object_id,
         v_object_type_id
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeletePermission (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 DECLARE v_val UUID;
 
 BEGIN
@@ -48,26 +48,26 @@ BEGIN
     DELETE
     FROM permissions
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetPermissionsByid (v_id UUID)
 RETURNS SETOF permissions_view STABLE
-AS $PROCEDURE$
+AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM permissions_view
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION get_user_permissions_for_domain (
     v_name VARCHAR(255),
     v_domain VARCHAR(255)
     )
-RETURNS SETOF permissions_view STABLE AS $PROCEDURE$
+RETURNS SETOF permissions_view STABLE AS $FUNCTION$
 DECLARE v_user_name VARCHAR(255);
 
 v_index INT;
@@ -94,11 +94,11 @@ WHERE permissions_view.ad_element_id IN (
                 users.name = v_user_name
                 OR users.name = v_user_name || '@' || upper(v_domain)
                 )
-        );END;$PROCEDURE$
+        );END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetConsumedPermissionsForQuotaId (v_quota_id UUID)
-RETURNS SETOF permissions_view STABLE AS $PROCEDURE$
+RETURNS SETOF permissions_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -113,7 +113,7 @@ BEGIN
             SELECT id
             FROM fn_get_entity_parents(v_quota_id, 17)
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetPermissionsByAdElementIdAndGroupIds(
@@ -123,7 +123,7 @@ CREATE OR REPLACE FUNCTION GetPermissionsByAdElementIdAndGroupIds(
     v_is_filtered BOOLEAN,
     v_app_mode INT
     )
-RETURNS SETOF permissions_view STABLE AS $PROCEDURE$
+RETURNS SETOF permissions_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -135,7 +135,7 @@ BEGIN
             OR ad_element_id = ANY(array_append(v_user_groups, 'EEE00000-0000-0000-0000-123456789EEE'))
             )
         AND (NOT v_is_filtered OR v_user_id = v_ad_element_id);
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetPermissionsByAdElementId (
@@ -144,7 +144,7 @@ CREATE OR REPLACE FUNCTION GetPermissionsByAdElementId (
     v_is_filtered BOOLEAN,
     v_app_mode INT
     )
-RETURNS SETOF permissions_view STABLE AS $PROCEDURE$
+RETURNS SETOF permissions_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -168,25 +168,25 @@ BEGIN
                     AND engine_sessions.id = v_engine_session_seq_id
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetPermissionsByRoleId (v_role_id UUID)
-RETURNS SETOF permissions_view STABLE AS $PROCEDURE$
+RETURNS SETOF permissions_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM permissions_view
     WHERE role_id = v_role_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetPermissionsByRoleIdAndAdElementId (
     v_role_id UUID,
     v_ad_element_id UUID
     )
-RETURNS SETOF permissions_view STABLE AS $PROCEDURE$
+RETURNS SETOF permissions_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -194,7 +194,7 @@ BEGIN
     FROM permissions_view
     WHERE role_id = v_role_id
         AND ad_element_id = v_ad_element_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetPermissionsByRoleIdAndAdElementIdAndObjectId (
@@ -202,7 +202,7 @@ CREATE OR REPLACE FUNCTION GetPermissionsByRoleIdAndAdElementIdAndObjectId (
     v_ad_element_id UUID,
     v_object_id UUID
     )
-RETURNS SETOF permissions_view STABLE AS $PROCEDURE$
+RETURNS SETOF permissions_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -211,18 +211,18 @@ BEGIN
     WHERE role_id = v_role_id
         AND ad_element_id = v_ad_element_id
         AND object_id = v_object_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetDirectPermissionsByAdElementId (v_ad_element_id UUID)
-RETURNS SETOF permissions_view STABLE AS $PROCEDURE$
+RETURNS SETOF permissions_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM permissions_view
     WHERE permissions_view.ad_element_id = v_ad_element_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ----------------------------------------------------------------
@@ -237,7 +237,7 @@ CREATE OR REPLACE FUNCTION InsertRole (
     v_allows_viewing_children BOOLEAN,
     v_app_mode INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO roles (
         description,
@@ -257,7 +257,7 @@ BEGIN
         v_allows_viewing_children,
         v_app_mode
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateRole (
@@ -270,7 +270,7 @@ CREATE OR REPLACE FUNCTION UpdateRole (
     )
 RETURNS VOID
     --The [roles] table doesn't have a timestamp column. Optimistic concurrency logic cannot be generated
-    AS $PROCEDURE$
+    AS $FUNCTION$
 BEGIN
     UPDATE roles
     SET description = v_description,
@@ -279,11 +279,11 @@ BEGIN
         role_type = v_role_type,
         allows_viewing_children = v_allows_viewing_children
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteRole (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 DECLARE v_val UUID;
 
 BEGIN
@@ -300,7 +300,7 @@ BEGIN
     DELETE
     FROM roles
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- The logic to get the applicable set of roles for a given application mode is as below-
@@ -326,39 +326,39 @@ LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromRole(v_app_mode INTEGER)
 RETURNS SETOF roles STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
    RETURN QUERY SELECT *
    FROM roles
    WHERE (roles.app_mode & v_app_mode) > 0;
 
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
 CREATE OR REPLACE FUNCTION GetAllNonAdminRoles(v_app_mode INTEGER)
 RETURNS SETOF roles STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
    RETURN QUERY SELECT *
    FROM roles
    WHERE (roles.app_mode & v_app_mode) > 0
       AND role_type != 1;
 
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
 
 CREATE OR REPLACE FUNCTION GetRolsByid(v_id UUID)
 RETURNS SETOF roles STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
    RETURN QUERY SELECT *
    FROM roles
    WHERE id = v_id;
 
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -366,13 +366,13 @@ LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetRoleByName(v_name VARCHAR(126))
 RETURNS SETOF roles STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
    RETURN QUERY SELECT *
    FROM roles
    WHERE name = v_name;
 
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -383,7 +383,7 @@ CREATE OR REPLACE FUNCTION GetAnyAdminRoleByUserIdAndGroupIds(
     v_group_ids text,
     v_app_mode INTEGER)
 RETURNS SETOF roles STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
    RETURN QUERY SELECT roles.*
    FROM roles INNER JOIN
@@ -396,7 +396,7 @@ BEGIN
                FROM getElementIdsByIdAndGroups(v_user_id, v_group_ids))
        ) LIMIT 1;
 
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 ----------------------------------------------------------------
@@ -410,12 +410,12 @@ LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetPermissionByRoleId(v_role_id UUID)
 RETURNS SETOF permissions STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
    RETURN QUERY SELECT *
    FROM permissions
    WHERE role_id = v_role_id;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -428,8 +428,8 @@ CREATE OR REPLACE FUNCTION get_entity_permissions(
     v_action_group_id INTEGER,
     v_object_id UUID,v_object_type_id INTEGER)
 RETURNS SETOF UUID STABLE
-   -- Add the parameters for the stored procedure here
-   AS $procedure$
+   -- Add the parameters for the stored FUNCTION here
+   AS $FUNCTION$
    DECLARE
    v_everyone_object_id  UUID;
 BEGIN
@@ -453,7 +453,7 @@ BEGIN
            SELECT *
            FROM getUserAndGroupsById(v_user_id)
        )) LIMIT 1;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 -- gets entity permissions given the user id, groups, action group id and the object type and object id
@@ -465,8 +465,8 @@ CREATE OR REPLACE FUNCTION get_entity_permissions_for_user_and_groups(
     v_object_type_id INTEGER,
     v_ignore_everyone BOOLEAN)
 RETURNS SETOF UUID STABLE
-	-- Add the parameters for the stored procedure here
-AS $procedure$
+	-- Add the parameters for the stored FUNCTION here
+AS $FUNCTION$
    DECLARE
    v_everyone_object_id  UUID;
 BEGIN
@@ -490,7 +490,7 @@ BEGIN
             SELECT *
             FROM fnsplitteruuid(v_group_ids)
        )) LIMIT 1;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 ----------------------------------------------------------------
@@ -503,7 +503,7 @@ CREATE OR REPLACE FUNCTION Insert_roles_groups(
     v_action_group_id INTEGER,
     v_role_id UUID)
 RETURNS VOID
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
     INSERT INTO roles_groups(
         action_group_id,
@@ -511,7 +511,7 @@ BEGIN
     VALUES(
         v_action_group_id,
         v_role_id);
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -522,14 +522,14 @@ CREATE OR REPLACE FUNCTION Delete_roles_groups(
     v_action_group_id INTEGER,
     v_role_id UUID)
 RETURNS VOID
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
 
     DELETE FROM roles_groups
     WHERE action_group_id = v_action_group_id
         AND role_id = v_role_id;
 
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -540,7 +540,7 @@ CREATE OR REPLACE FUNCTION Get_roles_groups_By_action_group_id_And_By_role_id(
     v_action_group_id INTEGER,
     v_role_id UUID)
 RETURNS SETOF roles_groups STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
     RETURN QUERY SELECT *
     FROM roles_groups
@@ -548,7 +548,7 @@ BEGIN
         action_group_id = v_action_group_id
         AND role_id = v_role_id;
 
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -557,14 +557,14 @@ LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Get_role_groups_By_role_id(v_role_id UUID)
 RETURNS SETOF roles_groups STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
     RETURN QUERY SELECT *
     FROM roles_groups
     WHERE
         role_id = v_role_id;
 
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -579,7 +579,7 @@ CREATE OR REPLACE FUNCTION GetPermissionsByEntityId(
 RETURNS SETOF permissions_view STABLE
 -- SET NOCOUNT ON added to prevent extra result sets from
 -- interfering with SELECT statements.
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
     RETURN QUERY SELECT *
     FROM permissions_view
@@ -593,7 +593,7 @@ BEGIN
                 v_is_filtered)
         )
     );
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -603,7 +603,7 @@ CREATE OR REPLACE FUNCTION GetAllUsersWithPermissionsOnEntityByEntityId(
     v_is_filtered BOOLEAN,
     v_app_mode INTEGER)
 RETURNS SETOF permissions_view STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
     RETURN QUERY SELECT *
     FROM permissions_view
@@ -617,7 +617,7 @@ BEGIN
                 v_is_filtered)
         )
     );
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -629,7 +629,7 @@ CREATE OR REPLACE FUNCTION GetUserPermissionsByEntityId(
 RETURNS SETOF permissions_view STABLE
 -- SET NOCOUNT ON added to prevent extra result sets from
 -- interfering with SELECT statements.
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
     RETURN QUERY SELECT *
     FROM permissions_view p
@@ -639,7 +639,7 @@ BEGIN
         FROM  engine_session_user_flat_groups u
         WHERE  p.ad_element_id = u.granted_id
             AND u.engine_session_seq_id = v_engine_session_seq_id));
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -649,7 +649,7 @@ CREATE OR REPLACE FUNCTION GetAllUsersWithPermissionsByEntityId(
      v_engine_session_seq_id INTEGER,
      v_is_filtered BOOLEAN)
 RETURNS SETOF permissions_view STABLE
-   AS $procedure$
+   AS $FUNCTION$
 DECLARE
     r_type int4;
 BEGIN
@@ -668,7 +668,7 @@ BEGIN
                     AND u.engine_session_seq_id = v_engine_session_seq_id));
     END LOOP;
     RETURN;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -677,21 +677,21 @@ CREATE OR REPLACE FUNCTION DeletePermissionsByEntityId(v_id UUID)
 RETURNS VOID
 	-- SET NOCOUNT ON added to prevent extra result sets from
 	-- interfering with SELECT statements.
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
    DELETE FROM permissions
    WHERE object_id = v_id;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
 CREATE OR REPLACE FUNCTION DeletePermissionsByEntityIds(v_ids UUID[])
 RETURNS VOID
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
    DELETE FROM permissions
    WHERE object_id = ANY(v_ids);
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -700,12 +700,12 @@ CREATE OR REPLACE FUNCTION GetRoleActionGroupsByRoleId(v_id UUID)
 RETURNS SETOF roles_groups STABLE
     -- SET NOCOUNT ON added to prevent extra result sets from
     -- interfering with SELECT statements.
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
    RETURN QUERY SELECT *
    FROM roles_groups
    WHERE role_id = v_id;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -721,7 +721,7 @@ CREATE OR REPLACE FUNCTION GetPermissionsTreeByEntityId(
 RETURNS SETOF permissions_view STABLE
 	-- SET NOCOUNT ON added to prevent extra result sets from
 	-- interfering with SELECT statements.
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
     RETURN QUERY SELECT *
     FROM  permissions_view p
@@ -737,7 +737,7 @@ BEGIN
                      AND u.engine_session_seq_id = v_engine_session_seq_id)
         );
 
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -748,14 +748,14 @@ CREATE OR REPLACE FUNCTION GetPermissionsByRoleIdAndObjectId(
     v_role_id UUID,
     v_object_id UUID)
 RETURNS SETOF permissions_view STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
    RETURN QUERY SELECT *
    FROM permissions_view
    WHERE role_id = v_role_id
        AND object_id = v_object_id;
 
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -764,7 +764,7 @@ CREATE OR REPLACE FUNCTION GetForRoleAndAdElementAndObject_wGroupCheck(
     v_ad_element_id UUID,
     v_object_id UUID)
 RETURNS SETOF permissions_view STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
    RETURN QUERY SELECT *
    FROM permissions_view
@@ -774,18 +774,18 @@ BEGIN
            SELECT *
            FROM getUserAndGroupsById(v_ad_element_id)
        );
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetPermissionsByAdElementAndObjectId(
     v_ad_element_id UUID,
     v_object_id UUID)
 RETURNS SETOF permissions_view STABLE
-    AS $procedure$
+    AS $FUNCTION$
 BEGIN
     RETURN QUERY SELECT *
     FROM permissions_view
     WHERE ad_element_id = v_ad_element_id
         AND object_id = v_object_id;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;

--- a/packaging/dbscripts/network_sp.sql
+++ b/packaging/dbscripts/network_sp.sql
@@ -27,7 +27,7 @@ CREATE OR REPLACE FUNCTION Insertnetwork (
     v_dns_resolver_configuration_id UUID,
     v_port_isolation BOOLEAN
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO network (
         addr,
@@ -75,7 +75,7 @@ BEGIN
         v_dns_resolver_configuration_id,
         v_port_isolation
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Updatenetwork (
@@ -103,7 +103,7 @@ CREATE OR REPLACE FUNCTION Updatenetwork (
     )
 RETURNS VOID
     --The [network] table doesn't have a timestamp column. Optimistic concurrency logic cannot be generated
-    AS $PROCEDURE$
+    AS $FUNCTION$
 BEGIN
     UPDATE network
     SET addr = v_addr,
@@ -127,11 +127,11 @@ BEGIN
         dns_resolver_configuration_id = v_dns_resolver_configuration_id,
         port_isolation = v_port_isolation
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Deletenetwork (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 DECLARE v_val UUID;
 
 BEGIN
@@ -149,14 +149,14 @@ BEGIN
 
     -- Delete the network's permissions
     PERFORM DeletePermissionsByEntityId(v_id);
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromnetwork (
     v_user_id uuid,
     v_is_filtered boolean
     )
-RETURNS SETOF network STABLE AS $PROCEDURE$
+RETURNS SETOF network STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -169,7 +169,7 @@ BEGIN
             WHERE user_id = v_user_id
                 AND entity_id = network.id
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetnetworkByid (
@@ -177,7 +177,7 @@ CREATE OR REPLACE FUNCTION GetnetworkByid (
     v_user_id uuid,
     v_is_filtered boolean
     )
-RETURNS SETOF network STABLE AS $PROCEDURE$
+RETURNS SETOF network STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -193,14 +193,14 @@ BEGIN
                     AND entity_id = v_id
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetNetworkByNameAndDataCenter (
     v_name VARCHAR(256),
     v_storage_pool_id UUID
     )
-RETURNS SETOF network STABLE AS $PROCEDURE$
+RETURNS SETOF network STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -208,14 +208,14 @@ BEGIN
     FROM network
     WHERE network.name = v_name
         AND network.storage_pool_id = v_storage_pool_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetNetworkByNameAndCluster (
     v_name VARCHAR(256),
     v_cluster_id UUID
     )
-RETURNS SETOF network STABLE AS $PROCEDURE$
+RETURNS SETOF network STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -228,25 +228,25 @@ BEGIN
             WHERE network.id = network_cluster.network_id
                 AND network_cluster.cluster_id = v_cluster_id
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllNetworksByProviderPhysicalNetworkId (v_network_id UUID)
-RETURNS SETOF network STABLE AS $PROCEDURE$
+RETURNS SETOF network STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT network.*
     FROM network
     WHERE provider_physical_network_id = v_network_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetNetworkByVdsmNameAndDataCenterId (
     v_vdsm_name      VARCHAR(15),
     v_data_center_id UUID
     )
-RETURNS SETOF network STABLE AS $PROCEDURE$
+RETURNS SETOF network STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -254,11 +254,11 @@ BEGIN
     FROM network
     WHERE vdsm_name = v_vdsm_name
           AND storage_pool_id = v_data_center_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetManagementNetworkByCluster (v_cluster_id UUID)
-RETURNS SETOF network STABLE AS $PROCEDURE$
+RETURNS SETOF network STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -270,7 +270,7 @@ BEGIN
             WHERE network_cluster.cluster_id = v_cluster_id
                 AND network_cluster.management
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllNetworkByStoragePoolId (
@@ -278,7 +278,7 @@ CREATE OR REPLACE FUNCTION GetAllNetworkByStoragePoolId (
     v_user_id uuid,
     v_is_filtered boolean
     )
-RETURNS SETOF network STABLE AS $PROCEDURE$
+RETURNS SETOF network STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -294,7 +294,7 @@ BEGIN
                     AND entity_id = network.id
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 DROP TYPE IF EXISTS networkViewClusterType CASCADE;
@@ -336,7 +336,7 @@ CREATE OR REPLACE FUNCTION GetAllNetworkByClusterId (
     v_user_id uuid,
     v_is_filtered boolean
     )
-RETURNS SETOF networkViewClusterType STABLE AS $PROCEDURE$
+RETURNS SETOF networkViewClusterType STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -384,44 +384,44 @@ BEGIN
                 )
             )
     ORDER BY network.name;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllNetworksByQosId (v_id UUID)
-RETURNS SETOF network STABLE AS $PROCEDURE$
+RETURNS SETOF network STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM network
     WHERE qos_id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllNetworksByNetworkProviderId (v_id UUID)
-RETURNS SETOF network STABLE AS $PROCEDURE$
+RETURNS SETOF network STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM network
     WHERE provider_network_provider_id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllNetworkViewsByNetworkProviderId (v_id UUID)
-RETURNS SETOF network_view STABLE AS $PROCEDURE$
+RETURNS SETOF network_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM network_view
     WHERE provider_network_provider_id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllNetworkLabelsByDataCenterId (v_id UUID)
-RETURNS SETOF TEXT STABLE AS $PROCEDURE$
+RETURNS SETOF TEXT STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -429,11 +429,11 @@ BEGIN
     FROM network
     WHERE network.storage_pool_id = v_id
         AND label IS NOT NULL;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetRequiredNetworksByDataCenterId (v_data_center_id UUID)
-RETURNS SETOF network STABLE AS $PROCEDURE$
+RETURNS SETOF network STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -443,10 +443,10 @@ BEGIN
         ON network.id = network_cluster.network_id
     WHERE network_cluster.required
         AND network.storage_pool_id = v_data_center_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
---The GetByFK stored procedure cannot be created because the [network] table doesn't have at least one foreign key column or the foreign keys are also primary keys.
+--The GetByFK stored FUNCTION cannot be created because the [network] table doesn't have at least one foreign key column or the foreign keys are also primary keys.
 ----------------------------------------------------------------
 -- [vds_interface] Table
 --
@@ -481,7 +481,7 @@ CREATE OR REPLACE FUNCTION Insertvds_interface (
     v_ad_aggregator_id INT,
     v_bond_active_slave VARCHAR(50)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO vds_interface (
         addr,
@@ -545,7 +545,7 @@ BEGIN
         v_ad_aggregator_id,
         v_bond_active_slave
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Updatevds_interface (
@@ -581,7 +581,7 @@ CREATE OR REPLACE FUNCTION Updatevds_interface (
     )
 RETURNS VOID
     --The [vds_interface] table doesn't have a timestamp column. Optimistic concurrency logic cannot be generated
-    AS $PROCEDURE$
+    AS $FUNCTION$
 BEGIN
     UPDATE vds_interface
     SET addr = v_addr,
@@ -614,25 +614,25 @@ BEGIN
         ad_aggregator_id = v_ad_aggregator_id,
         bond_active_slave = v_bond_active_slave
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Deletevds_interface (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM vds_interface
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Clear_network_from_nics (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE vds_interface
     SET network_name = NULL
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 DROP TYPE IF EXISTS vds_interface_view_qos_rs CASCADE;
@@ -693,7 +693,7 @@ CREATE OR REPLACE FUNCTION GetInterfaceViewWithQosByVdsId (
     v_user_id UUID,
     v_is_filtered boolean
     )
-RETURNS SETOF vds_interface_view_qos_rs STABLE AS $PROCEDURE$
+RETURNS SETOF vds_interface_view_qos_rs STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -768,7 +768,7 @@ BEGIN
         ) s2
         ON s1.id = s2.id
     ;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 DROP TYPE IF EXISTS host_networks_by_cluster_rs CASCADE;
@@ -778,7 +778,7 @@ CREATE TYPE host_networks_by_cluster_rs AS (
         );
 
 CREATE OR REPLACE FUNCTION GetHostNetworksByCluster (v_cluster_id UUID)
-RETURNS SETOF host_networks_by_cluster_rs STABLE AS $PROCEDURE$
+RETURNS SETOF host_networks_by_cluster_rs STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -788,14 +788,14 @@ BEGIN
     INNER JOIN vds_interface
         ON vds_interface.vds_id = vds_static.vds_id
             AND vds_static.cluster_id = v_cluster_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Getinterface_viewByAddr (
     v_cluster_id UUID,
     v_addr VARCHAR(50)
     )
-RETURNS SETOF vds_interface_view STABLE AS $PROCEDURE$
+RETURNS SETOF vds_interface_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -806,7 +806,7 @@ BEGIN
     WHERE (vds_interface_view.addr = v_addr
         OR vds_interface_view.ipv6_address = v_addr)
         AND vds_static.cluster_id = v_cluster_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVdsManagedInterfaceByVdsId (
@@ -814,7 +814,7 @@ CREATE OR REPLACE FUNCTION GetVdsManagedInterfaceByVdsId (
     v_user_id UUID,
     v_is_filtered boolean
     )
-RETURNS SETOF vds_interface_view STABLE AS $PROCEDURE$
+RETURNS SETOF vds_interface_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -832,11 +832,11 @@ BEGIN
                     AND entity_id = v_vds_id
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVdsInterfacesByNetworkId (v_network_id UUID)
-RETURNS SETOF vds_interface_view STABLE AS $PROCEDURE$
+RETURNS SETOF vds_interface_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -850,25 +850,25 @@ BEGIN
         ON network.id = network_cluster.network_id
             AND network.name = vds_interface_view.network_name
     WHERE network.id = v_network_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVdsInterfaceById (v_vds_interface_id UUID)
-RETURNS SETOF vds_interface_view STABLE AS $PROCEDURE$
+RETURNS SETOF vds_interface_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM vds_interface_view
     WHERE id = v_vds_interface_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVdsInterfaceByName (
     v_host_id UUID,
     v_name VARCHAR(50)
     )
-RETURNS SETOF vds_interface_view STABLE AS $PROCEDURE$
+RETURNS SETOF vds_interface_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -876,13 +876,13 @@ BEGIN
     FROM vds_interface_view
     WHERE name = v_name
         AND vds_id = v_host_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetInterfacesWithQosByClusterId (
     v_cluster_id UUID
     )
-RETURNS SETOF vds_interface_view_qos_rs STABLE AS $PROCEDURE$
+RETURNS SETOF vds_interface_view_qos_rs STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -950,11 +950,11 @@ BEGIN
         ) s2
         ON s1.id = s2.id
     ;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetInterfacesByDataCenterId (v_data_center_id UUID)
-RETURNS SETOF vds_interface_view STABLE AS $PROCEDURE$
+RETURNS SETOF vds_interface_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -965,7 +965,7 @@ BEGIN
     INNER JOIN cluster
         ON vds_static.cluster_id = cluster.cluster_id
     WHERE cluster.storage_pool_id = v_data_center_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ----------------------------------------------------------------
@@ -982,7 +982,7 @@ CREATE OR REPLACE FUNCTION InsertVmInterface (
     v_linked BOOLEAN,
     v_synced BOOLEAN
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO vm_interface (
         id,
@@ -1006,7 +1006,7 @@ BEGIN
         v_linked,
         v_synced
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateVmInterface (
@@ -1020,7 +1020,7 @@ CREATE OR REPLACE FUNCTION UpdateVmInterface (
     v_linked BOOLEAN,
     v_synced BOOLEAN
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE vm_interface
     SET mac_addr = v_mac_addr,
@@ -1033,11 +1033,11 @@ BEGIN
         linked = v_linked,
         synced = v_synced
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteVmInterface (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 DECLARE v_val UUID;
 
 BEGIN
@@ -1054,32 +1054,32 @@ BEGIN
     DELETE
     FROM vm_interface
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVmInterfaceByVmInterfaceId (v_id UUID)
-RETURNS SETOF vm_interface STABLE AS $PROCEDURE$
+RETURNS SETOF vm_interface STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM vm_interface
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromVmInterfaces ()
-RETURNS SETOF vm_interface STABLE AS $PROCEDURE$
+RETURNS SETOF vm_interface STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM vm_interface;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetActiveVmInterfacesByNetworkId (v_network_id UUID)
-RETURNS SETOF vm_interface STABLE AS $PROCEDURE$
+RETURNS SETOF vm_interface STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -1088,44 +1088,44 @@ BEGIN
     INNER JOIN vnic_profiles
         ON vm_interface.vnic_profile_id = vnic_profiles.id
     WHERE vnic_profiles.network_id = v_network_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetActiveVmInterfacesByProfileId (v_profile_id UUID)
-RETURNS SETOF vm_interface STABLE AS $PROCEDURE$
+RETURNS SETOF vm_interface STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT vm_interface.*
     FROM vm_interfaces_plugged_on_vm_not_down_view as vm_interface
     WHERE vm_interface.vnic_profile_id = v_profile_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVmInterfacesByVmId (v_vm_id UUID)
-RETURNS SETOF vm_interface STABLE AS $PROCEDURE$
+RETURNS SETOF vm_interface STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM vm_interface
     WHERE vm_guid = v_vm_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVmInterfaceByTemplateId (v_template_id UUID)
-RETURNS SETOF vm_interface STABLE AS $PROCEDURE$
+RETURNS SETOF vm_interface STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM vm_interface
     WHERE vm_guid = v_template_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVmInterfacesByNetworkId (v_network_id UUID)
-RETURNS SETOF vm_interface STABLE AS $PROCEDURE$
+RETURNS SETOF vm_interface STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -1137,11 +1137,11 @@ BEGIN
         ON vm_interface.vm_guid = vm_static.vm_guid
     WHERE vnic_profiles.network_id = v_network_id
         AND vm_static.entity_type = 'VM';
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVmTemplateInterfacesByNetworkId (v_network_id UUID)
-RETURNS SETOF vm_interface STABLE AS $PROCEDURE$
+RETURNS SETOF vm_interface STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -1153,11 +1153,11 @@ BEGIN
         ON vm_interface.vnic_profile_id = vnic_profiles.id
     WHERE vnic_profiles.network_id = v_network_id
         AND vm_static.entity_type = 'TEMPLATE';
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetMacsByDataCenterId (v_data_center_id UUID)
-RETURNS SETOF VARCHAR STABLE AS $PROCEDURE$
+RETURNS SETOF VARCHAR STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -1171,11 +1171,11 @@ BEGIN
             WHERE cluster.storage_pool_id = v_data_center_id
                 AND vm_static.vm_guid = vm_interface.vm_guid
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetMacsByClusterId (v_cluster_id UUID)
-RETURNS SETOF VARCHAR STABLE AS $PROCEDURE$
+RETURNS SETOF VARCHAR STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -1188,35 +1188,35 @@ BEGIN
               AND vm_static.vm_guid = vm_interface.vm_guid
               AND vm_interface.mac_addr IS NOT NULL
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ----------------------------------------------------------------
 -- VM Interface View
 ----------------------------------------------------------------
 CREATE OR REPLACE FUNCTION GetAllFromVmNetworkInterfaceViews ()
-RETURNS SETOF vm_interface_view STABLE AS $PROCEDURE$
+RETURNS SETOF vm_interface_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM vm_interface_view;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVmNetworkInterfaceViewByVmNetworkInterfaceViewId (v_id UUID)
-RETURNS SETOF vm_interface_view STABLE AS $PROCEDURE$
+RETURNS SETOF vm_interface_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM vm_interface_view
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetPluggedVmInterfacesByMac (v_mac_address VARCHAR(20))
-RETURNS SETOF vm_interface_view STABLE AS $PROCEDURE$
+RETURNS SETOF vm_interface_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -1224,7 +1224,7 @@ BEGIN
     FROM vm_interface_view
     WHERE mac_addr = v_mac_address
         AND is_plugged = true;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVmNetworkInterfaceViewByVmId (
@@ -1232,7 +1232,7 @@ CREATE OR REPLACE FUNCTION GetVmNetworkInterfaceViewByVmId (
     v_user_id UUID,
     v_is_filtered BOOLEAN
     )
-RETURNS SETOF vm_interface_view STABLE AS $PROCEDURE$
+RETURNS SETOF vm_interface_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -1248,18 +1248,18 @@ BEGIN
                     AND entity_id = v_vm_id
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVmNetworkInterfaceToMonitorByVmId (v_vm_id UUID)
-RETURNS SETOF vm_interface_monitoring_view STABLE AS $PROCEDURE$
+RETURNS SETOF vm_interface_monitoring_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM vm_interface_monitoring_view
     WHERE vm_guid = v_vm_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVmNetworkInterfaceViewByTemplateId (
@@ -1267,7 +1267,7 @@ CREATE OR REPLACE FUNCTION GetVmNetworkInterfaceViewByTemplateId (
     v_user_id UUID,
     v_is_filtered boolean
     )
-RETURNS SETOF vm_interface_view STABLE AS $PROCEDURE$
+RETURNS SETOF vm_interface_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -1283,11 +1283,11 @@ BEGIN
                     AND entity_id = v_template_id
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVmInterfaceViewsByNetworkId (v_network_id UUID)
-RETURNS SETOF vm_interface_view STABLE AS $PROCEDURE$
+RETURNS SETOF vm_interface_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -1297,11 +1297,11 @@ BEGIN
         ON vnic_profiles.id = vm_interface_view.vnic_profile_id
     WHERE vnic_profiles.network_id = v_network_id
         AND vm_interface_view.vm_entity_type = 'VM';
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVmTemplateInterfaceViewsByNetworkId (v_network_id UUID)
-RETURNS SETOF vm_interface_view STABLE AS $PROCEDURE$
+RETURNS SETOF vm_interface_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -1311,21 +1311,21 @@ BEGIN
         ON vnic_profiles.id = vm_interface_view.vnic_profile_id
     WHERE vnic_profiles.network_id = v_network_id
         AND vm_interface_view.vm_entity_type = 'TEMPLATE';
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ----------------------------------------------------------------
 -- [vm_interface_statistics] Table
 --
 CREATE OR REPLACE FUNCTION Getvm_interface_statisticsById (v_id UUID)
-RETURNS SETOF vm_interface_statistics STABLE AS $PROCEDURE$
+RETURNS SETOF vm_interface_statistics STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM vm_interface_statistics
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Insertvm_interface_statistics (
@@ -1342,7 +1342,7 @@ CREATE OR REPLACE FUNCTION Insertvm_interface_statistics (
     v_sample_time FLOAT,
     v_vm_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO vm_interface_statistics (
         id,
@@ -1372,7 +1372,7 @@ BEGIN
         v_iface_status,
         v_sample_time
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Updatevm_interface_statistics (
@@ -1391,7 +1391,7 @@ CREATE OR REPLACE FUNCTION Updatevm_interface_statistics (
     )
 RETURNS VOID
     --The [vm_interface_statistics] table doesn't have a timestamp column. Optimistic concurrency logic cannot be generated
-    AS $PROCEDURE$
+    AS $FUNCTION$
 BEGIN
     UPDATE vm_interface_statistics
     SET rx_drop = v_rx_drop,
@@ -1407,11 +1407,11 @@ BEGIN
         sample_time = v_sample_time,
         _update_date = LOCALTIMESTAMP
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Deletevm_interface_statistics (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 DECLARE v_val UUID;
 
 BEGIN
@@ -1428,7 +1428,7 @@ BEGIN
     DELETE
     FROM vm_interface_statistics
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ----------------------------------------------------------------
@@ -1439,7 +1439,7 @@ CREATE OR REPLACE FUNCTION GetVmGuestAgentInterfacesByVmId (
     v_user_id UUID,
     v_filtered BOOLEAN
     )
-RETURNS SETOF vm_guest_agent_interfaces STABLE AS $PROCEDURE$
+RETURNS SETOF vm_guest_agent_interfaces STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -1455,16 +1455,16 @@ BEGIN
                     AND entity_id = v_vm_id
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteVmGuestAgentInterfacesByVmIds (v_vm_ids UUID[])
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM vm_guest_agent_interfaces
     WHERE vm_id = ANY(v_vm_ids);
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION InsertVmGuestAgentInterface (
@@ -1474,7 +1474,7 @@ CREATE OR REPLACE FUNCTION InsertVmGuestAgentInterface (
     v_ipv4_addresses TEXT,
     v_ipv6_addresses TEXT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO vm_guest_agent_interfaces (
         vm_id,
@@ -1490,7 +1490,7 @@ BEGIN
         v_ipv4_addresses,
         v_ipv6_addresses
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ----------------------------------------------------------------
@@ -1510,7 +1510,7 @@ CREATE OR REPLACE FUNCTION Insertvds_interface_statistics (
     v_sample_time FLOAT,
     v_vds_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO vds_interface_statistics (
         id,
@@ -1540,7 +1540,7 @@ BEGIN
         v_iface_status,
         v_sample_time
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Updatevds_interface_statistics (
@@ -1559,7 +1559,7 @@ CREATE OR REPLACE FUNCTION Updatevds_interface_statistics (
     )
 RETURNS VOID
     --The [vds_interface_statistics] table doesn't have a timestamp column. Optimistic concurrency logic cannot be generated
-    AS $PROCEDURE$
+    AS $FUNCTION$
 BEGIN
     UPDATE vds_interface_statistics
     SET rx_drop = v_rx_drop,
@@ -1575,11 +1575,11 @@ BEGIN
         sample_time = v_sample_time,
         _update_date = LOCALTIMESTAMP
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Deletevds_interface_statistics (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 DECLARE v_val UUID;
 
 BEGIN
@@ -1596,7 +1596,7 @@ BEGIN
     DELETE
     FROM vds_interface_statistics
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ----------------------------------------------------------------
@@ -1613,7 +1613,7 @@ CREATE OR REPLACE FUNCTION Insertnetwork_cluster (
     v_is_gluster BOOLEAN,
     v_default_route BOOLEAN
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO network_cluster (
         cluster_id,
@@ -1637,7 +1637,7 @@ BEGIN
         v_is_gluster,
         v_default_route
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Updatenetwork_cluster (
@@ -1651,7 +1651,7 @@ CREATE OR REPLACE FUNCTION Updatenetwork_cluster (
     v_is_gluster BOOLEAN,
     v_default_route BOOLEAN
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE network_cluster
     SET status = v_status,
@@ -1663,7 +1663,7 @@ BEGIN
         default_route = v_default_route
     WHERE cluster_id = v_cluster_id
         AND network_id = v_network_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Updatenetwork_cluster_status (
@@ -1671,51 +1671,51 @@ CREATE OR REPLACE FUNCTION Updatenetwork_cluster_status (
     v_network_id UUID,
     v_status INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE network_cluster
     SET status = v_status
     WHERE cluster_id = v_cluster_id
         AND network_id = v_network_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Deletenetwork_cluster (
     v_cluster_id UUID,
     v_network_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM network_cluster
     WHERE cluster_id = v_cluster_id
         AND network_id = v_network_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromnetwork_cluster ()
-RETURNS SETOF network_cluster STABLE AS $PROCEDURE$
+RETURNS SETOF network_cluster STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM network_cluster;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromnetwork_clusterByClusterId (v_cluster_id UUID)
-RETURNS SETOF network_cluster STABLE AS $PROCEDURE$
+RETURNS SETOF network_cluster STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM network_cluster
     WHERE cluster_id = v_cluster_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllManagementNetworksByDataCenterId (v_data_center_id UUID)
-RETURNS SETOF network STABLE AS $PROCEDURE$
+RETURNS SETOF network STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -1727,25 +1727,25 @@ BEGIN
         ON network_cluster.cluster_id = cluster.cluster_id
     WHERE cluster.storage_pool_id = v_data_center_id
         AND network_cluster.management;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromnetwork_clusterByNetworkId (v_network_id UUID)
-RETURNS SETOF network_cluster STABLE AS $PROCEDURE$
+RETURNS SETOF network_cluster STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM network_cluster
     WHERE network_id = v_network_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Getnetwork_clusterBycluster_idAndBynetwork_id (
     v_cluster_id UUID,
     v_network_id UUID
     )
-RETURNS SETOF network_cluster STABLE AS $PROCEDURE$
+RETURNS SETOF network_cluster STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -1753,14 +1753,14 @@ BEGIN
     FROM network_cluster
     WHERE cluster_id = v_cluster_id
         AND network_id = v_network_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetvmStaticByGroupIdAndNetwork (
     v_groupId UUID,
     v_networkName VARCHAR(50)
     )
-RETURNS SETOF vm_static_view STABLE AS $PROCEDURE$
+RETURNS SETOF vm_static_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -1770,14 +1770,14 @@ BEGIN
         ON vm_static_view.vm_guid = vm_interface_view.vm_guid
             AND network_name = v_networkName
             AND vm_static_view.cluster_id = v_groupId;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION set_network_exclusively_as_display (
     v_cluster_id UUID,
     v_network_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE network_cluster
     SET is_display = true
@@ -1791,14 +1791,14 @@ BEGIN
             AND network_id != v_network_id;
     END IF;
 
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION set_network_exclusively_as_migration (
     v_cluster_id UUID,
     v_network_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE network_cluster
     SET migration = true
@@ -1812,14 +1812,14 @@ BEGIN
             AND network_id != v_network_id;
     END IF;
 
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION set_network_exclusively_as_default_role_network (
     v_cluster_id UUID,
     v_network_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE network_cluster
     SET default_route = true
@@ -1833,26 +1833,26 @@ BEGIN
             AND network_id != v_network_id;
     END IF;
 
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION set_network_exclusively_as_gluster (
     v_cluster_id UUID,
     v_network_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE network_cluster
     SET is_gluster = COALESCE(network_id = v_network_id, false)
     WHERE cluster_id = v_cluster_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION set_network_exclusively_as_management (
     v_cluster_id UUID,
     v_network_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE network_cluster
     SET management = true
@@ -1866,21 +1866,21 @@ BEGIN
             AND network_id != v_network_id;
     END IF;
 
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ----------------------------------------------------------------------
 --  Vnic Profile
 ----------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION GetVnicProfileByVnicProfileId (v_id UUID)
-RETURNS SETOF vnic_profiles STABLE AS $PROCEDURE$
+RETURNS SETOF vnic_profiles STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM vnic_profiles
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION InsertVnicProfile (
@@ -1896,7 +1896,7 @@ CREATE OR REPLACE FUNCTION InsertVnicProfile (
     v_network_filter_id UUID,
     v_failover_vnic_profile_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO vnic_profiles (
         id,
@@ -1924,7 +1924,7 @@ BEGIN
         v_network_filter_id,
         v_failover_vnic_profile_id
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateVnicProfile (
@@ -1940,7 +1940,7 @@ CREATE OR REPLACE FUNCTION UpdateVnicProfile (
     v_network_filter_id UUID,
     v_failover_vnic_profile_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE vnic_profiles
     SET id = v_id,
@@ -1956,11 +1956,11 @@ BEGIN
         network_filter_id = v_network_filter_id,
         failover_vnic_profile_id = v_failover_vnic_profile_id
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteVnicProfile (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 DECLARE v_val UUID;
 
 BEGIN
@@ -1970,39 +1970,39 @@ BEGIN
 
     -- Delete the vnic profiles permissions
     PERFORM DeletePermissionsByEntityId(v_id);
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromVnicProfiles ()
-RETURNS SETOF vnic_profiles STABLE AS $PROCEDURE$
+RETURNS SETOF vnic_profiles STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM vnic_profiles;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVnicProfilesByNetworkId (v_network_id UUID)
-RETURNS SETOF vnic_profiles STABLE AS $PROCEDURE$
+RETURNS SETOF vnic_profiles STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM vnic_profiles
     WHERE network_id = v_network_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVnicProfilesByFailoverVnicProfileId (v_failover_vnic_profile_id UUID)
-RETURNS SETOF vnic_profiles STABLE AS $PROCEDURE$
+RETURNS SETOF vnic_profiles STABLE AS $FUNCTION$
 BEGIN
 RETURN QUERY
 
 SELECT *
 FROM vnic_profiles
 WHERE failover_vnic_profile_id = v_failover_vnic_profile_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ----------------------------------------------------------------------
@@ -2013,7 +2013,7 @@ CREATE OR REPLACE FUNCTION GetVnicProfileViewByVnicProfileViewId (
     v_user_id uuid,
     v_is_filtered boolean
     )
-RETURNS SETOF vnic_profiles_view STABLE AS $PROCEDURE$
+RETURNS SETOF vnic_profiles_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -2029,14 +2029,14 @@ BEGIN
                     AND entity_id = vnic_profiles_view.id
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromVnicProfileViews (
     v_user_id uuid,
     v_is_filtered boolean
     )
-RETURNS SETOF vnic_profiles_view STABLE AS $PROCEDURE$
+RETURNS SETOF vnic_profiles_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -2049,7 +2049,7 @@ BEGIN
             WHERE user_id = v_user_id
                 AND entity_id = vnic_profiles_view.id
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVnicProfileViewsByNetworkId (
@@ -2057,7 +2057,7 @@ CREATE OR REPLACE FUNCTION GetVnicProfileViewsByNetworkId (
     v_user_id uuid,
     v_is_filtered boolean
     )
-RETURNS SETOF vnic_profiles_view STABLE AS $PROCEDURE$
+RETURNS SETOF vnic_profiles_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -2073,7 +2073,7 @@ BEGIN
                     AND entity_id = vnic_profiles_view.id
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVnicProfileViewsByDataCenterId (
@@ -2081,7 +2081,7 @@ CREATE OR REPLACE FUNCTION GetVnicProfileViewsByDataCenterId (
     v_user_id uuid,
     v_is_filtered boolean
     )
-RETURNS SETOF vnic_profiles_view STABLE AS $PROCEDURE$
+RETURNS SETOF vnic_profiles_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -2097,7 +2097,7 @@ BEGIN
                     AND entity_id = vnic_profiles_view.id
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVnicProfileViewsByClusterId (
@@ -2105,7 +2105,7 @@ CREATE OR REPLACE FUNCTION GetVnicProfileViewsByClusterId (
     v_user_id uuid,
     v_is_filtered boolean
     )
-RETURNS SETOF vnic_profiles_view STABLE AS $PROCEDURE$
+RETURNS SETOF vnic_profiles_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -2126,25 +2126,25 @@ BEGIN
                 AND entity_id = vnic_profiles_view.id
       )
     );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVnicProfileViewsByNetworkQosId (v_network_qos_id UUID)
-RETURNS SETOF vnic_profiles_view STABLE AS $PROCEDURE$
+RETURNS SETOF vnic_profiles_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM vnic_profiles_view
     WHERE network_qos_id = v_network_qos_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetIscsiIfacesByHostIdAndStorageTargetId (
     v_host_id UUID,
     v_target_id VARCHAR(50)
     )
-RETURNS SETOF vds_interface_view STABLE AS $PROCEDURE$
+RETURNS SETOF vds_interface_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -2161,18 +2161,18 @@ BEGIN
         AND network.name = vds_interface_view.network_name
         AND network_cluster.cluster_id = vds_interface_view.cluster_id
         AND vds_interface_view.vds_id = v_host_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION getActiveMigrationNetworkInterfaceForHost (v_host_id UUID)
-RETURNS SETOF active_migration_network_interfaces STABLE AS $PROCEDURE$
+RETURNS SETOF active_migration_network_interfaces STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM active_migration_network_interfaces
     WHERE vds_id = v_host_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ----------------------------------------------------------------------
@@ -2183,7 +2183,7 @@ CREATE OR REPLACE FUNCTION InsertHostNicVfsConfig (
     v_nic_id UUID,
     v_is_all_networks_allowed BOOLEAN
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO host_nic_vfs_config (
         id,
@@ -2195,7 +2195,7 @@ BEGIN
         v_nic_id,
         v_is_all_networks_allowed
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateHostNicVfsConfig (
@@ -2203,7 +2203,7 @@ CREATE OR REPLACE FUNCTION UpdateHostNicVfsConfig (
     v_nic_id UUID,
     v_is_all_networks_allowed BOOLEAN
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE host_nic_vfs_config
     SET id = v_id,
@@ -2211,52 +2211,52 @@ BEGIN
         is_all_networks_allowed = v_is_all_networks_allowed,
         _update_date = LOCALTIMESTAMP
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteHostNicVfsConfig (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM host_nic_vfs_config
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetHostNicVfsConfigById (v_id UUID)
-RETURNS SETOF host_nic_vfs_config STABLE AS $PROCEDURE$
+RETURNS SETOF host_nic_vfs_config STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM host_nic_vfs_config
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVfsConfigByNicId (v_nic_id UUID)
-RETURNS SETOF host_nic_vfs_config STABLE AS $PROCEDURE$
+RETURNS SETOF host_nic_vfs_config STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM host_nic_vfs_config
     WHERE nic_id = v_nic_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromHostNicVfsConfigs ()
-RETURNS SETOF host_nic_vfs_config STABLE AS $PROCEDURE$
+RETURNS SETOF host_nic_vfs_config STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM host_nic_vfs_config;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllVfsConfigByHostId (v_host_id UUID)
-RETURNS SETOF host_nic_vfs_config STABLE AS $PROCEDURE$
+RETURNS SETOF host_nic_vfs_config STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -2265,62 +2265,62 @@ BEGIN
     INNER JOIN vds_interface
         ON host_nic_vfs_config.nic_id = vds_interface.id
     WHERE vds_interface.vds_id = v_host_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -------------------------------------------------------------------------------------------
 -- DnsResolverConfiguration
 -------------------------------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION GetDnsResolverConfigurationByDnsResolverConfigurationId (v_id UUID)
-RETURNS SETOF dns_resolver_configuration STABLE AS $PROCEDURE$
+RETURNS SETOF dns_resolver_configuration STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM dns_resolver_configuration
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromDnsResolverConfigurations ()
-RETURNS SETOF dns_resolver_configuration STABLE AS $PROCEDURE$
+RETURNS SETOF dns_resolver_configuration STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM dns_resolver_configuration;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION InsertDnsResolverConfiguration (
     v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO dns_resolver_configuration (id)
     VALUES (v_id);
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateDnsResolverConfiguration (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE dns_resolver_configuration
     SET id = v_id
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteDnsResolverConfiguration (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM dns_resolver_configuration
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetNameServersByDnsResolverConfigurationId (v_dns_resolver_configuration_id UUID)
-RETURNS SETOF name_server STABLE AS $PROCEDURE$
+RETURNS SETOF name_server STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -2328,14 +2328,14 @@ BEGIN
     FROM name_server
     WHERE dns_resolver_configuration_id = v_dns_resolver_configuration_id
     ORDER BY position ASC;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION InsertNameServer (
     v_dns_resolver_configuration_id UUID,
     v_address VARCHAR(45),
     v_position SMALLINT)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO
     name_server(
@@ -2347,21 +2347,21 @@ BEGIN
       v_position,
       v_dns_resolver_configuration_id);
 
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteNameServersByDnsResolverConfigurationId (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM name_server
     WHERE dns_resolver_configuration_id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 
 CREATE OR REPLACE FUNCTION DeleteDnsResolverConfigurationByNetworkAttachmentId (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM dns_resolver_configuration
@@ -2372,11 +2372,11 @@ BEGIN
         network_attachments
       WHERE
         id = v_id);
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteDnsResolverConfigurationByNetworkId (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM dns_resolver_configuration
@@ -2387,30 +2387,30 @@ BEGIN
         network
       WHERE
         id = v_id);
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteDnsResolverConfigurationByVdsDynamicId (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM dns_resolver_configuration
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -------------------------------------------------------------------------------------------
 -- Network attachments
 -------------------------------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION GetNetworkAttachmentByNetworkAttachmentId (v_id UUID)
-RETURNS SETOF network_attachments STABLE AS $PROCEDURE$
+RETURNS SETOF network_attachments STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM network_attachments
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION InsertNetworkAttachment (
@@ -2428,7 +2428,7 @@ CREATE OR REPLACE FUNCTION InsertNetworkAttachment (
     v_custom_properties TEXT,
     v_dns_resolver_configuration_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO network_attachments (
         id,
@@ -2460,7 +2460,7 @@ BEGIN
         v_custom_properties,
         v_dns_resolver_configuration_id
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateNetworkAttachment (
@@ -2478,7 +2478,7 @@ CREATE OR REPLACE FUNCTION UpdateNetworkAttachment (
     v_custom_properties TEXT,
     v_dns_resolver_configuration_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE network_attachments
     SET network_id = v_network_id,
@@ -2495,48 +2495,48 @@ BEGIN
         _update_date = LOCALTIMESTAMP,
         dns_resolver_configuration_id = v_dns_resolver_configuration_id
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteNetworkAttachment (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM network_attachments
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromNetworkAttachments ()
-RETURNS SETOF network_attachments STABLE AS $PROCEDURE$
+RETURNS SETOF network_attachments STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM network_attachments;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetNetworkAttachmentsByNicId (v_nic_id UUID)
-RETURNS SETOF network_attachments STABLE AS $PROCEDURE$
+RETURNS SETOF network_attachments STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM network_attachments
     WHERE nic_id = v_nic_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetNetworkAttachmentsByNetworkId (v_network_id UUID)
-RETURNS SETOF network_attachments STABLE AS $PROCEDURE$
+RETURNS SETOF network_attachments STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM network_attachments
     WHERE network_id = v_network_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 DROP TYPE IF EXISTS network_attachments_qos_rs CASCADE;
@@ -2565,7 +2565,7 @@ CREATE TYPE network_attachments_qos_rs AS (
 );
 
 CREATE OR REPLACE FUNCTION GetNetworkAttachmentsWithQosByHostId (v_host_id UUID)
-RETURNS SETOF network_attachments_qos_rs STABLE AS $PROCEDURE$
+RETURNS SETOF network_attachments_qos_rs STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -2608,14 +2608,14 @@ BEGIN
         ) s2
         ON s1.id = s2.id
     ;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetNetworkAttachmentWithQosByNicIdAndNetworkId (
     v_nic_id UUID,
     v_network_id UUID
     )
-RETURNS SETOF network_attachments_qos_rs STABLE AS $PROCEDURE$
+RETURNS SETOF network_attachments_qos_rs STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -2654,16 +2654,16 @@ BEGIN
         ) s2
         ON s1.id = s2.id
     ;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION RemoveNetworkAttachmentByNetworkId (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM network_attachments na
     WHERE na.network_id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ----------------------------------------------------------------------
@@ -2673,7 +2673,7 @@ CREATE OR REPLACE FUNCTION InsertVfsConfigNetwork (
     v_vfs_config_id UUID,
     v_network_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO vfs_config_networks (
         vfs_config_id,
@@ -2683,40 +2683,40 @@ BEGIN
         v_vfs_config_id,
         v_network_id
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteVfsConfigNetwork (
     v_vfs_config_id UUID,
     v_network_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM vfs_config_networks
     WHERE vfs_config_id = v_vfs_config_id
         AND network_id = v_network_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteAllVfsConfigNetworks (v_vfs_config_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM vfs_config_networks
     WHERE vfs_config_id = v_vfs_config_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetNetworksByVfsConfigId (v_vfs_config_id UUID)
-RETURNS SETOF UUID STABLE AS $PROCEDURE$
+RETURNS SETOF UUID STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT network_id
     FROM vfs_config_networks
     WHERE vfs_config_id = v_vfs_config_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ----------------------------------------------------------------------
@@ -2726,7 +2726,7 @@ CREATE OR REPLACE FUNCTION InsertVfsConfigLabel (
     v_vfs_config_id UUID,
     v_label TEXT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO vfs_config_labels (
         vfs_config_id,
@@ -2736,103 +2736,103 @@ BEGIN
         v_vfs_config_id,
         v_label
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteVfsConfigLabel (
     v_vfs_config_id UUID,
     v_label TEXT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM vfs_config_labels
     WHERE vfs_config_id = v_vfs_config_id
         AND label = v_label;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteAllVfsConfigLabels (v_vfs_config_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM vfs_config_labels
     WHERE vfs_config_id = v_vfs_config_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetLabelsByVfsConfigId (v_vfs_config_id UUID)
-RETURNS SETOF TEXT STABLE AS $PROCEDURE$
+RETURNS SETOF TEXT STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT label
     FROM vfs_config_labels
     WHERE vfs_config_id = v_vfs_config_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 
 CREATE OR REPLACE FUNCTION GetAllNetworkFilters ()
 RETURNS SETOF network_filter STABLE
-AS $PROCEDURE$
+AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM network_filter;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 
 CREATE OR REPLACE FUNCTION GetAllSupportedNetworkFiltersByVersion (v_version VARCHAR(40))
 RETURNS SETOF network_filter STABLE
-AS $PROCEDURE$
+AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM network_filter
     WHERE v_version >= version;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetNetworkFilterById (v_filter_id UUID)
 RETURNS SETOF network_filter STABLE
-AS $PROCEDURE$
+AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM network_filter
     WHERE filter_id = v_filter_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetNetworkFilterByName (v_filter_name VARCHAR(50))
 RETURNS SETOF network_filter STABLE
-AS $PROCEDURE$
+AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM network_filter
     WHERE filter_name like v_filter_name;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetHostProviderBinding (
     v_vds_id UUID,
     v_plugin_type character varying(64)
     )
-RETURNS SETOF character varying(64) STABLE AS $PROCEDURE$
+RETURNS SETOF character varying(64) STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
     SELECT binding_host_id
     FROM provider_binding_host_id
     WHERE vds_id = v_vds_id
         AND plugin_type = v_plugin_type;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -2841,7 +2841,7 @@ CREATE OR REPLACE FUNCTION UpdateHostProviderBinding (
     v_plugin_types character varying(64)[],
     v_provider_binding_host_ids character varying(64)[]
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     PERFORM 1 FROM provider_binding_host_id WHERE vds_id = v_vds_id FOR UPDATE;
     DELETE FROM provider_binding_host_id WHERE vds_id = v_vds_id;
@@ -2851,11 +2851,11 @@ BEGIN
         binding_host_id
         )
     SELECT v_vds_id, unnest(v_plugin_types), unnest(v_provider_binding_host_ids);
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVmIdsForVnicsOutOfSync (v_ids UUID[])
-RETURNS SETOF UUID STABLE AS $PROCEDURE$
+RETURNS SETOF UUID STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -2863,15 +2863,15 @@ BEGIN
     FROM vm_interface
     WHERE NOT synced
     AND vm_guid = ANY(v_ids);
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION SetVmInterfacesSyncedForVm (v_vm_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE vm_interface
     SET synced = true
     WHERE vm_interface.vm_guid = v_vm_id;
 
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;

--- a/packaging/dbscripts/numa_sp.sql
+++ b/packaging/dbscripts/numa_sp.sql
@@ -20,7 +20,7 @@ CREATE OR REPLACE FUNCTION InsertNumaNode (
     v_hugepages TEXT,
     v_numa_tune_mode VARCHAR(20)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     BEGIN
         INSERT INTO numa_node (
@@ -60,7 +60,7 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateNumaNode (
@@ -72,7 +72,7 @@ CREATE OR REPLACE FUNCTION UpdateNumaNode (
     v_hugepages TEXT,
     v_numa_tune_mode VARCHAR(20)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     BEGIN
         UPDATE numa_node
@@ -86,7 +86,7 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateNumaNodeStatistics (
@@ -99,7 +99,7 @@ CREATE OR REPLACE FUNCTION UpdateNumaNodeStatistics (
     v_usage_cpu_percent INT,
     v_hugepages TEXT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     BEGIN
         UPDATE numa_node
@@ -114,11 +114,11 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteNumaNode (v_numa_node_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     BEGIN
         DELETE
@@ -127,11 +127,11 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteNumaNodeByVmId (v_vm_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     BEGIN
         DELETE
@@ -140,11 +140,11 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetNumaNodeByVdsId (v_vds_id UUID)
-RETURNS SETOF numa_node_cpus_view STABLE AS $PROCEDURE$
+RETURNS SETOF numa_node_cpus_view STABLE AS $FUNCTION$
 BEGIN
     BEGIN
         RETURN QUERY
@@ -156,11 +156,11 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetNumaNodeByVmId (v_vm_id UUID)
-RETURNS SETOF numa_node_cpus_view STABLE AS $PROCEDURE$
+RETURNS SETOF numa_node_cpus_view STABLE AS $FUNCTION$
 BEGIN
     BEGIN
         RETURN QUERY
@@ -172,7 +172,7 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ----------------------------------------------------------------
@@ -183,7 +183,7 @@ CREATE OR REPLACE FUNCTION InsertNumaNodeCpu (
     v_numa_node_id UUID,
     v_cpu_core_id INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     BEGIN
         INSERT INTO numa_node_cpu_map (
@@ -199,11 +199,11 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteNumaNodeCpuByNumaNodeId (v_numa_node_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     BEGIN
         DELETE
@@ -212,11 +212,11 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromNumaNodeCpuMap ()
-RETURNS SETOF numa_node_cpu_map STABLE AS $PROCEDURE$
+RETURNS SETOF numa_node_cpu_map STABLE AS $FUNCTION$
 BEGIN
     BEGIN
         RETURN QUERY
@@ -226,7 +226,7 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ----------------------------------------------------------------
@@ -237,7 +237,7 @@ CREATE OR REPLACE FUNCTION InsertNumaNodeMap (
     v_vm_numa_node_id UUID,
     v_vds_numa_node_index SMALLINT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     BEGIN
         INSERT INTO vm_vds_numa_node_map (
@@ -253,11 +253,11 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteNumaNodeMapByVmNumaNodeId (v_vm_numa_node_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     BEGIN
         DELETE
@@ -266,7 +266,7 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ----------------------------------------------------------------
@@ -274,7 +274,7 @@ LANGUAGE plpgsql;
 --
 
 CREATE OR REPLACE FUNCTION GetAllAssignedNumaNodeInfomation ()
-RETURNS SETOF numa_node_assignment_view STABLE AS $PROCEDURE$
+RETURNS SETOF numa_node_assignment_view STABLE AS $FUNCTION$
 BEGIN
     BEGIN
         RETURN QUERY
@@ -284,14 +284,14 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ----------------------------------------------------------------
 -- [numa_node_with_cluster_view] View
 --
 CREATE OR REPLACE FUNCTION GetVmNumaNodeByCluster (v_cluster_id UUID)
-RETURNS SETOF numa_node_with_cluster_view STABLE AS $PROCEDURE$
+RETURNS SETOF numa_node_with_cluster_view STABLE AS $FUNCTION$
 BEGIN
     BEGIN
         RETURN QUERY
@@ -302,7 +302,7 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/policy_unit_sp.sql
+++ b/packaging/dbscripts/policy_unit_sp.sql
@@ -3,25 +3,25 @@
 -- Policy units
 -- Get All policy units
 CREATE OR REPLACE FUNCTION GetAllFromPolicyUnits ()
-RETURNS SETOF policy_units STABLE AS $PROCEDURE$
+RETURNS SETOF policy_units STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM policy_units;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- get policy unit by id
 CREATE OR REPLACE FUNCTION GetPolicyUnitByPolicyUnitId (v_id UUID)
-RETURNS SETOF policy_units STABLE AS $PROCEDURE$
+RETURNS SETOF policy_units STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM policy_units
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- CRUD procs:
@@ -34,7 +34,7 @@ CREATE OR REPLACE FUNCTION InsertPolicyUnit (
     v_custom_properties_regex TEXT,
     v_enabled BOOLEAN
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO policy_units (
         id,
@@ -54,7 +54,7 @@ BEGIN
         v_custom_properties_regex,
         v_enabled
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdatePolicyUnit (
@@ -63,23 +63,23 @@ CREATE OR REPLACE FUNCTION UpdatePolicyUnit (
     v_custom_properties_regex TEXT,
     v_description TEXT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE policy_units
     SET custom_properties_regex = v_custom_properties_regex,
         enabled = v_enabled,
         description = v_description
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeletePolicyUnit (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM policy_units
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/providers_sp.sql
+++ b/packaging/dbscripts/providers_sp.sql
@@ -24,7 +24,7 @@ CREATE OR REPLACE FUNCTION InsertProvider (
     v_project_name VARCHAR(128) DEFAULT NULL,
     v_project_domain_name VARCHAR(128) DEFAULT NULL
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO providers (
         id,
@@ -68,7 +68,7 @@ BEGIN
         v_project_name,
         v_project_domain_name
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateProvider (
@@ -92,7 +92,7 @@ CREATE OR REPLACE FUNCTION UpdateProvider (
     v_project_name VARCHAR(128) DEFAULT NULL,
     v_project_domain_name VARCHAR(128) DEFAULT NULL
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE providers
     SET name = v_name,
@@ -115,59 +115,59 @@ BEGIN
         project_name = v_project_name,
         project_domain_name = v_project_domain_name
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteProvider (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM providers
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromProviders ()
-RETURNS SETOF providers STABLE AS $PROCEDURE$
+RETURNS SETOF providers STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM providers;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromProvidersByTypes(v_provider_types varchar[])
-RETURNS SETOF providers AS $PROCEDURE$
+RETURNS SETOF providers AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM providers
     WHERE provider_type = ANY(v_provider_types);
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetProviderByProviderId (v_id UUID)
-RETURNS SETOF providers STABLE AS $PROCEDURE$
+RETURNS SETOF providers STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM providers
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetProviderByName (v_name VARCHAR)
-RETURNS SETOF providers STABLE AS $PROCEDURE$
+RETURNS SETOF providers STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM providers
     WHERE name = v_name;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/qos_sp.sql
+++ b/packaging/dbscripts/qos_sp.sql
@@ -16,7 +16,7 @@ CREATE OR REPLACE FUNCTION InsertStorageQos (
     v_max_read_iops INT,
     v_max_write_iops INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO qos (
         id,
@@ -44,7 +44,7 @@ BEGIN
         v_max_read_iops,
         v_max_write_iops
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION InsertCpuQos (
@@ -55,7 +55,7 @@ CREATE OR REPLACE FUNCTION InsertCpuQos (
     v_storage_pool_id uuid,
     v_cpu_limit INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO qos (
         id,
@@ -73,7 +73,7 @@ BEGIN
         v_storage_pool_id,
         v_cpu_limit
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION InsertNetworkQos (
@@ -89,7 +89,7 @@ CREATE OR REPLACE FUNCTION InsertNetworkQos (
     v_outbound_peak INT,
     v_outbound_burst INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO qos (
         id,
@@ -117,7 +117,7 @@ BEGIN
         v_outbound_peak,
         v_outbound_burst
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION InsertHostNetworkQos (
@@ -130,7 +130,7 @@ CREATE OR REPLACE FUNCTION InsertHostNetworkQos (
     v_out_average_upperlimit INT,
     v_out_average_realtime INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO qos (
         id,
@@ -152,7 +152,7 @@ BEGIN
         v_out_average_upperlimit,
         v_out_average_realtime
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateStorageQos (
@@ -168,7 +168,7 @@ CREATE OR REPLACE FUNCTION UpdateStorageQos (
     v_max_read_iops INT,
     v_max_write_iops INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE qos
     SET qos_type = v_qos_type,
@@ -183,7 +183,7 @@ BEGIN
         max_write_iops = v_max_write_iops,
         _update_date = LOCALTIMESTAMP
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateCpuQos (
@@ -194,7 +194,7 @@ CREATE OR REPLACE FUNCTION UpdateCpuQos (
     v_storage_pool_id uuid,
     v_cpu_limit INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE qos
     SET qos_type = v_qos_type,
@@ -204,7 +204,7 @@ BEGIN
         cpu_limit = v_cpu_limit,
         _update_date = LOCALTIMESTAMP
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateNetworkQos (
@@ -220,7 +220,7 @@ CREATE OR REPLACE FUNCTION UpdateNetworkQos (
     v_outbound_peak INT,
     v_outbound_burst INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE qos
     SET qos_type = v_qos_type,
@@ -235,7 +235,7 @@ BEGIN
         outbound_burst = v_outbound_burst,
         _update_date = LOCALTIMESTAMP
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateHostNetworkQos (
@@ -248,7 +248,7 @@ CREATE OR REPLACE FUNCTION UpdateHostNetworkQos (
     v_out_average_upperlimit INT,
     v_out_average_realtime INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE qos
     SET qos_type = v_qos_type,
@@ -260,34 +260,34 @@ BEGIN
         out_average_realtime = v_out_average_realtime,
         _update_date = LOCALTIMESTAMP
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteQos (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM qos
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetQosByQosId (v_id UUID)
-RETURNS SETOF qos STABLE AS $PROCEDURE$
+RETURNS SETOF qos STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM qos
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllQosForStoragePoolByQosType (
     v_storage_pool_id UUID,
     v_qos_type SMALLINT
     )
-RETURNS SETOF qos STABLE AS $PROCEDURE$
+RETURNS SETOF qos STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -295,22 +295,22 @@ BEGIN
     FROM qos
     WHERE storage_pool_id = v_storage_pool_id
         AND qos_type = v_qos_type;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllQosForStoragePool (v_storage_pool_id UUID)
-RETURNS SETOF qos STABLE AS $PROCEDURE$
+RETURNS SETOF qos STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM qos
     WHERE storage_pool_id = v_storage_pool_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllQosByQosType (v_qos_type SMALLINT)
-RETURNS SETOF qos STABLE AS $PROCEDURE$
+RETURNS SETOF qos STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -318,11 +318,11 @@ BEGIN
     FROM qos
     WHERE qos_type = v_qos_type;
 
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllStorageQos (v_user_id UUID)
-RETURNS SETOF qos STABLE AS $PROCEDURE$
+RETURNS SETOF qos STABLE AS $FUNCTION$
 BEGIN
    RETURN QUERY SELECT *
       FROM qos WHERE
@@ -336,11 +336,11 @@ BEGIN
                 AND user_storage_domain_permissions_view.user_id = v_user_id
         );
 
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllCpuQos (v_user_id UUID)
-RETURNS SETOF qos STABLE AS $PROCEDURE$
+RETURNS SETOF qos STABLE AS $FUNCTION$
 BEGIN
    RETURN QUERY SELECT *
       FROM qos WHERE
@@ -354,11 +354,11 @@ BEGIN
                 AND user_cluster_permissions_view.user_id = v_user_id
         );
 
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllNetworkQos (v_user_id UUID)
-RETURNS SETOF qos STABLE AS $PROCEDURE$
+RETURNS SETOF qos STABLE AS $FUNCTION$
 BEGIN
    RETURN QUERY SELECT *
       FROM qos WHERE
@@ -372,11 +372,11 @@ BEGIN
                 AND user_vnic_profile_permissions_view.user_id = v_user_id
         );
 
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllHostNetworkQos ()
-RETURNS SETOF qos STABLE AS $PROCEDURE$
+RETURNS SETOF qos STABLE AS $FUNCTION$
 BEGIN
    RETURN QUERY SELECT *
       FROM qos WHERE
@@ -390,12 +390,12 @@ BEGIN
                 AND user_network_permissions_view.user_id = v_user_id
         );
 
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 
 CREATE OR REPLACE FUNCTION GetQosByDiskProfiles (v_disk_profile_ids UUID[])
-RETURNS SETOF qos_for_disk_profile_view STABLE AS $PROCEDURE$
+RETURNS SETOF qos_for_disk_profile_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -403,29 +403,29 @@ BEGIN
     FROM qos_for_disk_profile_view
     WHERE disk_profile_id = ANY(v_disk_profile_ids);
 
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetQosByVmIds (v_vm_ids UUID[])
-RETURNS SETOF qos_for_vm_view STABLE AS $PROCEDURE$
+RETURNS SETOF qos_for_vm_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM qos_for_vm_view
     WHERE vm_id = ANY(v_vm_ids);
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetHostNetworkQosOfMigrationNetworkByClusterId (v_cluster_id UUID)
-RETURNS SETOF host_network_qos_of_migration_network_by_cluster STABLE AS $PROCEDURE$
+RETURNS SETOF host_network_qos_of_migration_network_by_cluster STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM host_network_qos_of_migration_network_by_cluster
     WHERE cluster_id = v_cluster_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/quota_sp.sql
+++ b/packaging/dbscripts/quota_sp.sql
@@ -11,7 +11,7 @@ CREATE OR REPLACE FUNCTION InsertQuota (
     v_grace_storage_percentage INT,
     v_is_default BOOLEAN
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO quota (
         id,
@@ -35,7 +35,7 @@ BEGIN
         v_grace_storage_percentage,
         v_is_default
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION InsertQuotaLimitation (
@@ -47,7 +47,7 @@ CREATE OR REPLACE FUNCTION InsertQuotaLimitation (
     v_mem_size_mb BIGINT,
     v_storage_size_gb BIGINT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO quota_limitation (
         id,
@@ -67,7 +67,7 @@ BEGIN
         v_mem_size_mb,
         v_storage_size_gb
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Returns all the Quota storages in the storage pool if v_storage_id is null, if v_storage_id is not null then a specific quota storage will be returned.
@@ -77,7 +77,7 @@ CREATE OR REPLACE FUNCTION GetQuotaStorageByStorageGuid (
     v_id UUID,
     v_allow_empty BOOLEAN
     )
-RETURNS SETOF quota_storage_view STABLE AS $PROCEDURE$
+RETURNS SETOF quota_storage_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -102,7 +102,7 @@ BEGIN
             v_allow_empty
             OR storage_size_gb IS NOT NULL
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Returns all the global quotas in the storage pool if v_storage_pool_id is null, if v_storage_id is not null then a specific quota storage will be returned.
@@ -111,7 +111,7 @@ CREATE OR REPLACE FUNCTION GetQuotaByAdElementId (
     v_storage_pool_id UUID,
     v_recursive BOOLEAN
     )
-RETURNS SETOF quota_view STABLE AS $PROCEDURE$
+RETURNS SETOF quota_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -139,39 +139,39 @@ BEGIN
             v_storage_pool_id = quota_view.storage_pool_id
             OR v_storage_pool_id IS NULL
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Returns all the quotas in a thin view (only basic quota meta data. no limits or consumption)
 CREATE OR REPLACE FUNCTION getAllThinQuota ()
-RETURNS SETOF quota_view STABLE AS $PROCEDURE$
+RETURNS SETOF quota_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM quota_view;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION getQuotaCount ()
-RETURNS SETOF BIGINT STABLE AS $PROCEDURE$
+RETURNS SETOF BIGINT STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT count(*) AS num_quota
     FROM quota;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetQuotaStorageByQuotaGuid (v_id UUID)
-RETURNS SETOF quota_storage_view STABLE AS $PROCEDURE$
+RETURNS SETOF quota_storage_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM quota_storage_view
     WHERE quota_id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetQuotaClusterByClusterGuid (
@@ -179,7 +179,7 @@ CREATE OR REPLACE FUNCTION GetQuotaClusterByClusterGuid (
     v_id UUID,
     v_allow_empty BOOLEAN
     )
-RETURNS SETOF quota_cluster_view STABLE AS $PROCEDURE$
+RETURNS SETOF quota_cluster_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -205,36 +205,36 @@ BEGIN
     WHERE v_allow_empty
         OR virtual_cpu IS NOT NULL
         OR mem_size_mb IS NOT NULL;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetQuotaClusterByQuotaGuid (v_id UUID)
-RETURNS SETOF quota_cluster_view STABLE AS $PROCEDURE$
+RETURNS SETOF quota_cluster_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT quota_cluster_view.*
     FROM quota_cluster_view
     WHERE quota_id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteQuotaByQuotaGuid (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM quota
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteQuotaLimitationByQuotaGuid (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM quota_limitation
     WHERE quota_id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateQuotaMetaData (
@@ -248,7 +248,7 @@ CREATE OR REPLACE FUNCTION UpdateQuotaMetaData (
     v_grace_storage_percentage INT,
     v_is_default BOOLEAN
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE quota
     SET storage_pool_id = v_storage_pool_id,
@@ -261,12 +261,12 @@ BEGIN
         grace_storage_percentage = v_grace_storage_percentage,
         is_default = v_is_default
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Returns all the Quota storages in the storage pool if v_storage_id is null, if v_storage_id is not null then a specific quota storage will be returned.
 CREATE OR REPLACE FUNCTION GetQuotaByStoragePoolGuid (v_storage_pool_id UUID)
-RETURNS SETOF quota_global_view STABLE AS $PROCEDURE$
+RETURNS SETOF quota_global_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -276,11 +276,11 @@ BEGIN
             storage_pool_id = v_storage_pool_id
             OR v_storage_pool_id IS NULL
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetDefaultQuotaForStoragePool (v_storage_pool_id UUID)
-RETURNS SETOF quota_global_view STABLE AS $PROCEDURE$
+RETURNS SETOF quota_global_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -289,22 +289,22 @@ BEGIN
     WHERE is_default = TRUE
           AND storage_pool_id = v_storage_pool_id;
 END;
-$PROCEDURE$
+$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetQuotaByQuotaGuid (v_id UUID)
-RETURNS SETOF quota_global_view STABLE AS $PROCEDURE$
+RETURNS SETOF quota_global_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM quota_global_view
     WHERE quota_id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetQuotaByQuotaName (v_quota_name VARCHAR, v_storage_pool_id UUID)
-RETURNS SETOF quota_global_view STABLE AS $PROCEDURE$
+RETURNS SETOF quota_global_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -312,7 +312,7 @@ BEGIN
     FROM quota_global_view
     WHERE quota_name = v_quota_name
         AND storage_pool_id = v_storage_pool_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllThinQuotasByStorageId (
@@ -320,7 +320,7 @@ CREATE OR REPLACE FUNCTION GetAllThinQuotasByStorageId (
     v_engine_session_seq_id INT,
     v_is_filtered boolean
     )
-RETURNS SETOF quota_view STABLE AS $PROCEDURE$
+RETURNS SETOF quota_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -364,7 +364,7 @@ BEGIN
                     quota_id = p.object_id
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllThinQuotasByClusterId (
@@ -372,7 +372,7 @@ CREATE OR REPLACE FUNCTION GetAllThinQuotasByClusterId (
     v_engine_session_seq_id INT,
     v_is_filtered boolean
     )
-RETURNS SETOF quota_view STABLE AS $PROCEDURE$
+RETURNS SETOF quota_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -416,7 +416,7 @@ BEGIN
                     quota_id = p.object_id
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION IsQuotaInUse (v_quota_id UUID)

--- a/packaging/dbscripts/repo_files_meta_data_sp.sql
+++ b/packaging/dbscripts/repo_files_meta_data_sp.sql
@@ -12,7 +12,7 @@ CREATE OR REPLACE FUNCTION InsertRepo_domain_file_meta_data (
     v_last_refreshed BIGINT,
     v_file_type INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO repo_file_meta_data (
         repo_domain_id,
@@ -32,14 +32,14 @@ BEGIN
         v_last_refreshed,
         v_file_type
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteRepo_domain_file_list (
     v_storage_domain_id UUID,
     v_file_type INT DEFAULT NULL
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM repo_file_meta_data
@@ -50,14 +50,14 @@ BEGIN
             );
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetRepo_files_by_storage_domain (
     v_storage_domain_id UUID,
     v_file_type INT DEFAULT NULL
     )
-RETURNS SETOF repo_file_meta_data STABLE AS $PROCEDURE$
+RETURNS SETOF repo_file_meta_data STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -69,5 +69,5 @@ BEGIN
             OR repo_file_meta_data.file_type = v_file_type
             )
     ORDER BY repo_file_meta_data.last_refreshed;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;

--- a/packaging/dbscripts/snapshots_sp.sql
+++ b/packaging/dbscripts/snapshots_sp.sql
@@ -16,7 +16,7 @@ CREATE OR REPLACE FUNCTION InsertSnapshot (
     v_memory_metadata_disk_id UUID,
     v_changed_fields TEXT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO snapshots (
         snapshot_id,
@@ -44,7 +44,7 @@ BEGIN
         v_memory_metadata_disk_id,
         v_changed_fields
         );
-END; $PROCEDURE$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateSnapshot (
@@ -61,7 +61,7 @@ CREATE OR REPLACE FUNCTION UpdateSnapshot (
     v_vm_configuration_broken BOOLEAN,
     v_changed_fields TEXT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE snapshots
     SET status = v_status,
@@ -77,54 +77,54 @@ BEGIN
         changed_fields = v_changed_fields,
         _update_date = NOW()
     WHERE snapshot_id = v_snapshot_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateSnapshotStatus (
     v_snapshot_id UUID,
     v_status VARCHAR(32)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE snapshots
     SET status = v_status
     WHERE snapshot_id = v_snapshot_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateSnapshotId (
     v_snapshot_id UUID,
     v_new_snapshot_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE snapshots
     SET snapshot_id = v_new_snapshot_id
     WHERE snapshot_id = v_snapshot_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteSnapshot (v_snapshot_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM snapshots
     WHERE snapshot_id = v_snapshot_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromSnapshots ()
-RETURNS SETOF snapshots STABLE AS $PROCEDURE$
+RETURNS SETOF snapshots STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM snapshots;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllSnapshotsByStorageDomainId (v_storage_id UUID)
-RETURNS SETOF snapshots STABLE AS $PROCEDURE$
+RETURNS SETOF snapshots STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -135,7 +135,7 @@ BEGIN
     INNER JOIN image_storage_domain_map
         ON image_storage_domain_map.storage_domain_id = v_storage_id
             AND image_storage_domain_map.image_id = images.image_guid;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetSnapshotByVmIdAndType (
@@ -144,7 +144,7 @@ CREATE OR REPLACE FUNCTION GetSnapshotByVmIdAndType (
     v_user_id UUID,
     v_is_filtered BOOLEAN
     )
-RETURNS SETOF snapshots STABLE AS $PROCEDURE$
+RETURNS SETOF snapshots STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -162,7 +162,7 @@ BEGIN
                 )
             )
     ORDER BY creation_date ASC LIMIT 1;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetSnapshotByVmIdAndTypeAndStatus (
@@ -170,7 +170,7 @@ CREATE OR REPLACE FUNCTION GetSnapshotByVmIdAndTypeAndStatus (
     v_snapshot_type VARCHAR(32),
     v_status VARCHAR(32)
     )
-RETURNS SETOF snapshots STABLE AS $PROCEDURE$
+RETURNS SETOF snapshots STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -180,14 +180,14 @@ BEGIN
         AND snapshot_type = v_snapshot_type
         AND status = v_status
     ORDER BY creation_date ASC LIMIT 1;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetSnapshotByVmIdAndStatus (
     v_vm_id UUID,
     v_status VARCHAR(32)
     )
-RETURNS SETOF snapshots STABLE AS $PROCEDURE$
+RETURNS SETOF snapshots STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -196,7 +196,7 @@ BEGIN
     WHERE vm_id = v_vm_id
         AND status = v_status
     ORDER BY creation_date ASC LIMIT 1;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 DROP TYPE IF EXISTS GetAllFromSnapshotsByVmId_rs CASCADE;
@@ -222,7 +222,7 @@ CREATE OR REPLACE FUNCTION GetAllFromSnapshotsByVmId (
     v_is_filtered BOOLEAN,
     v_fill_configuration BOOLEAN
     )
-RETURNS SETOF GetAllFromSnapshotsByVmId_rs STABLE AS $PROCEDURE$
+RETURNS SETOF GetAllFromSnapshotsByVmId_rs STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -256,7 +256,7 @@ BEGIN
                 )
             )
     ORDER BY creation_date ASC;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetSnapshotBySnapshotId (
@@ -264,7 +264,7 @@ CREATE OR REPLACE FUNCTION GetSnapshotBySnapshotId (
     v_user_id UUID,
     v_is_filtered BOOLEAN
     )
-RETURNS SETOF snapshots STABLE AS $PROCEDURE$
+RETURNS SETOF snapshots STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -284,14 +284,14 @@ BEGIN
                         )
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetSnapshotIdsByVmIdAndType (
     v_vm_id UUID,
     v_snapshot_type VARCHAR(32)
     )
-RETURNS SETOF idUuidType STABLE AS $PROCEDURE$
+RETURNS SETOF idUuidType STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -300,7 +300,7 @@ BEGIN
     WHERE vm_id = v_vm_id
         AND snapshot_type = v_snapshot_type
     ORDER BY creation_date ASC;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetSnapshotIdsByVmIdAndTypeAndStatus (
@@ -308,7 +308,7 @@ CREATE OR REPLACE FUNCTION GetSnapshotIdsByVmIdAndTypeAndStatus (
     v_snapshot_type VARCHAR(32),
     v_status VARCHAR(32)
     )
-RETURNS SETOF idUuidType STABLE AS $PROCEDURE$
+RETURNS SETOF idUuidType STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -318,14 +318,14 @@ BEGIN
         AND snapshot_type = v_snapshot_type
         AND status = v_status
     ORDER BY creation_date ASC;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION CheckIfSnapshotExistsByVmIdAndType (
     v_vm_id UUID,
     v_snapshot_type VARCHAR(32)
     )
-RETURNS SETOF booleanResultType STABLE AS $PROCEDURE$
+RETURNS SETOF booleanResultType STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -335,14 +335,14 @@ BEGIN
             WHERE vm_id = v_vm_id
                 AND snapshot_type = v_snapshot_type
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION CheckIfSnapshotExistsByVmIdAndStatus (
     v_vm_id UUID,
     v_status VARCHAR(32)
     )
-RETURNS SETOF booleanResultType STABLE AS $PROCEDURE$
+RETURNS SETOF booleanResultType STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -352,14 +352,14 @@ BEGIN
             WHERE vm_id = v_vm_id
                 AND status = v_status
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION CheckIfSnapshotExistsByVmIdAndSnapshotId (
     v_vm_id UUID,
     v_snapshot_id UUID
     )
-RETURNS SETOF booleanResultType STABLE AS $PROCEDURE$
+RETURNS SETOF booleanResultType STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -369,11 +369,11 @@ BEGIN
             WHERE vm_id = v_vm_id
                 AND snapshot_id = v_snapshot_id
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetNumOfSnapshotsByMemoryVolume(v_memory_disk_ids UUID[])
-RETURNS SETOF BIGINT STABLE AS $PROCEDURE$
+RETURNS SETOF BIGINT STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -381,7 +381,7 @@ BEGIN
     FROM snapshots
     WHERE memory_dump_disk_id  = ANY(v_memory_disk_ids)
        OR memory_metadata_disk_id  = ANY(v_memory_disk_ids);
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateMemory (
@@ -390,48 +390,48 @@ CREATE OR REPLACE FUNCTION UpdateMemory (
     v_vm_id UUID,
     v_snapshot_type VARCHAR(32)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE snapshots
     SET    memory_dump_disk_id = v_memory_dump_disk_id,
            memory_metadata_disk_id = v_memory_metadata_disk_id
     WHERE vm_id = v_vm_id
         AND snapshot_type = v_snapshot_type;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION RemoveMemoryFromSnapshotByVmIdAndType (
     v_vm_id UUID,
     v_snapshot_type VARCHAR(32)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE snapshots
     SET    memory_dump_disk_id = NULL,
            memory_metadata_disk_id = NULL
     WHERE  vm_id = v_vm_id
         AND snapshot_type = v_snapshot_type;
-END; $PROCEDURE$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION RemoveMemoryFromSnapshotBySnapshotId (v_snapshot_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE snapshots
     SET    memory_dump_disk_id = NULL,
            memory_metadata_disk_id = NULL
     WHERE  snapshot_id = v_snapshot_id;
-END; $PROCEDURE$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
 CREATE OR REPLACE FUNCTION GetAllSnapshotsByMemoryDisk(v_memory_disk_id UUID)
-RETURNS SETOF snapshots STABLE AS $PROCEDURE$
+RETURNS SETOF snapshots STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM snapshots
     WHERE v_memory_disk_id IN (memory_dump_disk_id, memory_metadata_disk_id);
-END; $PROCEDURE$
+END; $FUNCTION$
 LANGUAGE plpgsql;

--- a/packaging/dbscripts/sso_clients_sp.sql
+++ b/packaging/dbscripts/sso_clients_sp.sql
@@ -14,7 +14,7 @@ CREATE OR REPLACE FUNCTION sso_oauth_register_client (
     v_notification_callback_verify_host BOOLEAN DEFAULT TRUE,
     v_notification_callback_verify_chain BOOLEAN DEFAULT TRUE
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 
 BEGIN
     -- Adding the sso client
@@ -48,26 +48,26 @@ BEGIN
         v_notification_callback_verify_host,
         v_notification_callback_verify_chain
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 
 LANGUAGE plpgsql;
 
 -- Deletes a sso client by client_id
 CREATE OR REPLACE FUNCTION sso_oauth_unregister_client (v_client_id VARCHAR(128))
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 
 BEGIN
     -- Removing the sso client
     DELETE
     FROM sso_clients
     WHERE client_id = v_client_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 
 LANGUAGE plpgsql;
 
 -- Checks if the sso client with id exists.
 CREATE OR REPLACE FUNCTION sso_oauth_client_exists (v_client_id VARCHAR(128))
-RETURNS SETOF INT IMMUTABLE AS $PROCEDURE$
+RETURNS SETOF INT IMMUTABLE AS $FUNCTION$
 
 BEGIN
     IF EXISTS (
@@ -83,13 +83,13 @@ BEGIN
         SELECT 0;
     END IF;
 
-END;$PROCEDURE$
+END;$FUNCTION$
 
 LANGUAGE plpgsql;
 
 -- Returns the Client by client Id
 CREATE OR REPLACE FUNCTION get_oauth_client (v_client_id VARCHAR(128))
-RETURNS SETOF sso_clients STABLE AS $PROCEDURE$
+RETURNS SETOF sso_clients STABLE AS $FUNCTION$
 
 BEGIN
     RETURN QUERY
@@ -97,7 +97,7 @@ BEGIN
     SELECT *
     FROM sso_clients
     WHERE client_id = v_client_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 
 LANGUAGE plpgsql;
 
@@ -113,7 +113,7 @@ CREATE OR REPLACE FUNCTION update_oauth_client (
     v_trusted BOOLEAN DEFAULT TRUE,
     v_notification_callback VARCHAR(1024) DEFAULT NULL
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 
 BEGIN
     UPDATE sso_clients
@@ -126,7 +126,7 @@ BEGIN
         trusted = v_trusted,
         notification_callback = v_notification_callback
     WHERE client_id = v_client_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 
 LANGUAGE plpgsql;
 
@@ -135,12 +135,12 @@ CREATE OR REPLACE FUNCTION update_oauth_client_callback_prefix (
     v_client_id VARCHAR(128),
     v_callback_prefix VARCHAR(1024) DEFAULT NULL
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 
 BEGIN
     UPDATE sso_clients
     SET callback_prefix = v_callback_prefix
     WHERE client_id = v_client_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 
 LANGUAGE plpgsql;

--- a/packaging/dbscripts/storage_device_sp.sql
+++ b/packaging/dbscripts/storage_device_sp.sql
@@ -1,7 +1,7 @@
 
 
 /* ----------------------------------------------------------------
- Stored procedures for database operations on Storage Device
+ Stored FUNCTIONs for database operations on Storage Device
  related table: storage_device
 ----------------------------------------------------------------*/
 CREATE OR REPLACE FUNCTION InsertStorageDevice (
@@ -19,7 +19,7 @@ CREATE OR REPLACE FUNCTION InsertStorageDevice (
     v_is_free BOOLEAN,
     v_is_gluster_brick BOOLEAN
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO storage_device (
         id,
@@ -51,7 +51,7 @@ BEGIN
         v_is_free,
         v_is_gluster_brick
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateStorageDevice (
@@ -67,7 +67,7 @@ CREATE OR REPLACE FUNCTION UpdateStorageDevice (
     v_size BIGINT,
     v_is_free BOOLEAN
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE storage_device
     SET name = v_name,
@@ -82,51 +82,51 @@ BEGIN
         is_free = v_is_free,
         _update_date = LOCALTIMESTAMP
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetStorageDeviceById (v_id UUID)
-RETURNS SETOF storage_device STABLE AS $PROCEDURE$
+RETURNS SETOF storage_device STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM storage_device
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetStorageDevicesByVdsId (v_vds_id UUID)
-RETURNS SETOF storage_device STABLE AS $PROCEDURE$
+RETURNS SETOF storage_device STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM storage_device
     WHERE vds_id = v_vds_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteStorageDeviceById (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM storage_device
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateIsFreeFlagById (
     v_id UUID,
     v_is_free BOOLEAN
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE storage_device
     SET is_free = v_is_free,
         _update_date = LOCALTIMESTAMP
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/storage_domain_dr_sp.sql
+++ b/packaging/dbscripts/storage_domain_dr_sp.sql
@@ -1,5 +1,5 @@
 /*--------------------------------------------------------------
-Stored procedures for database operations on storage_domain_dr table
+Stored FUNCTIONs for database operations on storage_domain_dr table
 --------------------------------------------------------------*/
 CREATE OR REPLACE FUNCTION InsertStorageDomainDR (
     v_storage_domain_id UUID,
@@ -7,7 +7,7 @@ CREATE OR REPLACE FUNCTION InsertStorageDomainDR (
     v_sync_schedule VARCHAR(256),
     v_gluster_scheduler_job_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO storage_domain_dr (
         storage_domain_id,
@@ -21,7 +21,7 @@ BEGIN
         v_sync_schedule,
         v_gluster_scheduler_job_id
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateStorageDomainDR (
@@ -30,63 +30,63 @@ CREATE OR REPLACE FUNCTION UpdateStorageDomainDR (
     v_sync_schedule VARCHAR(256),
     v_gluster_scheduler_job_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE storage_domain_dr
     set sync_schedule = v_sync_schedule,
         gluster_scheduler_job_id = v_gluster_scheduler_job_id
     WHERE storage_domain_id = v_storage_domain_id
     AND georep_session_id = v_georep_session_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetStorageDomainDR (
     v_storage_domain_id UUID,
     v_georep_session_id UUID
     )
-RETURNS SETOF storage_domain_dr STABLE AS $PROCEDURE$
+RETURNS SETOF storage_domain_dr STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
     SELECT *
     FROM storage_domain_dr
     WHERE storage_domain_id = v_storage_domain_id
     AND georep_session_id = v_georep_session_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetStorageDomainDRList (
     v_storage_domain_id UUID
     )
-RETURNS SETOF storage_domain_dr STABLE AS $PROCEDURE$
+RETURNS SETOF storage_domain_dr STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
     SELECT *
     FROM storage_domain_dr
     WHERE storage_domain_id = v_storage_domain_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetStorageDomainDRWithGeoRep (
     v_georep_session_id UUID
     )
-RETURNS SETOF storage_domain_dr STABLE AS $PROCEDURE$
+RETURNS SETOF storage_domain_dr STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
     SELECT *
     FROM storage_domain_dr
     WHERE georep_session_id = v_georep_session_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteStorageDomainDR (
     v_storage_domain_id UUID,
     v_georep_session_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM storage_domain_dr
     WHERE storage_domain_id = v_storage_domain_id
     AND georep_session_id = v_georep_session_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;

--- a/packaging/dbscripts/storages_san_sp.sql
+++ b/packaging/dbscripts/storages_san_sp.sql
@@ -14,7 +14,7 @@ CREATE OR REPLACE FUNCTION InsertLUNs (
     v_device_size INT,
     v_discard_max_size BIGINT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO LUNs (
         LUN_id,
@@ -38,7 +38,7 @@ BEGIN
         v_device_size,
         v_discard_max_size
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateLUNs (
@@ -52,7 +52,7 @@ CREATE OR REPLACE FUNCTION UpdateLUNs (
     v_device_size INT,
     v_discard_max_size BIGINT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE LUNs
     SET LUN_id = v_LUN_id,
@@ -65,30 +65,30 @@ BEGIN
         device_size = v_device_size,
         discard_max_size = v_discard_max_size
     WHERE LUN_id = v_LUN_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteLUN (v_LUN_id VARCHAR(255))
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM LUNs
     WHERE LUN_id = v_LUN_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromLUNs ()
-RETURNS SETOF luns_view STABLE AS $PROCEDURE$
+RETURNS SETOF luns_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM luns_view;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetLUNsBystorage_server_connection (v_storage_server_connection VARCHAR(50))
-RETURNS SETOF luns_view STABLE AS $PROCEDURE$
+RETURNS SETOF luns_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -97,29 +97,29 @@ BEGIN
     INNER JOIN LUN_storage_server_connection_map
         ON LUN_storage_server_connection_map.LUN_id = luns_view.LUN_id
     WHERE LUN_storage_server_connection_map.storage_server_connection = v_storage_server_connection;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetLUNsByVolumeGroupId (v_volume_group_id VARCHAR(50))
-RETURNS SETOF luns_view STABLE AS $PROCEDURE$
+RETURNS SETOF luns_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM luns_view
     WHERE volume_group_id = v_volume_group_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetLUNByLUNId (v_LUN_id VARCHAR(255))
-RETURNS SETOF luns_view STABLE AS $PROCEDURE$
+RETURNS SETOF luns_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM luns_view
     WHERE LUN_id = v_LUN_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ----------------------------------------------------------------
@@ -132,7 +132,7 @@ CREATE OR REPLACE FUNCTION Insertstorage_domain_dynamic (
     v_id UUID,
     v_used_disk_size INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO storage_domain_dynamic (
         available_disk_size,
@@ -144,7 +144,7 @@ BEGIN
         v_id,
         v_used_disk_size
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Updatestorage_domain_dynamic (
@@ -154,14 +154,14 @@ CREATE OR REPLACE FUNCTION Updatestorage_domain_dynamic (
     )
 RETURNS VOID
     --The [storage_domain_dynamic] table doesn't have a timestamp column. Optimistic concurrency logic cannot be generated
-    AS $PROCEDURE$
+    AS $FUNCTION$
 BEGIN
     UPDATE storage_domain_dynamic
     SET available_disk_size = v_available_disk_size,
         used_disk_size = v_used_disk_size,
         _update_date = LOCALTIMESTAMP
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateStorageDomainConfirmedSize (
@@ -171,59 +171,59 @@ CREATE OR REPLACE FUNCTION UpdateStorageDomainConfirmedSize (
     )
 RETURNS VOID
     --The [storage_domain_dynamic] table doesn't have a timestamp column. Optimistic concurrency logic cannot be generated
-    AS $PROCEDURE$
+    AS $FUNCTION$
 BEGIN
     UPDATE storage_domain_dynamic
     SET confirmed_available_disk_size = v_confirmed_available_disk_size,
         vdo_savings = v_vdo_savings,
         _update_date = LOCALTIMESTAMP
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateStorageDomainExternalStatus (
     v_storage_id UUID,
     v_external_status INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE storage_domain_dynamic
     SET external_status = v_external_status
     WHERE id = v_storage_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Deletestorage_domain_dynamic (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM storage_domain_dynamic
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromstorage_domain_dynamic ()
-RETURNS SETOF storage_domain_dynamic STABLE AS $PROCEDURE$
+RETURNS SETOF storage_domain_dynamic STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM storage_domain_dynamic;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Getstorage_domain_dynamicByid (v_id UUID)
-RETURNS SETOF storage_domain_dynamic STABLE AS $PROCEDURE$
+RETURNS SETOF storage_domain_dynamic STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM storage_domain_dynamic
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
---The GetByFK stored procedure cannot be created because the [storage_domain_dynamic] table doesn't have at least one foreign key column or the foreign keys are also primary keys.
+--The GetByFK stored FUNCTION cannot be created because the [storage_domain_dynamic] table doesn't have at least one foreign key column or the foreign keys are also primary keys.
 ----------------------------------------------------------------
 -- [storage_pool_iso_map] Table
 --
@@ -232,7 +232,7 @@ CREATE OR REPLACE FUNCTION Insertstorage_pool_iso_map (
     v_storage_pool_id UUID,
     v_status INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO storage_pool_iso_map (
         storage_id,
@@ -244,37 +244,37 @@ BEGIN
         v_storage_pool_id,
         v_status
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Deletestorage_pool_iso_map (
     v_storage_id UUID,
     v_storage_pool_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM storage_pool_iso_map
     WHERE storage_id = v_storage_id
         AND storage_pool_id = v_storage_pool_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromstorage_pool_iso_map ()
-RETURNS SETOF storage_pool_iso_map STABLE AS $PROCEDURE$
+RETURNS SETOF storage_pool_iso_map STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM storage_pool_iso_map;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Getstorage_pool_iso_mapBystorage_idAndBystorage_pool_id (
     v_storage_id UUID,
     v_storage_pool_id UUID
     )
-RETURNS SETOF storage_pool_iso_map STABLE AS $PROCEDURE$
+RETURNS SETOF storage_pool_iso_map STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -282,25 +282,25 @@ BEGIN
     FROM storage_pool_iso_map
     WHERE storage_id = v_storage_id
         AND storage_pool_id = v_storage_pool_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Getstorage_pool_iso_mapsBystorage_id (v_storage_id UUID)
-RETURNS SETOF storage_pool_iso_map STABLE AS $PROCEDURE$
+RETURNS SETOF storage_pool_iso_map STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM storage_pool_iso_map
     WHERE storage_id = v_storage_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Getstorage_pool_iso_mapsByBystorage_pool_id (
     v_storage_id UUID,
     v_storage_pool_id UUID
     )
-RETURNS SETOF storage_pool_iso_map STABLE AS $PROCEDURE$
+RETURNS SETOF storage_pool_iso_map STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -311,7 +311,7 @@ BEGIN
     WHERE storage_pool_id = v_storage_pool_id
         AND storage_domain_static.storage_type != 9
         AND storage_domain_static.storage_type != 10; -- filter Cinder and Managed block storage domains
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Updatestorage_pool_iso_map_status (
@@ -319,16 +319,16 @@ CREATE OR REPLACE FUNCTION Updatestorage_pool_iso_map_status (
     v_storage_pool_id UUID,
     v_status INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE storage_pool_iso_map
     SET status = v_status
     WHERE storage_pool_id = v_storage_pool_id
         AND storage_id = v_storage_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
---The GetByFK stored procedure cannot be created because the [storage_pool_iso_map] table doesn't have at least one foreign key column or the foreign keys are also primary keys.
+--The GetByFK stored FUNCTION cannot be created because the [storage_pool_iso_map] table doesn't have at least one foreign key column or the foreign keys are also primary keys.
 ----------------------------------------------------------------
 -- [storage_server_connections] Table
 --
@@ -350,7 +350,7 @@ CREATE OR REPLACE FUNCTION Insertstorage_server_connections (
     v_nfs_retrans SMALLINT,
     v_gluster_volume_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO storage_server_connections (
         connection,
@@ -384,7 +384,7 @@ BEGIN
         v_nfs_retrans,
         v_gluster_volume_id
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Updatestorage_server_connections (
@@ -405,7 +405,7 @@ CREATE OR REPLACE FUNCTION Updatestorage_server_connections (
     )
 RETURNS VOID
     --The [storage_server_connections] table doesn't have a timestamp column. Optimistic concurrency logic cannot be generated
-    AS $PROCEDURE$
+    AS $FUNCTION$
 BEGIN
     UPDATE storage_server_connections
     SET connection = v_connection,
@@ -422,11 +422,11 @@ BEGIN
         nfs_retrans = v_nfs_retrans,
         gluster_volume_id = v_gluster_volume_id
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Deletestorage_server_connections (v_id VARCHAR(50))
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 DECLARE v_val VARCHAR(50);
 
 BEGIN
@@ -441,33 +441,33 @@ BEGIN
     DELETE
     FROM storage_server_connections
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Getstorage_server_connectionsByid (v_id VARCHAR(50))
-RETURNS SETOF storage_server_connections STABLE AS $PROCEDURE$
+RETURNS SETOF storage_server_connections STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM storage_server_connections
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Getstorage_server_connectionsByConnection (v_connection VARCHAR(250))
-RETURNS SETOF storage_server_connections STABLE AS $PROCEDURE$
+RETURNS SETOF storage_server_connections STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM storage_server_connections
     WHERE connection = v_connection;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Getstorage_server_connectionsByIqn (v_iqn VARCHAR(128))
-RETURNS SETOF storage_server_connections STABLE AS $PROCEDURE$
+RETURNS SETOF storage_server_connections STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -476,14 +476,14 @@ BEGIN
     WHERE iqn = v_iqn
         OR iqn IS NULL
         AND v_iqn IS NULL;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Getstorage_server_connectionsByIqnAndConnection (
     v_iqn VARCHAR(128),
     v_connection VARCHAR(250)
     )
-RETURNS SETOF storage_server_connections STABLE AS $PROCEDURE$
+RETURNS SETOF storage_server_connections STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -494,7 +494,7 @@ BEGIN
             connection = v_connection
             OR connection IS NULL
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Getstorage_server_connectionsByKey (
@@ -504,7 +504,7 @@ CREATE OR REPLACE FUNCTION Getstorage_server_connectionsByKey (
     v_portal VARCHAR(50),
     v_username VARCHAR(50)
     )
-RETURNS SETOF storage_server_connections STABLE AS $PROCEDURE$
+RETURNS SETOF storage_server_connections STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -539,7 +539,7 @@ BEGIN
                 AND v_username IS NULL
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetStorageConnectionsByConnectionPortAndIqn (
@@ -547,7 +547,7 @@ CREATE OR REPLACE FUNCTION GetStorageConnectionsByConnectionPortAndIqn (
     v_connection VARCHAR(250),
     v_port VARCHAR(50)
     )
-RETURNS SETOF storage_server_connections STABLE AS $PROCEDURE$
+RETURNS SETOF storage_server_connections STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -556,44 +556,44 @@ BEGIN
     WHERE iqn = v_iqn
         AND connection = v_connection
         AND port = v_port;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 
 CREATE OR REPLACE FUNCTION Getstorage_server_connectionsByStorageType (v_storage_type INT)
-RETURNS SETOF storage_server_connections STABLE AS $PROCEDURE$
+RETURNS SETOF storage_server_connections STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM storage_server_connections
     WHERE storage_type = v_storage_type;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllstorage_server_connections ()
-RETURNS SETOF storage_server_connections STABLE AS $PROCEDURE$
+RETURNS SETOF storage_server_connections STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM storage_server_connections;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetStorageServerConnectionsByIds (v_ids TEXT)
-RETURNS SETOF storage_server_connections STABLE AS $PROCEDURE$
+RETURNS SETOF storage_server_connections STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM storage_server_connections
     WHERE id = ANY (string_to_array(v_ids, ',')::VARCHAR []);
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Getstorage_server_connectionsByVolumeGroupId (v_volume_group_id VARCHAR(50))
-RETURNS SETOF storage_server_connections STABLE AS $PROCEDURE$
+RETURNS SETOF storage_server_connections STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -606,7 +606,7 @@ BEGIN
     INNER JOIN storage_server_connections
         ON LUN_storage_server_connection_map.storage_server_connection = storage_server_connections.id
     WHERE (storage_domain_static.storage = v_volume_group_id);
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetStorageConnectionsByStorageTypeAndStatus (
@@ -614,7 +614,7 @@ CREATE OR REPLACE FUNCTION GetStorageConnectionsByStorageTypeAndStatus (
     v_storage_type INT,
     v_statuses VARCHAR(20)
     )
-RETURNS SETOF storage_server_connections STABLE AS $PROCEDURE$
+RETURNS SETOF storage_server_connections STABLE AS $FUNCTION$
 DECLARE statuses INT [];
 
 BEGIN
@@ -650,11 +650,11 @@ BEGIN
                     )
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Getstorage_server_connectionsByLunId (v_lunId VARCHAR(50))
-RETURNS SETOF storage_server_connections STABLE AS $PROCEDURE$
+RETURNS SETOF storage_server_connections STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -663,10 +663,10 @@ BEGIN
     INNER JOIN lun_storage_server_connection_map
         ON lun_storage_server_connection_map.storage_server_connection = storage_server_connections.id
     WHERE (lun_storage_server_connection_map.lun_id = v_lunId);
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
---The GetByFK stored procedure cannot be created because the [storage_server_connections] table doesn't have at least one foreign key column or the foreign keys are also primary keys.
+--The GetByFK stored FUNCTION cannot be created because the [storage_server_connections] table doesn't have at least one foreign key column or the foreign keys are also primary keys.
 ----------------------------------------------------------------
 -- [LUN_storage_server_connection_map] Table
 --
@@ -674,7 +674,7 @@ CREATE OR REPLACE FUNCTION InsertLUN_storage_server_connection_map (
     v_LUN_id VARCHAR(255),
     v_storage_server_connection VARCHAR(50)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO LUN_storage_server_connection_map (
         LUN_id,
@@ -684,7 +684,7 @@ BEGIN
         v_LUN_id,
         v_storage_server_connection
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateLUN_storage_server_connection_map (
@@ -693,45 +693,45 @@ CREATE OR REPLACE FUNCTION UpdateLUN_storage_server_connection_map (
     )
 RETURNS VOID
     --The [LUN_storage_server_connection_map] table doesn't have a timestamp column. Optimistic concurrency logic cannot be generated
-    AS $PROCEDURE$
+    AS $FUNCTION$
 BEGIN
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteLUN_storage_server_connection_map (
     v_LUN_id VARCHAR(255),
     v_storage_server_connection VARCHAR(50)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM LUN_storage_server_connection_map
     WHERE LUN_id = v_LUN_id
         AND storage_server_connection = v_storage_server_connection;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromLUN_storage_server_connection_map ()
-RETURNS SETOF LUN_storage_server_connection_map STABLE AS $PROCEDURE$
+RETURNS SETOF LUN_storage_server_connection_map STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM LUN_storage_server_connection_map lUN_storage_server_connection_map;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetLUN_storage_server_connection_mapByLUN (
     v_LUN_id VARCHAR(255)
     )
-RETURNS SETOF LUN_storage_server_connection_map STABLE AS $PROCEDURE$
+RETURNS SETOF LUN_storage_server_connection_map STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM LUN_storage_server_connection_map lUN_storage_server_connection_map
     WHERE LUN_id = v_LUN_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -739,7 +739,7 @@ CREATE OR REPLACE FUNCTION GetLUN_storage_server_connection_mapByLUNBystorage_se
     v_LUN_id VARCHAR(255),
     v_storage_server_connection VARCHAR(50)
     )
-RETURNS SETOF LUN_storage_server_connection_map STABLE AS $PROCEDURE$
+RETURNS SETOF LUN_storage_server_connection_map STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -747,7 +747,7 @@ BEGIN
     FROM LUN_storage_server_connection_map lUN_storage_server_connection_map
     WHERE LUN_id = v_LUN_id
         AND storage_server_connection = v_storage_server_connection;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION InsertStorageServerConnectionExtension (
@@ -757,7 +757,7 @@ CREATE OR REPLACE FUNCTION InsertStorageServerConnectionExtension (
     v_user_name TEXT,
     v_password TEXT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO storage_server_connection_extension (
         id,
@@ -773,7 +773,7 @@ BEGIN
         v_user_name,
         v_password
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateStorageServerConnectionExtension (
@@ -783,7 +783,7 @@ CREATE OR REPLACE FUNCTION UpdateStorageServerConnectionExtension (
     v_user_name TEXT,
     v_password TEXT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE storage_server_connection_extension
     SET vds_id = v_vds_id,
@@ -791,45 +791,45 @@ BEGIN
         user_name = v_user_name,
         password = v_password
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteStorageServerConnectionExtension (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM storage_server_connection_extension
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetStorageServerConnectionExtensionById (v_id UUID)
-RETURNS SETOF storage_server_connection_extension STABLE AS $PROCEDURE$
+RETURNS SETOF storage_server_connection_extension STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM storage_server_connection_extension
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetStorageServerConnectionExtensionsByHostId (v_vds_id UUID)
-RETURNS SETOF storage_server_connection_extension STABLE AS $PROCEDURE$
+RETURNS SETOF storage_server_connection_extension STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM storage_server_connection_extension
     WHERE vds_id = v_vds_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetStorageServerConnectionExtensionsByHostIdAndTarget (
     v_vds_id UUID,
     v_iqn VARCHAR(128)
     )
-RETURNS SETOF storage_server_connection_extension STABLE AS $PROCEDURE$
+RETURNS SETOF storage_server_connection_extension STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -837,17 +837,17 @@ BEGIN
     FROM storage_server_connection_extension
     WHERE vds_id = v_vds_id
         AND iqn = v_iqn;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromStorageServerConnectionExtensions ()
-RETURNS SETOF storage_server_connection_extension STABLE AS $PROCEDURE$
+RETURNS SETOF storage_server_connection_extension STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM storage_server_connection_extension;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/storages_sp.sql
+++ b/packaging/dbscripts/storages_sp.sql
@@ -16,7 +16,7 @@ CREATE OR REPLACE FUNCTION Insertstorage_pool (
     v_quota_enforcement_type INT,
     v_managed BOOLEAN
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO storage_pool (
         description,
@@ -44,7 +44,7 @@ BEGIN
         v_quota_enforcement_type,
         v_managed
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Updatestorage_pool (
@@ -63,7 +63,7 @@ CREATE OR REPLACE FUNCTION Updatestorage_pool (
     )
 RETURNS VOID
     --The [storage_pool] table doesn't have a timestamp column. Optimistic concurrency logic cannot be generated
-    AS $PROCEDURE$
+    AS $FUNCTION$
 BEGIN
     UPDATE storage_pool
     SET description = v_description,
@@ -79,7 +79,7 @@ BEGIN
         quota_enforcement_type = v_quota_enforcement_type,
         managed = v_managed
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Updatestorage_pool_partial (
@@ -94,7 +94,7 @@ CREATE OR REPLACE FUNCTION Updatestorage_pool_partial (
     )
 RETURNS VOID
     --The [storage_pool] table doesn't have a timestamp column. Optimistic concurrency logic cannot be generated
-    AS $PROCEDURE$
+    AS $FUNCTION$
 BEGIN
     UPDATE storage_pool
     SET description = v_description,
@@ -106,24 +106,24 @@ BEGIN
         _update_date = LOCALTIMESTAMP,
         quota_enforcement_type = v_quota_enforcement_type
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Updatestorage_pool_status (
     v_id UUID,
     v_status INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE storage_pool
     SET status = v_status,
         _update_date = LOCALTIMESTAMP
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION IncreaseStoragePoolMasterVersion (v_id UUID)
-RETURNS INT AS $PROCEDURE$
+RETURNS INT AS $FUNCTION$
 DECLARE v_master_domain_version INT;
 
 BEGIN
@@ -133,11 +133,11 @@ BEGIN
     INTO v_master_domain_version;
 
     RETURN v_master_domain_version;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Deletestorage_pool (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 DECLARE v_val UUID;
 
 BEGIN
@@ -208,14 +208,14 @@ BEGIN
 
     -- delete StoragePool permissions --
     PERFORM DeletePermissionsByEntityId(v_id);
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromstorage_pool (
     v_user_id UUID,
     v_is_filtered BOOLEAN
     )
-RETURNS SETOF storage_pool STABLE AS $PROCEDURE$
+RETURNS SETOF storage_pool STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -230,18 +230,18 @@ BEGIN
                     AND entity_id = id
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllByStatus (v_status INT)
-RETURNS SETOF storage_pool STABLE AS $PROCEDURE$
+RETURNS SETOF storage_pool STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM storage_pool
     WHERE status = v_status;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Getstorage_poolByid (
@@ -249,7 +249,7 @@ CREATE OR REPLACE FUNCTION Getstorage_poolByid (
     v_user_id UUID,
     v_is_filtered BOOLEAN
     )
-RETURNS SETOF storage_pool STABLE AS $PROCEDURE$
+RETURNS SETOF storage_pool STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -265,14 +265,14 @@ BEGIN
                     AND entity_id = v_id
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Getstorage_poolByName (
     v_name VARCHAR(40),
     v_is_case_sensitive BOOLEAN
     )
-RETURNS SETOF storage_pool STABLE AS $PROCEDURE$
+RETURNS SETOF storage_pool STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -283,11 +283,11 @@ BEGIN
             NOT v_is_case_sensitive
             AND name ilike v_name
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Getstorage_poolsByStorageDomainId (v_storage_domain_id UUID)
-RETURNS SETOF storage_pool STABLE AS $PROCEDURE$
+RETURNS SETOF storage_pool STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -296,7 +296,7 @@ BEGIN
     INNER JOIN storage_pool_iso_map
         ON storage_pool.id = storage_pool_iso_map.storage_pool_id
     WHERE storage_pool_iso_map.storage_id = v_storage_domain_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVmAndTemplatesIdsByStorageDomainId (
@@ -304,7 +304,7 @@ CREATE OR REPLACE FUNCTION GetVmAndTemplatesIdsByStorageDomainId (
     v_include_shareable BOOLEAN,
     v_active_only BOOLEAN
     )
-RETURNS SETOF UUID STABLE AS $PROCEDURE$
+RETURNS SETOF UUID STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -315,11 +315,11 @@ BEGIN
     WHERE i.storage_id = v_storage_domain_id
         AND i.active = v_active_only
         AND i.shareable = v_include_shareable;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Getstorage_poolsByVdsId (v_vdsId UUID)
-RETURNS SETOF storage_pool STABLE AS $PROCEDURE$
+RETURNS SETOF storage_pool STABLE AS $FUNCTION$
 DECLARE v_clusterId UUID;
 
 BEGIN
@@ -337,11 +337,11 @@ BEGIN
             FROM cluster
             WHERE cluster_id = v_clusterId
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Getstorage_poolsByClusterId (v_clusterId UUID)
-RETURNS SETOF storage_pool STABLE AS $PROCEDURE$
+RETURNS SETOF storage_pool STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -352,32 +352,32 @@ BEGIN
             FROM cluster
             WHERE cluster_id = v_clusterId
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ----------------------------------------------------------------
 -- [storage_domains_ovf_info] Table
 --
 CREATE OR REPLACE FUNCTION LoadStorageDomainInfoByDomainId (v_storage_domain_id UUID)
-RETURNS SETOF storage_domains_ovf_info STABLE AS $PROCEDURE$
+RETURNS SETOF storage_domains_ovf_info STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM storage_domains_ovf_info ovf
     WHERE ovf.storage_domain_id = v_storage_domain_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION LoadStorageDomainInfoByDiskId (v_disk_id UUID)
-RETURNS SETOF storage_domains_ovf_info STABLE AS $PROCEDURE$
+RETURNS SETOF storage_domains_ovf_info STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM storage_domains_ovf_info ovf
     WHERE ovf.ovf_disk_id = v_disk_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION InsertStorageDomainOvfInfo (
@@ -386,7 +386,7 @@ CREATE OR REPLACE FUNCTION InsertStorageDomainOvfInfo (
     v_ovf_disk_id UUID,
     v_stored_ovfs_ids TEXT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO storage_domains_ovf_info (
         storage_domain_id,
@@ -400,18 +400,18 @@ BEGIN
         v_ovf_disk_id,
         v_stored_ovfs_ids
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION LoadStorageDomainsForOvfIds (v_ovfs_ids TEXT)
-RETURNS SETOF UUID AS $PROCEDURE$
+RETURNS SETOF UUID AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT ovf.storage_domain_id
     FROM storage_domains_ovf_info ovf
     WHERE string_to_array(ovf.stored_ovfs_ids, ',') && string_to_array(v_ovfs_ids, ',');
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateStorageDomainOvfInfo (
@@ -421,7 +421,7 @@ CREATE OR REPLACE FUNCTION UpdateStorageDomainOvfInfo (
     v_stored_ovfs_ids TEXT,
     v_last_updated TIMESTAMP WITH TIME ZONE
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE storage_domains_ovf_info
     SET status = v_status,
@@ -430,16 +430,16 @@ BEGIN
         stored_ovfs_ids = v_stored_ovfs_ids,
         last_updated = v_last_updated
     WHERE ovf_disk_id = v_ovf_disk_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteStorageDomainOvfInfo (v_ovf_disk_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM storage_domains_ovf_info
     WHERE ovf_disk_id = v_ovf_disk_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateOvfUpdatedInfo (
@@ -447,7 +447,7 @@ CREATE OR REPLACE FUNCTION UpdateOvfUpdatedInfo (
     v_status INT,
     v_except_status INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 DECLARE curs_storages_ids CURSOR
 FOR
 SELECT *
@@ -473,7 +473,7 @@ BEGIN
     END LOOP;
 
     CLOSE curs_storages_ids;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- ----------------------------------------------------------------
@@ -501,7 +501,7 @@ CREATE OR REPLACE FUNCTION Insertstorage_domain_static (
     v_backup BOOLEAN,
     v_block_size INTEGER
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO storage_domain_static (
         id,
@@ -543,11 +543,11 @@ BEGIN
         v_backup,
         v_block_size
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Getstorage_domains_List_By_ImageId (v_image_id UUID)
-RETURNS SETOF storage_domains STABLE AS $PROCEDURE$
+RETURNS SETOF storage_domains STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -558,7 +558,7 @@ BEGIN
             FROM image_storage_domain_map
             WHERE image_id = v_image_id
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Updatestorage_domain_static (
@@ -583,7 +583,7 @@ CREATE OR REPLACE FUNCTION Updatestorage_domain_static (
     )
 RETURNS VOID
     --The [storage_domain_static] table doesn't have a timestamp column. Optimistic concurrency logic cannot be generated
-    AS $PROCEDURE$
+    AS $FUNCTION$
 BEGIN
     UPDATE storage_domain_static
     SET storage = v_storage,
@@ -605,11 +605,11 @@ BEGIN
         backup = v_backup,
         block_size = v_block_size
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Deletestorage_domain_static (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 DECLARE v_val UUID;
 
 BEGIN
@@ -627,39 +627,39 @@ BEGIN
 
     -- delete Storage permissions --
     PERFORM DeletePermissionsByEntityId(v_id);
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromstorage_domain_static ()
-RETURNS SETOF storage_domain_static STABLE AS $PROCEDURE$
+RETURNS SETOF storage_domain_static STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM storage_domain_static;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Getstorage_domain_staticByid (v_id UUID)
-RETURNS SETOF storage_domain_static STABLE AS $PROCEDURE$
+RETURNS SETOF storage_domain_static STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM storage_domain_static
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Getstorage_domain_staticByName (v_name VARCHAR(250))
-RETURNS SETOF storage_domain_static STABLE AS $PROCEDURE$
+RETURNS SETOF storage_domain_static STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM storage_domain_static
     WHERE storage_name = v_name;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Getstorage_domain_staticByNameFiltered (
@@ -667,7 +667,7 @@ CREATE OR REPLACE FUNCTION Getstorage_domain_staticByNameFiltered (
     v_user_id UUID,
     v_is_filtered BOOLEAN
     )
-RETURNS SETOF storage_domain_static STABLE AS $PROCEDURE$
+RETURNS SETOF storage_domain_static STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -683,11 +683,11 @@ BEGIN
                     AND entity_id = sds.id
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Getstorage_domain_staticBystorage_pool_id (v_storage_pool_id UUID)
-RETURNS SETOF storage_domain_static STABLE AS $PROCEDURE$
+RETURNS SETOF storage_domain_static STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -696,7 +696,7 @@ BEGIN
     INNER JOIN storage_pool_iso_map
         ON storage_pool_iso_map.storage_id = storage_domain_static.id
     WHERE storage_pool_iso_map.storage_pool_id = v_storage_pool_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 DROP TYPE IF EXISTS GetStorageDomainIdsByStoragePoolIdAndStatus_rs CASCADE;
@@ -706,7 +706,7 @@ CREATE OR REPLACE FUNCTION GetStorageDomainIdsByStoragePoolIdAndStatus (
     v_storage_pool_id UUID,
     v_status INT
     )
-RETURNS SETOF GetStorageDomainIdsByStoragePoolIdAndStatus_rs STABLE AS $PROCEDURE$
+RETURNS SETOF GetStorageDomainIdsByStoragePoolIdAndStatus_rs STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -718,7 +718,7 @@ BEGIN
         AND status = v_status
         AND storage_domain_static.storage_type != 9
         AND storage_domain_static.storage_type != 10; -- filter Cinder and Managed block storage domains
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Getstorage_domains_By_id (
@@ -726,7 +726,7 @@ CREATE OR REPLACE FUNCTION Getstorage_domains_By_id (
     v_user_id UUID,
     v_is_filtered BOOLEAN
     )
-RETURNS SETOF storage_domains_without_storage_pools STABLE AS $PROCEDURE$
+RETURNS SETOF storage_domains_without_storage_pools STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -742,7 +742,7 @@ BEGIN
                     AND entity_id = v_id
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Getstorage_domains_by_storage_pool_id_with_permitted_action (
@@ -750,7 +750,7 @@ CREATE OR REPLACE FUNCTION Getstorage_domains_by_storage_pool_id_with_permitted_
     v_action_group_id INT,
     v_storage_pool_id UUID
     )
-RETURNS SETOF storage_domains STABLE AS $PROCEDURE$
+RETURNS SETOF storage_domains STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -760,14 +760,14 @@ BEGIN
         AND (
             SELECT get_entity_permissions(v_user_id, v_action_group_id, id, 11)
             ) IS NOT NULL;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Getstorage_domains_By_id_and_by_storage_pool_id (
     v_id UUID,
     v_storage_pool_id UUID
     )
-RETURNS SETOF storage_domains STABLE AS $PROCEDURE$
+RETURNS SETOF storage_domains STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -775,7 +775,7 @@ BEGIN
     FROM storage_domains
     WHERE id = v_id
         AND storage_pool_id = v_storage_pool_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Getstorage_domains_By_storagePoolId (
@@ -783,7 +783,7 @@ CREATE OR REPLACE FUNCTION Getstorage_domains_By_storagePoolId (
     v_user_id UUID,
     v_is_filtered BOOLEAN
     )
-RETURNS SETOF storage_domains STABLE AS $PROCEDURE$
+RETURNS SETOF storage_domains STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -799,7 +799,7 @@ BEGIN
                     AND entity_id = id
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Getstorage_domain_by_type_storagePoolId_and_status (
@@ -807,7 +807,7 @@ CREATE OR REPLACE FUNCTION Getstorage_domain_by_type_storagePoolId_and_status (
     v_storage_pool_id UUID,
     v_status INT
     )
-RETURNS SETOF storage_domains STABLE AS $PROCEDURE$
+RETURNS SETOF storage_domains STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -819,11 +819,11 @@ BEGIN
             v_status IS NULL
             OR status = v_status
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Getstorage_domains_By_connection (v_connection VARCHAR)
-RETURNS SETOF storage_domains STABLE AS $PROCEDURE$
+RETURNS SETOF storage_domains STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -834,25 +834,25 @@ BEGIN
             FROM storage_server_connections
             WHERE connection = v_connection
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromStorageDomainsByConnectionId (v_connection_id VARCHAR)
-RETURNS SETOF storage_domains STABLE AS $PROCEDURE$
+RETURNS SETOF storage_domains STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM storage_domains
     WHERE storage = v_connection_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromstorage_domains (
     v_user_id UUID,
     v_is_filtered BOOLEAN
     )
-RETURNS SETOF storage_domains STABLE AS $PROCEDURE$
+RETURNS SETOF storage_domains STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -867,11 +867,11 @@ BEGIN
                     AND entity_id = id
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Remove_Entities_From_storage_domain (v_storage_domain_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 DECLARE v_ids UUID[];
 BEGIN
     BEGIN
@@ -1139,11 +1139,11 @@ BEGIN
     -- Deletes the disks's permissions which the only storage domain they are reside on, is the storage domain.
     v_ids := array_agg(disk_id::UUID) FROM STORAGE_DOMAIN_MAP_TABLE;
     PERFORM DeletePermissionsByEntityIds(v_ids);
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Force_Delete_storage_domain (v_storage_domain_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     PERFORM Remove_Entities_From_storage_domain(v_storage_domain_id);
 
@@ -1156,11 +1156,11 @@ BEGIN
     DELETE
     FROM storage_domain_static
     WHERE id = v_storage_domain_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Getstorage_domains_List_By_storageDomainId (v_storage_domain_id UUID, v_user_id UUID, v_is_filtered BOOLEAN)
-RETURNS SETOF storage_domains STABLE AS $PROCEDURE$
+RETURNS SETOF storage_domains STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -1176,7 +1176,7 @@ BEGIN
                     AND entity_id = v_storage_domain_id
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 --This SP returns all data centers containing cluster with permissions to run the given action by user
@@ -1186,7 +1186,7 @@ CREATE OR REPLACE FUNCTION fn_perms_get_storage_pools_with_permitted_action_on_c
     v_supports_virt_service boolean,
     v_supports_gluster_service boolean
     )
-RETURNS SETOF storage_pool STABLE AS $PROCEDURE$
+RETURNS SETOF storage_pool STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -1209,14 +1209,14 @@ BEGIN
                         )
                     )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Getstorage_domains_By_storage_pool_id_and_connection (
     v_storage_pool_id UUID,
     v_connection VARCHAR
     )
-RETURNS SETOF storage_domains STABLE AS $PROCEDURE$
+RETURNS SETOF storage_domains STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -1228,11 +1228,11 @@ BEGIN
             FROM storage_server_connections
             WHERE connection = v_connection
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetFailingStorage_domains ()
-RETURNS SETOF storage_domains STABLE AS $PROCEDURE$
+RETURNS SETOF storage_domains STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -1240,11 +1240,11 @@ BEGIN
     FROM storage_domains
     WHERE recoverable
         AND status = 4;--inactive
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetFailingVdss ()
-RETURNS SETOF vds STABLE AS $PROCEDURE$
+RETURNS SETOF vds STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -1252,14 +1252,14 @@ BEGIN
     FROM vds
     WHERE recoverable
         AND status = 10;--non operational
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetStoragePoolsByClusterService (
     v_supports_virt_service BOOLEAN,
     v_supports_gluster_service BOOLEAN
     )
-RETURNS SETOF storage_pool STABLE AS $PROCEDURE$
+RETURNS SETOF storage_pool STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -1280,11 +1280,11 @@ BEGIN
                     )
                 AND vg.storage_pool_id = sp.id
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetStorageServerConnectionsForDomain (v_storage_domain_id UUID)
-RETURNS SETOF storage_server_connections STABLE AS $PROCEDURE$
+RETURNS SETOF storage_server_connections STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -1314,44 +1314,44 @@ BEGIN
             WHERE storage_domain_static.id = v_storage_domain_id
                 AND storage_domain_static.storage_type = 3 -- storage type = iscsi
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetDcIdByExternalNetworkId (v_external_id TEXT)
-RETURNS SETOF UUID STABLE AS $PROCEDURE$
+RETURNS SETOF UUID STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT storage_pool_id
     FROM network
     WHERE provider_network_external_id = v_external_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- This SP returns the number of images in the specified storage domain
 CREATE OR REPLACE FUNCTION GetNumberOfImagesInStorageDomain (v_storage_domain_id UUID)
-RETURNS SETOF BIGINT STABLE AS $PROCEDURE$
+RETURNS SETOF BIGINT STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT COUNT(*)
     FROM image_storage_domain_map
     WHERE storage_domain_id = v_storage_domain_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetHostedEngineStorageDomainIds()
-RETURNS SETOF UUID STABLE AS $PROCEDURE$
+RETURNS SETOF UUID STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT id
     FROM hosted_engine_storage_domains_ids_view;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetStorageDomainByGlusterVolumeId (v_gluster_vol_id UUID)
-RETURNS SETOF storage_domains STABLE AS $PROCEDURE$
+RETURNS SETOF storage_domains STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -1362,7 +1362,7 @@ BEGIN
             FROM storage_server_connections
             WHERE gluster_volume_id = v_gluster_vol_id
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- ----------------------------------------------------------------
@@ -1375,7 +1375,7 @@ CREATE OR REPLACE FUNCTION InsertCinderStorage (
     v_driver_options JSONB,
     v_driver_sensitive_options TEXT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO cinder_storage (
         storage_domain_id,
@@ -1387,7 +1387,7 @@ BEGIN
         v_driver_options,
         v_driver_sensitive_options
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateCinderStorage (
@@ -1396,17 +1396,17 @@ CREATE OR REPLACE FUNCTION UpdateCinderStorage (
     v_driver_sensitive_options TEXT
     )
 RETURNS VOID
-    AS $PROCEDURE$
+    AS $FUNCTION$
 BEGIN
     UPDATE cinder_storage
     SET driver_options = v_driver_options,
         driver_sensitive_options = v_driver_sensitive_options
     WHERE storage_domain_id = v_storage_domain_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteCinderStorage (v_storage_domain_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 DECLARE v_val UUID;
 
 BEGIN
@@ -1421,30 +1421,30 @@ BEGIN
     DELETE
     FROM cinder_storage
     WHERE id = v_storage_domain_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetCinderStorage (v_storage_domain_id UUID)
-RETURNS SETOF cinder_storage STABLE AS $PROCEDURE$
+RETURNS SETOF cinder_storage STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM cinder_storage
     WHERE storage_domain_id = v_storage_domain_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetCinderStorageByDrivers (
     v_driver_options JSONB)
-RETURNS SETOF cinder_storage STABLE AS $PROCEDURE$
+RETURNS SETOF cinder_storage STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM cinder_storage
     WHERE driver_options = v_driver_options;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- ----------------------------------------------------------------
@@ -1454,7 +1454,7 @@ CREATE OR REPLACE FUNCTION InsertExternalLease (
     v_storage_domain_id UUID,
     v_lease_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO external_leases (
         storage_domain_id,
@@ -1464,7 +1464,7 @@ BEGIN
         v_storage_domain_id,
         v_lease_id
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateExternalLease (
@@ -1472,16 +1472,16 @@ CREATE OR REPLACE FUNCTION UpdateExternalLease (
     v_storage_domain_id UUID
     )
 RETURNS VOID
-    AS $PROCEDURE$
+    AS $FUNCTION$
 BEGIN
     UPDATE external_leases
     SET storage_domain_id = v_storage_domain_id
     WHERE lease_id = v_lease_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteExternalLease (v_lease_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 DECLARE v_val UUID;
 
 BEGIN
@@ -1494,16 +1494,16 @@ BEGIN
     DELETE
     FROM external_leases
     WHERE lease_id = v_lease_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetExternalLease (v_lease_id UUID)
-RETURNS SETOF external_leases STABLE AS $PROCEDURE$
+RETURNS SETOF external_leases STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM external_leases
     WHERE lease_id = v_lease_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;

--- a/packaging/dbscripts/system_statistics_sp.sql
+++ b/packaging/dbscripts/system_statistics_sp.sql
@@ -7,7 +7,7 @@ CREATE OR REPLACE FUNCTION Getsystem_statistics (
     v_entity VARCHAR(10), -- /*VM,HOST,USER,SD*/
     v_status VARCHAR(20)
     ) -- comma-separated list of status values
-RETURNS Getsystem_statistics_rs STABLE AS $PROCEDURE$
+RETURNS Getsystem_statistics_rs STABLE AS $FUNCTION$
 DECLARE v_i Getsystem_statistics_rs;
 
 v_sql VARCHAR(4000);
@@ -45,7 +45,7 @@ BEGIN
     EXECUTE v_sql
     INTO v_i;
 
-RETURN v_i;END;$PROCEDURE$
+RETURN v_i;END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/tags_sp.sql
+++ b/packaging/dbscripts/tags_sp.sql
@@ -11,7 +11,7 @@ CREATE OR REPLACE FUNCTION Inserttags (
     v_readonly BOOLEAN,
     v_type INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO tags (
         tag_id,
@@ -29,7 +29,7 @@ BEGIN
         v_readonly,
         v_type
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Updatetags (
@@ -42,7 +42,7 @@ CREATE OR REPLACE FUNCTION Updatetags (
     )
 RETURNS VOID
     --The [tags] table doesn't have a timestamp column. Optimistic concurrency logic cannot be generated
-    AS $PROCEDURE$
+    AS $FUNCTION$
 BEGIN
     UPDATE tags
     SET description = v_description,
@@ -52,11 +52,11 @@ BEGIN
         type = v_type,
         _update_date = LOCALTIMESTAMP
     WHERE tag_id = v_tag_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Deletetags (v_tag_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 DECLARE v_val UUID;
 
 BEGIN
@@ -93,50 +93,50 @@ BEGIN
     DELETE
     FROM tags
     WHERE tag_id = v_tag_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromtags ()
-RETURNS SETOF tags STABLE AS $PROCEDURE$
+RETURNS SETOF tags STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT tags.*
     FROM tags;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GettagsBytag_id (v_tag_id UUID)
-RETURNS SETOF tags STABLE AS $PROCEDURE$
+RETURNS SETOF tags STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT tags.*
     FROM tags
     WHERE tag_id = v_tag_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GettagsByparent_id (v_parent_id UUID)
-RETURNS SETOF tags STABLE AS $PROCEDURE$
+RETURNS SETOF tags STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT tags.*
     FROM tags
     WHERE parent_id = v_parent_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GettagsBytag_name (v_tag_name VARCHAR(50))
-RETURNS SETOF tags STABLE AS $PROCEDURE$
+RETURNS SETOF tags STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT tags.*
     FROM tags
     WHERE tag_name = v_tag_name;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ----------------------------------------------------------------
@@ -146,7 +146,7 @@ CREATE OR REPLACE FUNCTION Inserttags_user_group_map (
     v_group_id UUID,
     v_tag_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO tags_user_group_map (
         group_id,
@@ -156,37 +156,37 @@ BEGIN
         v_group_id,
         v_tag_id
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Deletetags_user_group_map (
     v_group_id UUID,
     v_tag_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM tags_user_group_map
     WHERE group_id = v_group_id
         AND tag_id = v_tag_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromtags_user_group_map ()
-RETURNS SETOF tags_user_group_map STABLE AS $PROCEDURE$
+RETURNS SETOF tags_user_group_map STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT tags_user_group_map.*
     FROM tags_user_group_map;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetTagUserGroupByGroupIdAndByTagId (
     v_group_id UUID,
     v_tag_id UUID
     )
-RETURNS SETOF tags_user_group_map STABLE AS $PROCEDURE$
+RETURNS SETOF tags_user_group_map STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -194,11 +194,11 @@ BEGIN
     FROM tags_user_group_map
     WHERE group_id = v_group_id
         AND tag_id = v_tag_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetTagsByUserGroupId (v_group_ids VARCHAR(4000))
-RETURNS SETOF tags_user_group_map_view STABLE AS $PROCEDURE$
+RETURNS SETOF tags_user_group_map_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -208,7 +208,7 @@ BEGIN
             SELECT *
             FROM fnSplitterUuid(v_group_ids)
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ----------------------------------------------------------------
@@ -218,7 +218,7 @@ CREATE OR REPLACE FUNCTION Inserttags_user_map (
     v_tag_id UUID,
     v_user_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO tags_user_map (
         tag_id,
@@ -228,37 +228,37 @@ BEGIN
         v_tag_id,
         v_user_id
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Deletetags_user_map (
     v_tag_id UUID,
     v_user_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM tags_user_map
     WHERE tag_id = v_tag_id
         AND user_id = v_user_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromtags_user_map ()
-RETURNS SETOF tags_user_map STABLE AS $PROCEDURE$
+RETURNS SETOF tags_user_map STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT tags_user_map.*
     FROM tags_user_map;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetTagUserByTagIdAndByuserId (
     v_tag_id UUID,
     v_user_id UUID
     )
-RETURNS SETOF tags_user_map STABLE AS $PROCEDURE$
+RETURNS SETOF tags_user_map STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -266,11 +266,11 @@ BEGIN
     FROM tags_user_map
     WHERE tag_id = v_tag_id
         AND user_id = v_user_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetTagsByUserId (v_user_ids VARCHAR(4000))
-RETURNS SETOF tags_user_map_view STABLE AS $PROCEDURE$
+RETURNS SETOF tags_user_map_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -280,11 +280,11 @@ BEGIN
             SELECT *
             FROM fnSplitterUuid(v_user_ids)
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetUserTagsByTagIds (v_tag_ids VARCHAR(4000))
-RETURNS SETOF tags_user_map_view STABLE AS $PROCEDURE$
+RETURNS SETOF tags_user_map_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -294,7 +294,7 @@ BEGIN
             SELECT *
             FROM fnSplitterUuid(v_tag_ids)
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ----------------------------------------------------------------
@@ -304,7 +304,7 @@ CREATE OR REPLACE FUNCTION Inserttags_vds_map (
     v_tag_id UUID,
     v_vds_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO tags_vds_map (
         tag_id,
@@ -314,48 +314,48 @@ BEGIN
         v_tag_id,
         v_vds_id
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Deletetags_vds_map (
     v_tag_id UUID,
     v_vds_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM tags_vds_map
     WHERE tag_id = v_tag_id
         AND vds_id = v_vds_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteAllTagsVdsMapForHost (
     v_vds_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM tags_vds_map
     WHERE vds_id = v_vds_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromtags_vds_map ()
-RETURNS SETOF tags_vds_map STABLE AS $PROCEDURE$
+RETURNS SETOF tags_vds_map STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT tags_vds_map.*
     FROM tags_vds_map;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetTagVdsBytagIdAndByVdsId (
     v_tag_id UUID,
     v_vds_id UUID
     )
-RETURNS SETOF tags_vds_map STABLE AS $PROCEDURE$
+RETURNS SETOF tags_vds_map STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -363,11 +363,11 @@ BEGIN
     FROM tags_vds_map
     WHERE tag_id = v_tag_id
         AND vds_id = v_vds_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetTagsByVdsId (v_vds_ids VARCHAR(4000))
-RETURNS SETOF tags_vds_map_view STABLE AS $PROCEDURE$
+RETURNS SETOF tags_vds_map_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -377,7 +377,7 @@ BEGIN
             SELECT *
             FROM fnSplitterUuid(v_vds_ids)
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ----------------------------------------------------------------
@@ -388,7 +388,7 @@ CREATE OR REPLACE FUNCTION Inserttags_vm_map (
     v_vm_id UUID,
     v_DefaultDisplayType INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO tags_vm_map (
         tag_id,
@@ -400,37 +400,37 @@ BEGIN
         v_vm_id,
         v_DefaultDisplayType
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Deletetags_vm_map (
     v_tag_id UUID,
     v_vm_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM tags_vm_map
     WHERE tag_id = v_tag_id
         AND vm_id = v_vm_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromtags_vm_map ()
-RETURNS SETOF tags_vm_map STABLE AS $PROCEDURE$
+RETURNS SETOF tags_vm_map STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT tags_vm_map.*
     FROM tags_vm_map;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetTagVmByTagIdAndByvmId (
     v_tag_id UUID,
     v_vm_id UUID
     )
-RETURNS SETOF tags_vm_map STABLE AS $PROCEDURE$
+RETURNS SETOF tags_vm_map STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -438,11 +438,11 @@ BEGIN
     FROM tags_vm_map
     WHERE tag_id = v_tag_id
         AND vm_id = v_vm_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetTagsByVmId (v_vm_ids VARCHAR(4000))
-RETURNS SETOF tags_vm_map_view STABLE AS $PROCEDURE$
+RETURNS SETOF tags_vm_map_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -452,11 +452,11 @@ BEGIN
             SELECT *
             FROM fnSplitterUuid(v_vm_ids)
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVmTagsByTagId (v_tag_ids VARCHAR(4000))
-RETURNS SETOF tags_vm_map_view STABLE AS $PROCEDURE$
+RETURNS SETOF tags_vm_map_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -466,7 +466,7 @@ BEGIN
             SELECT *
             FROM fnSplitterUuid(v_tag_ids)
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateVmTagsDefaultDisplayType (
@@ -474,28 +474,28 @@ CREATE OR REPLACE FUNCTION UpdateVmTagsDefaultDisplayType (
     v_vm_id UUID,
     v_DefaultDisplayType INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE tags_vm_map
     SET DefaultDisplayType = v_DefaultDisplayType
     WHERE tags_vm_map.tag_id = v_tag_id
         AND tags_vm_map.vm_id = v_vm_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetnVmTagsByVmId (v_vm_id UUID)
-RETURNS SETOF tags_vm_map STABLE AS $PROCEDURE$
+RETURNS SETOF tags_vm_map STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM tags_vm_map
     WHERE tags_vm_map.vm_id = v_vm_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetnVmTagsByVmIdAndDefaultTag (v_vm_id UUID)
-RETURNS SETOF tags_vm_map STABLE AS $PROCEDURE$
+RETURNS SETOF tags_vm_map STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -505,16 +505,16 @@ BEGIN
         ON tags.tag_id = tags_vm_map.tag_id
     WHERE tags_vm_map.vm_id = v_vm_id
         AND tags.type = 1;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION RemoveAllVmTagsByVmId (v_vm_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM tags_vm_map
     WHERE vm_id = v_vm_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/tags_vm_pool_map_sp.sql
+++ b/packaging/dbscripts/tags_vm_pool_map_sp.sql
@@ -7,7 +7,7 @@ CREATE OR REPLACE FUNCTION Inserttags_vm_pool_map (
     v_tag_id UUID,
     v_vm_pool_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO tags_vm_pool_map (
         tag_id,
@@ -17,7 +17,7 @@ BEGIN
         v_tag_id,
         v_vm_pool_id
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Updatetags_vm_pool_map (
@@ -26,39 +26,39 @@ CREATE OR REPLACE FUNCTION Updatetags_vm_pool_map (
     )
 RETURNS VOID
     --The [tags_vm_pool_map] table doesn't have a timestamp column. Optimistic concurrency logic cannot be generated
-    AS $PROCEDURE$
+    AS $FUNCTION$
 BEGIN
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Deletetags_vm_pool_map (
     v_tag_id UUID,
     v_vm_pool_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM tags_vm_pool_map
     WHERE tag_id = v_tag_id
         AND vm_pool_id = v_vm_pool_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromtags_vm_pool_map ()
-RETURNS SETOF tags_vm_pool_map STABLE AS $PROCEDURE$
+RETURNS SETOF tags_vm_pool_map STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT tags_vm_pool_map.*
     FROM tags_vm_pool_map;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Gettags_vm_pool_mapBytag_idAndByvm_pool_id (
     v_tag_id UUID,
     v_vm_pool_id UUID
     )
-RETURNS SETOF tags_vm_pool_map STABLE AS $PROCEDURE$
+RETURNS SETOF tags_vm_pool_map STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -66,13 +66,13 @@ BEGIN
     FROM tags_vm_pool_map
     WHERE tag_id = v_tag_id
         AND vm_pool_id = v_vm_pool_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
---The GetByFK stored procedure cannot be created because the [tags_vm_pool_map] table doesn't have at least one foreign key column or the foreign keys are also primary keys.
+--The GetByFK stored FUNCTION cannot be created because the [tags_vm_pool_map] table doesn't have at least one foreign key column or the foreign keys are also primary keys.
 ----custom
 CREATE OR REPLACE FUNCTION GetTagsByVmpoolId (v_vm_pool_ids VARCHAR(4000))
-RETURNS SETOF tags_vm_pool_map_view STABLE AS $PROCEDURE$
+RETURNS SETOF tags_vm_pool_map_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -82,7 +82,7 @@ BEGIN
             SELECT *
             FROM fnSplitterUuid(v_vm_pool_ids)
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/unregistered_OVF_data_sp.sql
+++ b/packaging/dbscripts/unregistered_OVF_data_sp.sql
@@ -13,7 +13,7 @@ CREATE OR REPLACE FUNCTION InsertOVFDataForEntities (
     v_ovf_extra_data TEXT,
     v_status INTEGER
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO unregistered_ovf_of_entities (
         entity_guid,
@@ -44,14 +44,14 @@ BEGIN
     WHERE vog.vm_guid = u.entity_guid
         AND u.entity_guid = v_entity_guid
         AND v_ovf_data IS NULL;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION RemoveEntityFromUnregistered (
     v_entity_guid UUID,
     v_storage_domain_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM unregistered_ovf_of_entities
@@ -60,14 +60,14 @@ BEGIN
             storage_domain_id = v_storage_domain_id
             OR v_storage_domain_id IS NULL
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllOVFEntitiesForStorageDomainByEntityType (
     v_storage_domain_id UUID,
     v_entity_type VARCHAR(20)
     )
-RETURNS SETOF unregistered_ovf_of_entities STABLE AS $PROCEDURE$
+RETURNS SETOF unregistered_ovf_of_entities STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -78,14 +78,14 @@ BEGIN
             entity_type = v_entity_type
             OR v_entity_type IS NULL
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetOVFDataByEntityIdAndStorageDomain (
     v_entity_guid UUID,
     v_storage_domain_id UUID
     )
-RETURNS SETOF unregistered_ovf_of_entities STABLE AS $PROCEDURE$
+RETURNS SETOF unregistered_ovf_of_entities STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -96,7 +96,7 @@ BEGIN
             storage_domain_id = v_storage_domain_id
             OR v_storage_domain_id IS NULL
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/unregistered_disks_sp.sql
+++ b/packaging/dbscripts/unregistered_disks_sp.sql
@@ -14,7 +14,7 @@ CREATE OR REPLACE FUNCTION InsertUnregisteredDisk (
     v_size bigint
     )
 RETURNS VOID
-AS $PROCEDURE$
+AS $FUNCTION$
 BEGIN
     INSERT INTO unregistered_disks (
         disk_id,
@@ -42,7 +42,7 @@ BEGIN
         v_actual_size,
         v_size
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION InsertUnregisteredDisksToVms (
@@ -52,7 +52,7 @@ CREATE OR REPLACE FUNCTION InsertUnregisteredDisksToVms (
     v_storage_domain_id UUID
     )
 RETURNS VOID
-AS $PROCEDURE$
+AS $FUNCTION$
 BEGIN
     INSERT INTO unregistered_disks_to_vms (
         disk_id,
@@ -66,7 +66,7 @@ BEGIN
         v_entity_name,
         v_storage_domain_id
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -75,7 +75,7 @@ CREATE OR REPLACE FUNCTION RemoveDiskFromUnregistered (
     v_storage_domain_id UUID
     )
 RETURNS VOID
-AS $PROCEDURE$
+AS $FUNCTION$
 BEGIN
     DELETE
     FROM unregistered_disks
@@ -85,7 +85,7 @@ BEGIN
             storage_domain_id = v_storage_domain_id
             OR v_storage_domain_id IS NULL
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION RemoveDiskFromUnregisteredRelatedToVM (
@@ -93,7 +93,7 @@ CREATE OR REPLACE FUNCTION RemoveDiskFromUnregisteredRelatedToVM (
     v_storage_domain_id UUID
     )
 RETURNS VOID
-AS $PROCEDURE$
+AS $FUNCTION$
 BEGIN
     DELETE
     FROM unregistered_disks
@@ -104,7 +104,7 @@ BEGIN
             storage_domain_id = v_storage_domain_id
             OR v_storage_domain_id IS NULL
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -113,7 +113,7 @@ CREATE OR REPLACE FUNCTION GetDiskByDiskIdAndStorageDomainId (
     v_storage_domain_id UUID
     )
 RETURNS SETOF unregistered_disks STABLE
-AS $PROCEDURE$
+AS $FUNCTION$
 BEGIN
     RETURN QUERY
     SELECT *
@@ -124,19 +124,19 @@ BEGIN
             storage_domain_id = v_storage_domain_id
             OR v_storage_domain_id IS NULL
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 
 CREATE OR REPLACE FUNCTION GetEntitiesByDiskId (
     v_disk_id UUID)
 RETURNS SETOF unregistered_disks_to_vms STABLE
-AS $PROCEDURE$
+AS $FUNCTION$
 BEGIN
     RETURN QUERY
     SELECT *
     FROM unregistered_disks_to_vms
     WHERE disk_id = v_disk_id
        OR v_disk_id IS NULL;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;

--- a/packaging/dbscripts/user_profiles_sp.sql
+++ b/packaging/dbscripts/user_profiles_sp.sql
@@ -10,7 +10,7 @@ CREATE OR REPLACE FUNCTION InsertUserProfileProperty (
     v_property_type TEXT,
     v_property_content TEXT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO user_profiles (
         user_id,
@@ -26,7 +26,7 @@ BEGIN
         v_property_type,
         v_property_content::jsonb
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateUserProfileProperty (
@@ -37,7 +37,7 @@ CREATE OR REPLACE FUNCTION UpdateUserProfileProperty (
     v_property_content TEXT,
     v_new_property_id UUID
     )
-RETURNS SETOF user_profiles AS $PROCEDURE$
+RETURNS SETOF user_profiles AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -53,59 +53,59 @@ BEGIN
         property_name = v_property_name AND
         property_type = v_property_type
     RETURNING *;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteUserProfileProperty (v_property_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM user_profiles
     WHERE property_id = v_property_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllPublicSshKeysFromUserProfiles ()
-RETURNS SETOF user_profiles_view STABLE AS $PROCEDURE$
+RETURNS SETOF user_profiles_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT user_profiles_view.*
     FROM user_profiles_view
     WHERE user_profiles_view.property_type = 'SSH_PUBLIC_KEY';
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetUserProfileByUserId (v_user_id UUID)
-RETURNS SETOF user_profiles STABLE AS $PROCEDURE$
+RETURNS SETOF user_profiles STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM user_profiles
     WHERE user_id = v_user_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetUserProfileProperty (v_property_id UUID)
-RETURNS SETOF user_profiles STABLE AS $PROCEDURE$
+RETURNS SETOF user_profiles STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM user_profiles
     WHERE property_id = v_property_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetUserProfilePropertyByName (v_user_id UUID, v_property_name TEXT)
-RETURNS SETOF user_profiles STABLE AS $PROCEDURE$
+RETURNS SETOF user_profiles STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM user_profiles
     WHERE user_id = v_user_id AND property_name = v_property_name;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 

--- a/packaging/dbscripts/user_sp.sql
+++ b/packaging/dbscripts/user_sp.sql
@@ -16,7 +16,7 @@ CREATE OR REPLACE FUNCTION InsertUser (
     v_external_id TEXT,
     v_namespace VARCHAR(2048)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO users (
         department,
@@ -42,7 +42,7 @@ BEGIN
         v_external_id,
         v_namespace
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateUserImpl (
@@ -59,7 +59,7 @@ CREATE OR REPLACE FUNCTION UpdateUserImpl (
     )
 RETURNS INT
     --The [users] table doesn't have a timestamp column. Optimistic concurrency logic cannot be generated
-    AS $PROCEDURE$
+    AS $FUNCTION$
 DECLARE updated_rows INT;
 
 BEGIN
@@ -80,7 +80,7 @@ BEGIN
     GET DIAGNOSTICS updated_rows = ROW_COUNT;
 
     RETURN updated_rows;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateUser (
@@ -98,7 +98,7 @@ CREATE OR REPLACE FUNCTION UpdateUser (
     )
 RETURNS VOID
     --The [users] table doesn't have a timestamp column. Optimistic concurrency logic cannot be generated
-    AS $PROCEDURE$
+    AS $FUNCTION$
 BEGIN
     PERFORM UpdateUserImpl(
         v_department,
@@ -116,7 +116,7 @@ BEGIN
     SET last_admin_check_status = v_last_admin_check_status
     WHERE domain = v_domain
         AND external_id = v_external_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION InsertOrUpdateUser (
@@ -131,7 +131,7 @@ CREATE OR REPLACE FUNCTION InsertOrUpdateUser (
     v_external_id TEXT,
     v_namespace VARCHAR(2048)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 DECLARE updated_rows INT;
 
 BEGIN
@@ -161,12 +161,12 @@ BEGIN
             v_external_id,
             v_namespace);
     END IF;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
     CREATE
         OR REPLACE FUNCTION DeleteUser (v_user_id UUID)
-    RETURNS VOID AS $PROCEDURE$
+    RETURNS VOID AS $FUNCTION$
 
     DECLARE v_val UUID;
 
@@ -188,7 +188,7 @@ LANGUAGE plpgsql;
         DELETE
         FROM users
         WHERE user_id = v_user_id;
-    END;$PROCEDURE$
+    END;$FUNCTION$
 
     LANGUAGE plpgsql;
 
@@ -197,7 +197,7 @@ LANGUAGE plpgsql;
         v_user_id UUID,
         v_is_filtered BOOLEAN
         )
-    RETURNS SETOF users STABLE AS $PROCEDURE$
+    RETURNS SETOF users STABLE AS $FUNCTION$
 
     BEGIN
         RETURN QUERY
@@ -214,7 +214,7 @@ LANGUAGE plpgsql;
                         AND u.user_id = p.ad_element_id
                     )
                 );
-    END;$PROCEDURE$
+    END;$FUNCTION$
 
     LANGUAGE plpgsql;
 
@@ -223,7 +223,7 @@ LANGUAGE plpgsql;
         v_user_id UUID,
         v_is_filtered BOOLEAN
         )
-    RETURNS SETOF users STABLE AS $PROCEDURE$
+    RETURNS SETOF users STABLE AS $FUNCTION$
 
     BEGIN
         RETURN QUERY
@@ -241,7 +241,7 @@ LANGUAGE plpgsql;
                         AND u.user_id = p.ad_element_id
                     )
                 );
-    END;$PROCEDURE$
+    END;$FUNCTION$
 
     LANGUAGE plpgsql;
 
@@ -250,7 +250,7 @@ LANGUAGE plpgsql;
         v_domain VARCHAR(255),
         v_external_id TEXT
         )
-    RETURNS SETOF users STABLE AS $PROCEDURE$
+    RETURNS SETOF users STABLE AS $FUNCTION$
 
     BEGIN
         RETURN QUERY
@@ -259,7 +259,7 @@ LANGUAGE plpgsql;
         FROM users
         WHERE domain = v_domain
             AND external_id = v_external_id;
-    END;$PROCEDURE$
+    END;$FUNCTION$
 
     LANGUAGE plpgsql;
 
@@ -268,7 +268,7 @@ LANGUAGE plpgsql;
         v_username VARCHAR(255),
         v_domain VARCHAR(255)
         )
-    RETURNS SETOF users STABLE AS $PROCEDURE$
+    RETURNS SETOF users STABLE AS $FUNCTION$
 
     BEGIN
         RETURN QUERY
@@ -277,13 +277,13 @@ LANGUAGE plpgsql;
         FROM users
         WHERE username = v_username
             AND domain = v_domain;
-    END;$PROCEDURE$
+    END;$FUNCTION$
 
     LANGUAGE plpgsql;
 
     CREATE
         OR REPLACE FUNCTION GetUsersByVmGuid (v_vm_guid UUID)
-    RETURNS SETOF users STABLE AS $PROCEDURE$
+    RETURNS SETOF users STABLE AS $FUNCTION$
 
     BEGIN
         RETURN QUERY
@@ -294,12 +294,12 @@ LANGUAGE plpgsql;
             ON users.user_id = permissions.ad_element_id
         WHERE permissions.object_type_id = 2
             AND permissions.object_id = v_vm_guid;
-    END;$PROCEDURE$
+    END;$FUNCTION$
 
     LANGUAGE plpgsql;
 
     CREATE OR REPLACE FUNCTION GetUsersByTemplateGuid (v_template_guid UUID)
-    RETURNS SETOF users STABLE AS $PROCEDURE$
+    RETURNS SETOF users STABLE AS $FUNCTION$
 
     BEGIN
         RETURN QUERY
@@ -310,13 +310,13 @@ LANGUAGE plpgsql;
                 ON users.user_id = permissions.ad_element_id
         WHERE permissions.object_type_id = 4
             AND permissions.object_id = v_template_guid;
-    END;$PROCEDURE$
+    END;$FUNCTION$
 
     LANGUAGE plpgsql;
 
     CREATE
         OR REPLACE FUNCTION UpdateLastAdminCheckStatus (v_userIds VARCHAR(4000))
-    RETURNS VOID AS $PROCEDURE$
+    RETURNS VOID AS $FUNCTION$
 
     DECLARE v_id UUID;
 
@@ -384,14 +384,14 @@ LANGUAGE plpgsql;
 
 
     CLOSE myCursor;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetSessionUserAndGroupsById (
     v_id UUID,
     v_engine_session_seq_id INT
     )
-RETURNS SETOF idUuidType STABLE AS $PROCEDURE$
+RETURNS SETOF idUuidType STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -412,11 +412,11 @@ BEGIN
 
     -- user is also member of 'Everyone'
     SELECT 'EEE00000-0000-0000-0000-123456789EEE';
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetUsersByTemplateGuid (v_template_guid UUID)
-RETURNS SETOF users STABLE AS $PROCEDURE$
+RETURNS SETOF users STABLE AS $FUNCTION$
 
 BEGIN
     RETURN QUERY
@@ -427,6 +427,6 @@ BEGIN
             ON users.user_id = permissions.ad_element_id
     WHERE permissions.object_type_id = 4
         AND permissions.object_id = v_template_guid;
-END;$PROCEDURE$
+END;$FUNCTION$
 
 LANGUAGE plpgsql;

--- a/packaging/dbscripts/vdc_option_sp.sql
+++ b/packaging/dbscripts/vdc_option_sp.sql
@@ -10,7 +10,7 @@ CREATE OR REPLACE FUNCTION InsertVdcOption (
     v_default_value TEXT,
     v_version VARCHAR(40),
     INOUT v_option_id INT
-    ) AS $PROCEDURE$
+    ) AS $FUNCTION$
 BEGIN
     INSERT INTO vdc_options (
         option_name,
@@ -26,7 +26,7 @@ BEGIN
         );
 
     v_option_id := CURRVAL('vdc_options_seq');
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateVdcOption (
@@ -37,51 +37,51 @@ CREATE OR REPLACE FUNCTION UpdateVdcOption (
     )
 RETURNS VOID
     --The [vdc_options] table doesn't have a timestamp column. Optimistic concurrency logic cannot be generated
-    AS $PROCEDURE$
+    AS $FUNCTION$
 BEGIN
     UPDATE vdc_options
     SET option_name = v_option_name,
         option_value = v_option_value,
         version = v_version
     WHERE option_id = v_option_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteVdcOption (v_option_id INT)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM vdc_options
     WHERE option_id = v_option_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromVdcOption ()
-RETURNS SETOF vdc_options STABLE AS $PROCEDURE$
+RETURNS SETOF vdc_options STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT vdc_options.*
     FROM vdc_options;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVdcOptionById (v_option_id INT)
-RETURNS SETOF vdc_options STABLE AS $PROCEDURE$
+RETURNS SETOF vdc_options STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT vdc_options.*
     FROM vdc_options
     WHERE option_id = v_option_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVdcOptionByName (
     v_option_name VARCHAR(50),
     v_version VARCHAR(40)
     )
-RETURNS SETOF vdc_options STABLE AS $PROCEDURE$
+RETURNS SETOF vdc_options STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -89,7 +89,7 @@ BEGIN
     FROM vdc_options
     WHERE OPTION_name = v_option_name
         AND version = v_version;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/vds_kdump_status_sp.sql
+++ b/packaging/dbscripts/vds_kdump_status_sp.sql
@@ -9,7 +9,7 @@ CREATE OR REPLACE FUNCTION UpsertKdumpStatus (
     v_status VARCHAR(20),
     v_address VARCHAR(255)
     )
-RETURNS INT AS $PROCEDURE$
+RETURNS INT AS $FUNCTION$
 BEGIN
     UPDATE vds_kdump_status
     SET status = v_status,
@@ -30,7 +30,7 @@ BEGIN
     END IF;
 
     RETURN 1;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpsertKdumpStatusForIp (
@@ -38,7 +38,7 @@ CREATE OR REPLACE FUNCTION UpsertKdumpStatusForIp (
     v_status VARCHAR(20),
     v_address VARCHAR(255)
     )
-RETURNS INT AS $PROCEDURE$
+RETURNS INT AS $FUNCTION$
 DECLARE v_vds_id UUID;
 
 updated_rows INT;
@@ -57,40 +57,40 @@ BEGIN
     END IF;
 
     RETURN updated_rows;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION RemoveFinishedKdumpStatusForVds (v_vds_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM vds_kdump_status
     WHERE vds_id = v_vds_id
         AND status = 'finished';
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetKdumpStatusForVds (v_vds_id UUID)
-RETURNS SETOF vds_kdump_status STABLE AS $PROCEDURE$
+RETURNS SETOF vds_kdump_status STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM vds_kdump_status
     WHERE vds_id = v_vds_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- GetAllUnfinishedKdumpStatus is used in fence_kdump listener
 CREATE OR REPLACE FUNCTION GetAllUnfinishedVdsKdumpStatus ()
-RETURNS SETOF vds_kdump_status STABLE AS $PROCEDURE$
+RETURNS SETOF vds_kdump_status STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM vds_kdump_status
     WHERE status <> 'finished';
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/vds_sp.sql
+++ b/packaging/dbscripts/vds_sp.sql
@@ -30,7 +30,7 @@ CREATE OR REPLACE FUNCTION InsertVdsStatistics (
     v_cpu_over_commit_time_stamp TIMESTAMP WITH TIME ZONE,
     v_hugepages TEXT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     BEGIN
         INSERT INTO vds_statistics (
@@ -88,7 +88,7 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateVdsStatistics (
@@ -119,7 +119,7 @@ CREATE OR REPLACE FUNCTION UpdateVdsStatistics (
     )
 RETURNS VOID
     --The [vds_dynamic] table doesn't have a timestamp column. Optimistic concurrency logic cannot be generated
-    AS $PROCEDURE$
+    AS $FUNCTION$
 BEGIN
     BEGIN
         UPDATE vds_statistics
@@ -151,11 +151,11 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteVdsStatistics (v_vds_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     BEGIN
         DELETE
@@ -164,11 +164,11 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromVdsStatistics ()
-RETURNS SETOF vds_statistics STABLE AS $PROCEDURE$
+RETURNS SETOF vds_statistics STABLE AS $FUNCTION$
 BEGIN
     BEGIN
         RETURN QUERY
@@ -178,11 +178,11 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVdsStatisticsByVdsId (v_vds_id UUID)
-RETURNS SETOF vds_statistics STABLE AS $PROCEDURE$
+RETURNS SETOF vds_statistics STABLE AS $FUNCTION$
 BEGIN
     BEGIN
         RETURN QUERY
@@ -193,7 +193,7 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ----------------------------------------------------------------
@@ -279,7 +279,7 @@ CREATE OR REPLACE FUNCTION InsertVdsDynamic (
     v_cpu_topology JSONB,
     v_vdsm_cpus_affinity VARCHAR(256)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     BEGIN
         INSERT INTO vds_dynamic (
@@ -445,14 +445,14 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateVdsDynamicPowerManagementPolicyFlag (
     v_vds_id UUID,
     v_controlled_by_pm_policy BOOLEAN
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     BEGIN
         UPDATE vds_dynamic
@@ -461,7 +461,7 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateVdsDynamic (
@@ -549,7 +549,7 @@ CREATE OR REPLACE FUNCTION UpdateVdsDynamic (
     )
 RETURNS VOID
     --The [vds_dynamic] table doesn't have a timestamp column. Optimistic concurrency logic cannot be generated
-    AS $PROCEDURE$
+    AS $FUNCTION$
 BEGIN
     BEGIN
         UPDATE vds_dynamic
@@ -638,11 +638,11 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteVdsDynamic (v_vds_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     BEGIN
         DELETE
@@ -651,11 +651,11 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromVdsDynamic ()
-RETURNS SETOF vds_dynamic STABLE AS $PROCEDURE$
+RETURNS SETOF vds_dynamic STABLE AS $FUNCTION$
 BEGIN
     BEGIN
         RETURN QUERY
@@ -665,11 +665,11 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVdsDynamicByVdsId (v_vds_id UUID)
-RETURNS SETOF vds_dynamic STABLE AS $PROCEDURE$
+RETURNS SETOF vds_dynamic STABLE AS $FUNCTION$
 BEGIN
     BEGIN
         RETURN QUERY
@@ -680,7 +680,7 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ----------------------------------------------------------------
@@ -711,7 +711,7 @@ CREATE OR REPLACE FUNCTION InsertVdsStatic (
     v_last_stored_kernel_cmdline TEXT,
     v_vgpu_placement INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     IF v_vds_unique_id IS NULL
         OR NOT EXISTS (
@@ -774,7 +774,7 @@ BEGIN
 END IF;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateVdsStaticLastStoredKernelCmdline (
@@ -783,7 +783,7 @@ CREATE OR REPLACE FUNCTION UpdateVdsStaticLastStoredKernelCmdline (
     )
 RETURNS VOID
     --The [vds_static] table doesn't have a timestamp column. Optimistic concurrency logic cannot be generated
-    AS $PROCEDURE$
+    AS $FUNCTION$
 BEGIN
     BEGIN
         UPDATE vds_static
@@ -792,7 +792,7 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateVdsStaticKernelCmdlines (
@@ -801,7 +801,7 @@ CREATE OR REPLACE FUNCTION UpdateVdsStaticKernelCmdlines (
     )
 RETURNS VOID
     --The [vds_static] table doesn't have a timestamp column. Optimistic concurrency logic cannot be generated
-    AS $PROCEDURE$
+    AS $FUNCTION$
 BEGIN
     BEGIN
         UPDATE vds_static
@@ -811,7 +811,7 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateVdsReinstallRequired (
@@ -819,7 +819,7 @@ CREATE OR REPLACE FUNCTION UpdateVdsReinstallRequired (
     v_reinstall_required BOOLEAN
     )
 RETURNS VOID
-    AS $PROCEDURE$
+    AS $FUNCTION$
 BEGIN
     BEGIN
         UPDATE vds_static
@@ -828,7 +828,7 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateVdsStatic (
@@ -859,7 +859,7 @@ CREATE OR REPLACE FUNCTION UpdateVdsStatic (
 )
     RETURNS VOID
     --The [vds_static] table doesn't have a timestamp column. Optimistic concurrency logic cannot be generated
-AS $PROCEDURE$
+AS $FUNCTION$
 BEGIN
     BEGIN
         UPDATE vds_static
@@ -891,11 +891,11 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteVdsStatic (v_vds_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     BEGIN
         DELETE
@@ -914,11 +914,11 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromVdsStatic ()
-RETURNS SETOF vds_static STABLE AS $PROCEDURE$
+RETURNS SETOF vds_static STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -926,11 +926,11 @@ BEGIN
     FROM vds_static;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVdsStaticByIp (v_ip VARCHAR(40))
-RETURNS SETOF vds_static STABLE AS $PROCEDURE$
+RETURNS SETOF vds_static STABLE AS $FUNCTION$
 BEGIN
     BEGIN
         RETURN QUERY
@@ -943,11 +943,11 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVdsStaticByHostName (v_host_name VARCHAR(255))
-RETURNS SETOF vds_static STABLE AS $PROCEDURE$
+RETURNS SETOF vds_static STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -956,11 +956,11 @@ BEGIN
     WHERE host_name = v_host_name;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVdsStaticByVdsId (v_vds_id UUID)
-RETURNS SETOF vds_static STABLE AS $PROCEDURE$
+RETURNS SETOF vds_static STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -969,11 +969,11 @@ BEGIN
     WHERE vds_id = v_vds_id;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVdsStaticByVdsIds (v_vds_ids UUID[])
-RETURNS SETOF vds_static STABLE AS $PROCEDURE$
+RETURNS SETOF vds_static STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -982,11 +982,11 @@ BEGIN
     WHERE vds_id = ANY(v_vds_ids);
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVdsStaticByVdsName (v_host_name VARCHAR(255))
-RETURNS SETOF vds_static STABLE AS $PROCEDURE$
+RETURNS SETOF vds_static STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -995,11 +995,11 @@ BEGIN
     WHERE vds_name = v_host_name;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVdsByUniqueID (v_vds_unique_id VARCHAR(128))
-RETURNS SETOF vds STABLE AS $PROCEDURE$
+RETURNS SETOF vds STABLE AS $FUNCTION$
 BEGIN
     BEGIN
         RETURN QUERY
@@ -1010,11 +1010,11 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVdsStaticByClusterId (v_cluster_id UUID)
-RETURNS SETOF vds_static STABLE AS $PROCEDURE$
+RETURNS SETOF vds_static STABLE AS $FUNCTION$
 BEGIN
     BEGIN
         RETURN QUERY
@@ -1025,14 +1025,14 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ---------------------------------------------------------------------------------------------------
 --    [vds] - view
 ---------------------------------------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION GetUpAndPrioritizedVds (v_storage_pool_id UUID)
-RETURNS SETOF vds STABLE AS $PROCEDURE$
+RETURNS SETOF vds STABLE AS $FUNCTION$
 BEGIN
     BEGIN
         RETURN QUERY
@@ -1052,14 +1052,14 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromVds (
     v_user_id UUID,
     v_is_filtered BOOLEAN
     )
-RETURNS SETOF vds STABLE AS $PROCEDURE$
+RETURNS SETOF vds STABLE AS $FUNCTION$
 BEGIN
     BEGIN
         RETURN QUERY
@@ -1078,7 +1078,7 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVdsByVdsId (
@@ -1086,7 +1086,7 @@ CREATE OR REPLACE FUNCTION GetVdsByVdsId (
     v_user_id UUID,
     v_is_filtered BOOLEAN
     )
-RETURNS SETOF vds STABLE AS $PROCEDURE$
+RETURNS SETOF vds STABLE AS $FUNCTION$
 DECLARE v_columns TEXT [];
 
 BEGIN
@@ -1114,11 +1114,11 @@ BEGIN
 
     END;
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVdsWithoutMigratingVmsByClusterId (v_cluster_id UUID)
-RETURNS SETOF vds STABLE AS $PROCEDURE$
+RETURNS SETOF vds STABLE AS $FUNCTION$
 BEGIN
     -- this sp returns all vds in given cluster that have no pending vms and no vms in migration states
     BEGIN
@@ -1142,11 +1142,11 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteVds (v_vds_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     BEGIN
         DELETE
@@ -1172,11 +1172,11 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVdsByType (v_vds_type INT)
-RETURNS SETOF vds STABLE AS $PROCEDURE$
+RETURNS SETOF vds STABLE AS $FUNCTION$
 BEGIN
     BEGIN
         RETURN QUERY
@@ -1187,11 +1187,11 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVdsByName (v_vds_name VARCHAR(255))
-RETURNS SETOF vds STABLE AS $PROCEDURE$
+RETURNS SETOF vds STABLE AS $FUNCTION$
 BEGIN
     BEGIN
         RETURN QUERY
@@ -1202,11 +1202,11 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVdsByNameAndClusterId (v_vds_name VARCHAR(255), v_cluster_id UUID)
-RETURNS SETOF vds STABLE AS $PROCEDURE$
+RETURNS SETOF vds STABLE AS $FUNCTION$
 BEGIN
     BEGIN
         RETURN QUERY
@@ -1218,11 +1218,11 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVdsByHostNameAndClusterId (v_host_name VARCHAR(255), v_cluster_id UUID)
-RETURNS SETOF vds STABLE AS $PROCEDURE$
+RETURNS SETOF vds STABLE AS $FUNCTION$
 BEGIN
     BEGIN
         RETURN QUERY
@@ -1234,11 +1234,11 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVdsByHostName (v_host_name VARCHAR(255))
-RETURNS SETOF vds STABLE AS $PROCEDURE$
+RETURNS SETOF vds STABLE AS $FUNCTION$
 BEGIN
     BEGIN
         RETURN QUERY
@@ -1249,7 +1249,7 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVdsByClusterId (
@@ -1257,7 +1257,7 @@ CREATE OR REPLACE FUNCTION GetVdsByClusterId (
     v_user_id UUID,
     v_is_filtered boolean
     )
-RETURNS SETOF vds STABLE AS $PROCEDURE$
+RETURNS SETOF vds STABLE AS $FUNCTION$
 BEGIN
     -- this sp returns all vds for a given cluster
     BEGIN
@@ -1283,7 +1283,7 @@ BEGIN
 
     END;
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVdsByStoragePoolId (
@@ -1291,7 +1291,7 @@ CREATE OR REPLACE FUNCTION GetVdsByStoragePoolId (
     v_user_id UUID,
     v_is_filtered boolean
     )
-RETURNS SETOF vds STABLE AS $PROCEDURE$
+RETURNS SETOF vds STABLE AS $FUNCTION$
 BEGIN
     BEGIN
         RETURN QUERY
@@ -1311,7 +1311,7 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Returns all VDS for a given cluster and having given status
@@ -1319,7 +1319,7 @@ CREATE OR REPLACE FUNCTION getVdsForClusterWithStatus (
     v_cluster_id UUID,
     v_status INT
     )
-RETURNS SETOF vds STABLE AS $PROCEDURE$
+RETURNS SETOF vds STABLE AS $FUNCTION$
 BEGIN
     BEGIN
         RETURN QUERY
@@ -1332,7 +1332,7 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Returns all gluster VDS for a given cluster and having given status, peer status
@@ -1341,7 +1341,7 @@ CREATE OR REPLACE FUNCTION getVdsForClusterWithPeerStatus (
     v_status INT,
     v_peer_status VARCHAR(50)
     )
-RETURNS SETOF vds STABLE AS $PROCEDURE$
+RETURNS SETOF vds STABLE AS $FUNCTION$
 BEGIN
     BEGIN
         RETURN QUERY
@@ -1357,7 +1357,7 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Returns all VDS for a given pool with one of the given statuses or in any status in case v_statuses is NULL.
@@ -1365,7 +1365,7 @@ CREATE OR REPLACE FUNCTION getVdsByStoragePoolIdWithStatuses(
     v_storage_pool_id UUID,
     v_statuses VARCHAR(150))
 RETURNS SETOF vds STABLE
-    AS $procedure$
+    AS $FUNCTION$
 BEGIN
     BEGIN
         RETURN QUERY
@@ -1381,14 +1381,14 @@ BEGIN
             AND cluster.virt_service = true;
     END;
     RETURN;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION getHostsForStorageOperation (
     v_storage_pool_id UUID,
     v_local_fs_only BOOLEAN
     )
-RETURNS SETOF vds STABLE AS $PROCEDURE$
+RETURNS SETOF vds STABLE AS $FUNCTION$
 BEGIN
     BEGIN
         RETURN QUERY
@@ -1416,19 +1416,19 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateVdsDynamicStatus (
     v_vds_guid UUID,
     v_status INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE vds_dynamic
     SET status = v_status
     WHERE vds_id = v_vds_guid;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateVdsDynamicStatusAndReasons (
@@ -1437,54 +1437,54 @@ CREATE OR REPLACE FUNCTION UpdateVdsDynamicStatusAndReasons (
     v_non_operational_reason INT,
     v_maintenance_reason TEXT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE vds_dynamic
     SET status = v_status,
         non_operational_reason = v_non_operational_reason,
         maintenance_reason = v_maintenance_reason
     WHERE vds_id = v_vds_guid;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateHostExternalStatus (
     v_vds_guid UUID,
     v_external_status INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE vds_dynamic
     SET external_status = v_external_status
     WHERE vds_id = v_vds_guid;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateVdsDynamicNetConfigDirty (
     v_vds_guid UUID,
     v_net_config_dirty BOOLEAN
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE vds_dynamic
     SET net_config_dirty = v_net_config_dirty
     WHERE vds_id = v_vds_guid;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateVdsDynamicIsUpdateAvailable (
     v_vds_guid UUID,
     v_is_update_available BOOLEAN
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE vds_dynamic
     SET is_update_available = v_is_update_available
     WHERE vds_id = v_vds_guid;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVdsByNetworkId (v_network_id UUID)
-RETURNS SETOF vds STABLE AS $PROCEDURE$
+RETURNS SETOF vds STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -1501,11 +1501,11 @@ BEGIN
                 AND vds.cluster_id = network_cluster.cluster_id
                 AND vds_interface.vds_id = vds.vds_id
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVdsWithoutNetwork (v_network_id UUID)
-RETURNS SETOF vds STABLE AS $PROCEDURE$
+RETURNS SETOF vds STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -1525,34 +1525,34 @@ BEGIN
                 AND vds.cluster_id = network_cluster.cluster_id
                 AND vds_interface.vds_id = vds.vds_id
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateCpuFlags (
     v_vds_id UUID,
     v_cpu_flags VARCHAR(4000)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE vds_dynamic
     SET cpu_flags = v_cpu_flags
     WHERE vds_id = v_vds_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetIdsOfHostsWithStatus (v_status INT)
-RETURNS SETOF UUID STABLE AS $PROCEDURE$
+RETURNS SETOF UUID STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT vds_id
     FROM vds_dynamic
     WHERE status = v_status;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION getFirstUpRhelForClusterId (v_cluster_id UUID)
-RETURNS SETOF vds STABLE AS $PROCEDURE$
+RETURNS SETOF vds STABLE AS $FUNCTION$
 BEGIN
     BEGIN
         -- both centos and RHEL return RHEL as host_os
@@ -1570,12 +1570,12 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Get host names dedicated to vm
 CREATE OR REPLACE FUNCTION GetNamesOfHostsDedicatedToVm (v_vm_guid UUID)
-RETURNS SETOF VARCHAR STABLE AS $PROCEDURE$
+RETURNS SETOF VARCHAR STABLE AS $FUNCTION$
 BEGIN
     BEGIN
         RETURN QUERY
@@ -1586,7 +1586,7 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION CheckIfExistsHostThatMissesNetworkInCluster(
@@ -1594,7 +1594,7 @@ CREATE OR REPLACE FUNCTION CheckIfExistsHostThatMissesNetworkInCluster(
     v_network_name VARCHAR(50),
     v_host_status  INT
     )
-RETURNS BOOLEAN STABLE AS $PROCEDURE$
+RETURNS BOOLEAN STABLE AS $FUNCTION$
 BEGIN
     RETURN EXISTS (
         SELECT 1
@@ -1607,14 +1607,14 @@ BEGIN
                        WHERE vds_static.vds_id = vds_interface.vds_id
                        AND vds_interface.network_name = v_network_name)
     );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION CheckIfExistsHostWithStatusInCluster(
     v_cluster_id   UUID,
     v_host_status  INT
     )
-RETURNS BOOLEAN STABLE AS $PROCEDURE$
+RETURNS BOOLEAN STABLE AS $FUNCTION$
 BEGIN
     RETURN EXISTS (
         SELECT 1
@@ -1623,5 +1623,5 @@ BEGIN
         WHERE vds_static.cluster_id = v_cluster_id
         AND vds_dynamic.status = v_host_status
     );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;

--- a/packaging/dbscripts/vds_spm_id_map_sp.sql
+++ b/packaging/dbscripts/vds_spm_id_map_sp.sql
@@ -8,7 +8,7 @@ CREATE OR REPLACE FUNCTION Insertvds_spm_id_map (
     v_vds_id UUID,
     v_vds_spm_id INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO vds_spm_id_map (
         storage_pool_id,
@@ -20,46 +20,46 @@ BEGIN
         v_vds_id,
         v_vds_spm_id
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Deletevds_spm_id_map (v_vds_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM vds_spm_id_map
     WHERE vds_id = v_vds_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteByPoolvds_spm_id_map (
     v_vds_id UUID,
     v_storage_pool_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM vds_spm_id_map
     WHERE vds_id = v_vds_id
         AND storage_pool_id = v_storage_pool_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromvds_spm_id_map ()
-RETURNS SETOF vds_spm_id_map STABLE AS $PROCEDURE$
+RETURNS SETOF vds_spm_id_map STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT vds_spm_id_map.*
     FROM vds_spm_id_map;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Getvds_spm_id_mapBystorage_pool_idAndByvds_spm_id (
     v_storage_pool_id UUID,
     v_vds_spm_id INT
     )
-RETURNS SETOF vds_spm_id_map STABLE AS $PROCEDURE$
+RETURNS SETOF vds_spm_id_map STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -67,29 +67,29 @@ BEGIN
     FROM vds_spm_id_map
     WHERE storage_pool_id = v_storage_pool_id
         AND vds_spm_id = v_vds_spm_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Getvds_spm_id_mapBystorage_pool_id (v_storage_pool_id UUID)
-RETURNS SETOF vds_spm_id_map STABLE AS $PROCEDURE$
+RETURNS SETOF vds_spm_id_map STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT vds_spm_id_map.*
     FROM vds_spm_id_map
     WHERE storage_pool_id = v_storage_pool_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION Getvds_spm_id_mapByvds_id (v_vds_id UUID)
-RETURNS SETOF vds_spm_id_map STABLE AS $PROCEDURE$
+RETURNS SETOF vds_spm_id_map STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT vds_spm_id_map.*
     FROM vds_spm_id_map
     WHERE vds_id = v_vds_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/vm_backups_sp.sql
+++ b/packaging/dbscripts/vm_backups_sp.sql
@@ -4,14 +4,14 @@
 --  [vm_backups] Table
 ----------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION GetVmBackupByVmBackupId (v_backup_id UUID)
-RETURNS SETOF vm_backups STABLE AS $PROCEDURE$
+RETURNS SETOF vm_backups STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM vm_backups
     WHERE backup_id = v_backup_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION InsertVmBackup (
@@ -27,7 +27,7 @@ CREATE OR REPLACE FUNCTION InsertVmBackup (
     v_backup_type VARCHAR(50),
     v_snapshot_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO vm_backups (
         backup_id,
@@ -55,7 +55,7 @@ BEGIN
         v_backup_type,
         v_snapshot_id
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateVmBackup (
@@ -70,7 +70,7 @@ CREATE OR REPLACE FUNCTION UpdateVmBackup (
     v_backup_type VARCHAR(50),
     v_snapshot_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE vm_backups
     SET backup_id = v_backup_id,
@@ -84,46 +84,46 @@ BEGIN
         backup_type = v_backup_type,
         snapshot_id = v_snapshot_id
     WHERE backup_id = v_backup_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteVmBackup (v_backup_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM vm_backups
     WHERE backup_id = v_backup_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromVmBackups ()
-RETURNS SETOF vm_backups STABLE AS $PROCEDURE$
+RETURNS SETOF vm_backups STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM vm_backups;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVmBackupsByVmId (v_vm_id UUID)
-RETURNS SETOF vm_backups STABLE AS $PROCEDURE$
+RETURNS SETOF vm_backups STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM vm_backups
     WHERE vm_id = v_vm_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateVmBackupStopped (v_backup_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE vm_backups
     SET is_stopped = true
     WHERE backup_id = v_backup_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -135,7 +135,7 @@ CREATE OR REPLACE FUNCTION InsertVmBackupDiskMap (
     v_disk_id UUID,
     v_disk_snapshot_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     BEGIN
         INSERT INTO vm_backup_disk_map (
@@ -151,7 +151,7 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateVmBackupDiskMap (
@@ -159,18 +159,18 @@ CREATE OR REPLACE FUNCTION UpdateVmBackupDiskMap (
     v_disk_id UUID,
     v_backup_url TEXT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE vm_backup_disk_map
     SET backup_id = v_backup_id,
         disk_id = v_disk_id,
         backup_url = v_backup_url
     WHERE backup_id = v_backup_id AND disk_id = v_disk_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetDisksByVmBackupId (v_backup_id UUID)
-RETURNS SETOF images_storage_domain_view STABLE AS $PROCEDURE$
+RETURNS SETOF images_storage_domain_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -178,7 +178,7 @@ BEGIN
     FROM   images_storage_domain_view
     JOIN   vm_backup_disk_map on vm_backup_disk_map.disk_id = images_storage_domain_view.image_group_id
     WHERE  images_storage_domain_view.active AND vm_backup_disk_map.backup_id = v_backup_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetBackupUrlForDiskId (v_backup_id UUID, v_disk_id UUID)
@@ -209,7 +209,7 @@ CREATE OR REPLACE FUNCTION DeleteCompletedBackupsOlderThanDate (
     v_succeeded_end_time TIMESTAMP WITH TIME ZONE,
     v_failed_end_time TIMESTAMP WITH TIME ZONE
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM vm_backups
@@ -223,5 +223,5 @@ BEGIN
                 AND phase = 'Failed'
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;

--- a/packaging/dbscripts/vm_checkpoints_sp.sql
+++ b/packaging/dbscripts/vm_checkpoints_sp.sql
@@ -4,14 +4,14 @@
 --  VM Checkpoints Table
 ----------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION GetVmCheckpointByVmCheckpointId (v_checkpoint_id UUID)
-RETURNS SETOF vm_checkpoints STABLE AS $PROCEDURE$
+RETURNS SETOF vm_checkpoints STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM vm_checkpoints
     WHERE checkpoint_id = v_checkpoint_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION InsertVmCheckpoint (
@@ -22,7 +22,7 @@ CREATE OR REPLACE FUNCTION InsertVmCheckpoint (
     v_state TEXT,
     v_description VARCHAR(1024)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO vm_checkpoints (
         checkpoint_id,
@@ -40,7 +40,7 @@ BEGIN
         v_state,
         v_description
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateVmCheckpoint (
@@ -50,7 +50,7 @@ CREATE OR REPLACE FUNCTION UpdateVmCheckpoint (
     v_state TEXT,
     v_description VARCHAR(1024)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE vm_checkpoints
     SET checkpoint_id = v_checkpoint_id,
@@ -59,30 +59,30 @@ BEGIN
         state = v_state,
         description = v_description
     WHERE checkpoint_id = v_checkpoint_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteVmCheckpoint (v_checkpoint_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM vm_checkpoints
     WHERE checkpoint_id = v_checkpoint_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromVmCheckpoints ()
-RETURNS SETOF vm_checkpoints STABLE AS $PROCEDURE$
+RETURNS SETOF vm_checkpoints STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM vm_checkpoints;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVmCheckpointsByVmId (v_vm_id UUID)
-RETURNS SETOF vm_checkpoints STABLE AS $PROCEDURE$
+RETURNS SETOF vm_checkpoints STABLE AS $FUNCTION$
 BEGIN
      RETURN QUERY WITH RECURSIVE checkpoint_list AS (
           SELECT *
@@ -97,39 +97,39 @@ BEGIN
       )
       SELECT *
       FROM checkpoint_list;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteAllCheckpointsByVmId (v_vm_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM vm_checkpoints
     WHERE vm_id = v_vm_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVmCheckpointByVmCheckpointParentId (v_checkpoint_id UUID)
-RETURNS SETOF vm_checkpoints STABLE AS $PROCEDURE$
+RETURNS SETOF vm_checkpoints STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM vm_checkpoints
     WHERE parent_id = v_checkpoint_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION InvalidateAllCheckpointsByVmId (
     v_vm_id UUID,
     v_state TEXT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE vm_checkpoints
     SET state = v_state
     WHERE vm_id = v_vm_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ----------------------------------------------------------------
@@ -139,7 +139,7 @@ CREATE OR REPLACE FUNCTION InsertVmCheckpointDiskMap (
     v_checkpoint_id UUID,
     v_disk_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     BEGIN
         INSERT INTO vm_checkpoint_disk_map (
@@ -153,11 +153,11 @@ BEGIN
     END;
 
     RETURN;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetDisksByVmCheckpointId (v_checkpoint_id UUID)
-RETURNS SETOF images_storage_domain_view STABLE AS $PROCEDURE$
+RETURNS SETOF images_storage_domain_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -165,12 +165,12 @@ BEGIN
     FROM   images_storage_domain_view
     JOIN   vm_checkpoint_disk_map on vm_checkpoint_disk_map.disk_id = images_storage_domain_view.image_group_id
     WHERE  images_storage_domain_view.active AND vm_checkpoint_disk_map.checkpoint_id = v_checkpoint_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION IsDiskIncludedInCheckpoint (v_disk_id UUID)
 RETURNS SETOF booleanResultType STABLE
-    AS $PROCEDURE$
+    AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -179,5 +179,5 @@ BEGIN
             FROM vm_checkpoint_disk_map
             WHERE disk_id = v_disk_id
            );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;

--- a/packaging/dbscripts/vm_device_sp.sql
+++ b/packaging/dbscripts/vm_device_sp.sql
@@ -19,7 +19,7 @@ CREATE OR REPLACE FUNCTION InsertVmDevice (
     v_logical_name VARCHAR(255),
     v_host_device VARCHAR(255)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO vm_device (
         device_id,
@@ -53,7 +53,7 @@ BEGIN
         v_logical_name,
         v_host_device
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateVmDevice (
@@ -72,7 +72,7 @@ CREATE OR REPLACE FUNCTION UpdateVmDevice (
     v_logical_name VARCHAR(255),
     v_host_device VARCHAR(255)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE vm_device
     SET device = v_device,
@@ -90,14 +90,14 @@ BEGIN
         _update_date = current_timestamp
     WHERE device_id = v_device_id
         AND vm_id = v_vm_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteVmDevice (
     v_device_id UUID,
     v_vm_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM vm_device
@@ -106,37 +106,37 @@ BEGIN
             v_vm_id IS NULL
             OR vm_id = v_vm_id
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteVmDevicesByVmIdAndType (
     v_vm_id UUID,
     v_type VARCHAR(30)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM vm_device
     WHERE vm_id = v_vm_id
         AND type = v_type;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromVmDevice ()
-RETURNS SETOF vm_device_view STABLE AS $PROCEDURE$
+RETURNS SETOF vm_device_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM vm_device_view;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVmDeviceByDeviceId (
     v_device_id UUID,
     v_vm_id UUID
     )
-RETURNS SETOF vm_device_view STABLE AS $PROCEDURE$
+RETURNS SETOF vm_device_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -147,7 +147,7 @@ BEGIN
             v_vm_id IS NULL
             OR vm_id = v_vm_id
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVmDeviceByVmId (
@@ -155,7 +155,7 @@ CREATE OR REPLACE FUNCTION GetVmDeviceByVmId (
     v_user_id UUID,
     v_is_filtered BOOLEAN
     )
-RETURNS SETOF vm_device_view STABLE AS $PROCEDURE$
+RETURNS SETOF vm_device_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -172,14 +172,14 @@ BEGIN
                 )
             )
     ORDER BY device_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVmDeviceByVmIdAndType (
     v_vm_id UUID,
     v_type VARCHAR(30)
     )
-RETURNS SETOF vm_device_view STABLE AS $PROCEDURE$
+RETURNS SETOF vm_device_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -188,7 +188,7 @@ BEGIN
     WHERE vm_id = v_vm_id
         AND type = v_type
     ORDER BY NULLIF(alias, '') NULLS LAST;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVmDeviceByVmIdTypeAndDevice (
@@ -198,7 +198,7 @@ CREATE OR REPLACE FUNCTION GetVmDeviceByVmIdTypeAndDevice (
     v_user_id UUID,
     v_is_filtered BOOLEAN
     )
-RETURNS SETOF vm_device_view STABLE AS $PROCEDURE$
+RETURNS SETOF vm_device_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -222,7 +222,7 @@ BEGIN
             )
         )
     ORDER BY NULLIF(alias, '') NULLS LAST;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- Returns for all VMs
@@ -233,7 +233,7 @@ CREATE OR REPLACE FUNCTION GetVmDeviceByTypeAndDevice (
     v_user_id UUID,
     v_is_filtered BOOLEAN
     )
-RETURNS SETOF vm_device_view STABLE AS $PROCEDURE$
+RETURNS SETOF vm_device_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -252,11 +252,11 @@ BEGIN
                 )
             )
     ORDER BY NULLIF(alias, '') NULLS LAST;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVmUnmanagedDevicesByVmId (v_vm_id UUID)
-RETURNS SETOF vm_device_view STABLE AS $PROCEDURE$
+RETURNS SETOF vm_device_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -264,7 +264,7 @@ BEGIN
     FROM vm_device_view
     WHERE vm_id = v_vm_id
         AND NOT is_managed;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION isMemBalloonEnabled (v_vm_id UUID)
@@ -323,7 +323,7 @@ CREATE OR REPLACE FUNCTION ExistsVmDeviceByVmIdAndType (
     v_vm_id UUID,
     v_type VARCHAR(30)
     )
-RETURNS BOOLEAN STABLE AS $PROCEDURE$
+RETURNS BOOLEAN STABLE AS $FUNCTION$
 BEGIN
     RETURN EXISTS (
             SELECT 1
@@ -331,17 +331,17 @@ BEGIN
             WHERE vm_id = v_vm_id
                 AND type = v_type
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVmDeviceByType (v_type VARCHAR(30))
-RETURNS SETOF vm_device_view STABLE AS $PROCEDURE$
+RETURNS SETOF vm_device_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM vm_device_view
     WHERE type = v_type;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 

--- a/packaging/dbscripts/vm_icons_sp.sql
+++ b/packaging/dbscripts/vm_icons_sp.sql
@@ -2,31 +2,31 @@
 
 -- VmIcon vm_icons
 CREATE OR REPLACE FUNCTION GetVmIconByVmIconId (v_id UUID)
-RETURNS SETOF vm_icons STABLE AS $PROCEDURE$
+RETURNS SETOF vm_icons STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM vm_icons
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromVmIcons ()
-RETURNS SETOF vm_icons STABLE AS $PROCEDURE$
+RETURNS SETOF vm_icons STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM vm_icons;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromVmIconsFiltered (
     v_user_id UUID,
     v_is_filtered boolean
     )
-RETURNS SETOF vm_icons STABLE AS $PROCEDURE$
+RETURNS SETOF vm_icons STABLE AS $FUNCTION$
 BEGIN
     IF v_is_filtered THEN
         RETURN QUERY
@@ -70,14 +70,14 @@ BEGIN
     FROM vm_icons;
     END IF;
 
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION InsertVmIcon (
     v_id UUID,
     v_data_url TEXT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO vm_icons (
         id,
@@ -87,44 +87,44 @@ BEGIN
         v_id,
         v_data_url
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateVmIcon (
     v_id UUID,
     v_data_url TEXT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE vm_icons
     SET id = v_id,
         data_url = v_data_url
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteVmIcon (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM vm_icons
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVmIconByVmIconDataUrl (v_data_url TEXT)
-RETURNS SETOF vm_icons STABLE AS $PROCEDURE$
+RETURNS SETOF vm_icons STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM vm_icons
     WHERE data_url = v_data_url;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteVmIconIfUnused (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM vm_icons
@@ -141,11 +141,11 @@ BEGIN
             WHERE vm_static.small_icon_id = vm_icons.id
                 OR vm_static.large_icon_id = vm_icons.id
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteAllUnusedVmIcons ()
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM vm_icons
@@ -161,11 +161,11 @@ BEGIN
             WHERE vm_static.small_icon_id = vm_icons.id
                 OR vm_static.large_icon_id = vm_icons.id
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION IsVmIconExist (v_id UUID)
-RETURNS BOOLEAN STABLE AS $PROCEDURE$
+RETURNS BOOLEAN STABLE AS $FUNCTION$
 BEGIN
     RETURN (
             SELECT EXISTS (
@@ -174,29 +174,29 @@ BEGIN
                     WHERE id = v_id
                     )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 -- VmIconDefaults vm_icon_defaults
 CREATE OR REPLACE FUNCTION GetVmIconDefaultByVmIconDefaultId (v_id UUID)
-RETURNS SETOF vm_icon_defaults STABLE AS $PROCEDURE$
+RETURNS SETOF vm_icon_defaults STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM vm_icon_defaults
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromVmIconDefaults ()
-RETURNS SETOF vm_icon_defaults STABLE AS $PROCEDURE$
+RETURNS SETOF vm_icon_defaults STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM vm_icon_defaults;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION InsertVmIconDefault (
@@ -205,7 +205,7 @@ CREATE OR REPLACE FUNCTION InsertVmIconDefault (
     v_small_icon_id UUID,
     v_large_icon_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO vm_icon_defaults (
         id,
@@ -219,7 +219,7 @@ BEGIN
         v_small_icon_id,
         v_large_icon_id
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateVmIconDefault (
@@ -228,7 +228,7 @@ CREATE OR REPLACE FUNCTION UpdateVmIconDefault (
     v_small_icon_id UUID,
     v_large_icon_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE vm_icon_defaults
     SET id = v_id,
@@ -236,46 +236,46 @@ BEGIN
         small_icon_id = v_small_icon_id,
         large_icon_id = v_large_icon_id
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteVmIconDefault (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM vm_icon_defaults
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVmIconDefaultByVmIconDefaultLargeIconId (v_large_icon_id UUID)
-RETURNS SETOF vm_icon_defaults STABLE AS $PROCEDURE$
+RETURNS SETOF vm_icon_defaults STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM vm_icon_defaults
     WHERE large_icon_id = v_large_icon_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVmIconDefaultByVmIconDefaultOsId (v_os_id INT)
-RETURNS SETOF vm_icon_defaults STABLE AS $PROCEDURE$
+RETURNS SETOF vm_icon_defaults STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT *
     FROM vm_icon_defaults
     WHERE os_id = v_os_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteAllFromVmIconDefaults ()
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM vm_icon_defaults;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/vm_interface_filter_parameters_sp.sql
+++ b/packaging/dbscripts/vm_interface_filter_parameters_sp.sql
@@ -2,35 +2,35 @@
 -- [vm_interface_filter_parameters] Table
 --
 CREATE OR REPLACE FUNCTION GetVmInterfaceFilterParameterByVmInterfaceFilterParameterId (v_id UUID)
-RETURNS SETOF vm_interface_filter_parameters STABLE AS $PROCEDURE$
+RETURNS SETOF vm_interface_filter_parameters STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT vm_interface_filter_parameters.*
     FROM vm_interface_filter_parameters
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromVmInterfaceFilterParameters ()
-RETURNS SETOF vm_interface_filter_parameters STABLE AS $PROCEDURE$
+RETURNS SETOF vm_interface_filter_parameters STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT vm_interface_filter_parameters.*
     FROM vm_interface_filter_parameters;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVmInterfaceFilterParametersByVmInterfaceId (v_vm_interface_id UUID)
-RETURNS SETOF vm_interface_filter_parameters STABLE AS $PROCEDURE$
+RETURNS SETOF vm_interface_filter_parameters STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT vm_interface_filter_parameters.*
     FROM vm_interface_filter_parameters
     WHERE vm_interface_id = v_vm_interface_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION InsertVmInterfaceFilterParameter (
@@ -39,7 +39,7 @@ CREATE OR REPLACE FUNCTION InsertVmInterfaceFilterParameter (
     v_value VARCHAR(255),
     v_vm_interface_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO vm_interface_filter_parameters (
         id,
@@ -53,7 +53,7 @@ BEGIN
         v_value,
         v_vm_interface_id
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateVmInterfaceFilterParameter (
@@ -61,22 +61,22 @@ CREATE OR REPLACE FUNCTION UpdateVmInterfaceFilterParameter (
     v_name VARCHAR(255),
     v_value VARCHAR(255)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE vm_interface_filter_parameters
     SET name = v_name,
         value = v_value
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteVmInterfaceFilterParameter (v_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 DECLARE v_val UUID;
 
 BEGIN
     DELETE
     FROM vm_interface_filter_parameters
     WHERE id = v_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;

--- a/packaging/dbscripts/vm_jobs_sp.sql
+++ b/packaging/dbscripts/vm_jobs_sp.sql
@@ -4,13 +4,13 @@
 -- vm_jobs functions
 ---------------------
 CREATE OR REPLACE FUNCTION GetAllVmJobs ()
-RETURNS SETOF vm_jobs STABLE AS $PROCEDURE$
+RETURNS SETOF vm_jobs STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT vm_jobs.*
     FROM vm_jobs;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateVmJobs (
@@ -24,7 +24,7 @@ CREATE OR REPLACE FUNCTION UpdateVmJobs (
     v_cursor_end BIGINT,
     v_image_group_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE vm_jobs
     SET vm_job_id = v_vm_job_id,
@@ -37,16 +37,16 @@ BEGIN
         cursor_end = v_cursor_end,
         image_group_id = v_image_group_id
     WHERE vm_job_id = v_vm_job_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteVmJobs (v_vm_job_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM vm_jobs
     WHERE vm_job_id = v_vm_job_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION InsertVmJobs (
@@ -60,7 +60,7 @@ CREATE OR REPLACE FUNCTION InsertVmJobs (
     v_cursor_end BIGINT,
     v_image_group_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO vm_jobs (
         vm_job_id,
@@ -84,7 +84,7 @@ BEGIN
         v_cursor_end,
         v_image_group_id
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/vm_pool_maps_sp.sql
+++ b/packaging/dbscripts/vm_pool_maps_sp.sql
@@ -7,7 +7,7 @@ CREATE OR REPLACE FUNCTION InsertVm_pool_map (
     v_vm_guid UUID,
     v_vm_pool_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO vm_pool_map (
         vm_guid,
@@ -17,7 +17,7 @@ BEGIN
         v_vm_guid,
         v_vm_pool_id
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateVm_pool_map (
@@ -26,16 +26,16 @@ CREATE OR REPLACE FUNCTION UpdateVm_pool_map (
     )
 RETURNS VOID
     --The [vm_pool_map] table doesn't have a timestamp column. Optimistic concurrency logic cannot be generated
-    AS $PROCEDURE$
+    AS $FUNCTION$
 BEGIN
     UPDATE vm_pool_map
     SET vm_pool_id = v_vm_pool_id
     WHERE vm_guid = v_vm_guid;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteVm_pool_map (v_vm_guid UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 DECLARE v_val VARCHAR(50);
 
 BEGIN
@@ -50,21 +50,21 @@ BEGIN
     DELETE
     FROM vm_pool_map
     WHERE vm_guid = v_vm_guid;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromVm_pool_map ()
-RETURNS SETOF vm_pool_map STABLE AS $PROCEDURE$
+RETURNS SETOF vm_pool_map STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT vm_pool_map.*
     FROM vm_pool_map;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVm_pool_mapByvm_pool_id (v_vm_pool_id UUID)
-RETURNS SETOF vm_pool_map STABLE AS $PROCEDURE$
+RETURNS SETOF vm_pool_map STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -74,14 +74,14 @@ BEGIN
         ON vm_pool_map.vm_guid = vm_static.vm_guid
     WHERE vm_pool_id = v_vm_pool_id
     ORDER BY vm_static.vm_name;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION getVmMapsInVmPoolByVmPoolIdAndStatus (
     v_vm_pool_id UUID,
     v_status INT
     )
-RETURNS SETOF vm_pool_map STABLE AS $PROCEDURE$
+RETURNS SETOF vm_pool_map STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -92,7 +92,7 @@ BEGIN
     WHERE vm_pool_map.vm_guid = vm_dynamic.vm_guid
         AND vm_pool_id = v_vm_pool_id
         AND vm_dynamic.status = v_status;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 

--- a/packaging/dbscripts/vm_pools_sp.sql
+++ b/packaging/dbscripts/vm_pools_sp.sql
@@ -17,7 +17,7 @@ CREATE OR REPLACE FUNCTION InsertVm_pools (
     v_spice_proxy VARCHAR(255),
     v_is_auto_storage_select BOOLEAN
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO vm_pools (
         vm_pool_id,
@@ -47,7 +47,7 @@ BEGIN
         v_spice_proxy,
         v_is_auto_storage_select
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateVm_pools (
@@ -66,7 +66,7 @@ CREATE OR REPLACE FUNCTION UpdateVm_pools (
     )
 RETURNS VOID
     --The [vm_pools] table doesn't have a timestamp column. Optimistic concurrency logic cannot be generated
-    AS $PROCEDURE$
+    AS $FUNCTION$
 BEGIN
     UPDATE vm_pools
     SET vm_pool_description = v_vm_pool_description,
@@ -81,11 +81,11 @@ BEGIN
         spice_proxy = v_spice_proxy,
         is_auto_storage_select = v_is_auto_storage_select
     WHERE vm_pool_id = v_vm_pool_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteVm_pools (v_vm_pool_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 DECLARE v_val UUID;
 
 BEGIN
@@ -105,19 +105,19 @@ BEGIN
 
     -- delete VmPool permissions --
     PERFORM DeletePermissionsByEntityId(v_vm_pool_id);
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION SetVmPoolBeingDestroyed (
     v_vm_pool_id UUID,
     v_is_being_destroyed BOOLEAN
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE vm_pools
     SET is_being_destroyed = v_is_being_destroyed
     WHERE vm_pool_id = v_vm_pool_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 DROP TYPE IF EXISTS GetAllFromVm_pools_rs CASCADE;
@@ -141,7 +141,7 @@ DROP TYPE IF EXISTS GetAllFromVm_pools_rs CASCADE;
         );
 
 CREATE OR REPLACE FUNCTION GetAllFromVm_pools ()
-RETURNS SETOF GetAllFromVm_pools_rs AS $PROCEDURE$
+RETURNS SETOF GetAllFromVm_pools_rs AS $FUNCTION$
 BEGIN
     -- BEGIN TRAN
     BEGIN
@@ -287,7 +287,7 @@ BEGIN
 
     SELECT *
     FROM tt_VM_POOL_RESULT;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVm_poolsByvm_pool_id (
@@ -295,7 +295,7 @@ CREATE OR REPLACE FUNCTION GetVm_poolsByvm_pool_id (
     v_user_id UUID,
     v_is_filtered BOOLEAN
     )
-RETURNS SETOF vm_pools_full_view STABLE AS $PROCEDURE$
+RETURNS SETOF vm_pools_full_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -311,22 +311,22 @@ BEGIN
                     AND entity_id = v_vm_pool_id
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVm_poolsByvm_pool_name (v_vm_pool_name VARCHAR(255))
-RETURNS SETOF vm_pools_view STABLE AS $PROCEDURE$
+RETURNS SETOF vm_pools_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT vm_pools_view.*
     FROM vm_pools_view
     WHERE vm_pool_name = v_vm_pool_name;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllVm_poolsByUser_id (v_user_id UUID)
-RETURNS SETOF vm_pools_view STABLE AS $PROCEDURE$
+RETURNS SETOF vm_pools_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -335,11 +335,11 @@ BEGIN
     INNER JOIN vm_pools_view
         ON users_and_groups_to_vm_pool_map_view.vm_pool_id = vm_pools_view.vm_pool_id
     WHERE (users_and_groups_to_vm_pool_map_view.user_id = v_user_id);
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromVmPoolsFilteredAndSorted (v_user_id UUID, v_offset int, v_limit int)
-RETURNS SETOF vm_pools_view STABLE AS $PROCEDURE$
+RETURNS SETOF vm_pools_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -350,11 +350,11 @@ BEGIN
             AND entity_id = pools.vm_pool_id
     ORDER BY pools.vm_pool_name ASC
     LIMIT v_limit OFFSET v_offset;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVm_poolsByAdGroup_names (v_ad_group_names VARCHAR(4000))
-RETURNS SETOF vm_pools_view STABLE AS $PROCEDURE$
+RETURNS SETOF vm_pools_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -370,7 +370,7 @@ BEGIN
                 FROM fnSplitter(v_ad_group_names)
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVmDataFromPoolByPoolId (
@@ -378,7 +378,7 @@ CREATE OR REPLACE FUNCTION GetVmDataFromPoolByPoolId (
     v_user_id uuid,
     v_is_filtered boolean
     )
-RETURNS SETOF vms STABLE AS $PROCEDURE$
+RETURNS SETOF vms STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -396,11 +396,11 @@ BEGIN
             )
         -- Limiting results to 1 since we only need a single VM from the pool to retrieve the pool data
         LIMIT 1;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllVm_poolsByUser_id_with_groups_and_UserRoles (v_user_id UUID)
-RETURNS SETOF vm_pools_view STABLE AS $PROCEDURE$
+RETURNS SETOF vm_pools_view STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -409,11 +409,11 @@ BEGIN
     INNER JOIN user_vm_pool_permissions_view
         ON user_id = v_user_id
             AND entity_id = pools.vm_pool_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION BoundVmPoolPrestartedVms (v_vm_pool_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE vm_pools
     SET prestarted_vms = LEAST (
@@ -424,5 +424,5 @@ BEGIN
             )
         )
     WHERE vm_pool_id = v_vm_pool_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;

--- a/packaging/dbscripts/vms_sp.sql
+++ b/packaging/dbscripts/vms_sp.sql
@@ -8,7 +8,7 @@ CREATE OR REPLACE FUNCTION UpdateOvfGenerations (
     v_ovf_data TEXT,
     v_ovf_data_seperator VARCHAR(10)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 DECLARE curs_vmids CURSOR
 FOR
 SELECT *
@@ -62,11 +62,11 @@ CLOSE curs_vmids;
 
 CLOSE curs_newovfgen;
 
-CLOSE curs_newovfdata;END;$PROCEDURE$
+CLOSE curs_newovfdata;END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION LoadOvfDataForIds (v_ids VARCHAR(5000))
-RETURNS SETOF vm_ovf_generations STABLE AS $PROCEDURE$
+RETURNS SETOF vm_ovf_generations STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -76,11 +76,11 @@ BEGIN
             SELECT *
             FROM fnSplitterUuid(v_ids)
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetIdsForOvfDeletion (v_storage_pool_id UUID)
-RETURNS SETOF UUID STABLE AS $PROCEDURE$
+RETURNS SETOF UUID STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -91,22 +91,22 @@ BEGIN
             SELECT vm_guid
             FROM vm_static
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetOvfGeneration (v_vm_id UUID)
-RETURNS SETOF BIGINT STABLE AS $PROCEDURE$
+RETURNS SETOF BIGINT STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT vm.ovf_generation
     FROM vm_ovf_generations vm
     WHERE vm.vm_guid = v_vm_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVmTemplatesIdsForOvfUpdate (v_storage_pool_id UUID)
-RETURNS SETOF UUID STABLE AS $PROCEDURE$
+RETURNS SETOF UUID STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -116,11 +116,11 @@ BEGIN
     WHERE generations.vm_guid = templates.vmt_guid
         AND templates.db_generation > generations.ovf_generation
         AND templates.storage_pool_id = v_storage_pool_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVmsIdsForOvfUpdate (v_storage_pool_id UUID)
-RETURNS SETOF UUID STABLE AS $PROCEDURE$
+RETURNS SETOF UUID STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -132,11 +132,11 @@ BEGIN
         AND vm.storage_pool_id = v_storage_pool_id
         -- filter out external VMs if needed.
         AND vm.origin != 4;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteOvfGenerations (v_vms_ids VARCHAR(5000))
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM vm_ovf_generations
@@ -149,7 +149,7 @@ BEGIN
             SELECT vm_guid
             FROM vm_static
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ----------------------------------------------------------------
@@ -167,7 +167,7 @@ CREATE OR REPLACE FUNCTION InsertVmStatistics (
     v_guest_mem_buffered BIGINT,
     v_guest_mem_cached BIGINT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO vm_statistics (
         cpu_sys,
@@ -193,7 +193,7 @@ BEGIN
         v_guest_mem_buffered,
         v_guest_mem_cached
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateVmStatistics (
@@ -208,7 +208,7 @@ CREATE OR REPLACE FUNCTION UpdateVmStatistics (
     v_guest_mem_buffered BIGINT,
     v_guest_mem_cached BIGINT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE vm_statistics
     SET cpu_sys = v_cpu_sys,
@@ -222,47 +222,47 @@ BEGIN
         guest_mem_cached = v_guest_mem_cached,
         _update_date = LOCALTIMESTAMP
     WHERE vm_guid = v_vm_guid;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteVmStatistics (v_vm_guid UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM vm_statistics
     WHERE vm_guid = v_vm_guid;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromVmStatistics ()
-RETURNS SETOF vm_statistics STABLE AS $PROCEDURE$
+RETURNS SETOF vm_statistics STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT vm_statistics.*
     FROM vm_statistics;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromVmDynamic ()
-RETURNS SETOF vm_dynamic STABLE AS $PROCEDURE$
+RETURNS SETOF vm_dynamic STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT vm_dynamic.*
     FROM vm_dynamic;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVmStatisticsByVmGuid (v_vm_guid UUID)
-RETURNS SETOF vm_statistics STABLE AS $PROCEDURE$
+RETURNS SETOF vm_statistics STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT vm_statistics.*
     FROM vm_statistics
     WHERE vm_guid = v_vm_guid;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 ----------------------------------------------------------------
@@ -327,7 +327,7 @@ CREATE OR REPLACE FUNCTION InsertVmDynamic (
     v_current_threads INT,
     v_current_numa_pinning VARCHAR(4000)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO vm_dynamic (
         app_list,
@@ -447,7 +447,7 @@ BEGIN
         v_current_threads,
         v_current_numa_pinning
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateVmDynamic (
@@ -512,7 +512,7 @@ CREATE OR REPLACE FUNCTION UpdateVmDynamic (
     )
 RETURNS VOID
     --The [vm_dynamic] table doesn't have a timestamp column. Optimistic concurrency logic cannot be generated
-    AS $PROCEDURE$
+    AS $FUNCTION$
 BEGIN
     UPDATE vm_dynamic
     SET app_list = v_app_list,
@@ -573,92 +573,92 @@ BEGIN
         current_threads = v_current_threads,
         current_numa_pinning = v_current_numa_pinning
     WHERE vm_guid = v_vm_guid;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateVmDynamicStatus (
     v_vm_guid UUID,
     v_status INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE vm_dynamic
     SET status = v_status
     WHERE vm_guid = v_vm_guid;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION ClearMigratingToVds (v_vm_guid UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE vm_dynamic
     SET migrating_to_vds = NULL
     WHERE vm_guid = v_vm_guid;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION ClearMigratingToVdsAndSetDynamicPinning (v_vm_guid UUID, v_current_cpu_pinning VARCHAR(4000), v_current_numa_pinning VARCHAR(4000))
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE vm_dynamic
     SET migrating_to_vds = NULL,
         current_cpu_pinning = v_current_cpu_pinning,
         current_numa_pinning = v_current_numa_pinning
     WHERE vm_guid = v_vm_guid;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteVmDynamic (v_vm_guid UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM vm_dynamic
     WHERE vm_guid = v_vm_guid;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllFromVmDynamic ()
-RETURNS SETOF vm_dynamic STABLE AS $PROCEDURE$
+RETURNS SETOF vm_dynamic STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT vm_dynamic.*
     FROM vm_dynamic;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVmDynamicByVmGuid (v_vm_guid UUID)
-RETURNS SETOF vm_dynamic STABLE AS $PROCEDURE$
+RETURNS SETOF vm_dynamic STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT vm_dynamic.*
     FROM vm_dynamic
     WHERE vm_guid = v_vm_guid;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 DROP TYPE IF EXISTS GetAllHashesFromVmDynamic_rs CASCADE;
 CREATE TYPE GetAllHashesFromVmDynamic_rs AS (vm_guid UUID, hash VARCHAR);
 CREATE OR REPLACE FUNCTION GetAllHashesFromVmDynamic ()
 RETURNS SETOF GetAllHashesFromVmDynamic_rs STABLE
-AS $procedure$
+AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
     SELECT vm_guid, hash
     FROM vm_dynamic;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION SetHashByVmGuid (v_vm_guid UUID, v_hash VARCHAR(30))
 RETURNS VOID
-AS $procedure$
+AS $FUNCTION$
 BEGIN
     UPDATE vm_dynamic
     SET hash = v_hash
     WHERE vm_guid = v_vm_guid;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 ----------------------------------------------------------------
@@ -746,7 +746,7 @@ CREATE OR REPLACE FUNCTION InsertVmStatic (
     v_cpu_pinning_policy SMALLINT,
     v_parallel_migrations SMALLINT)
   RETURNS VOID
-   AS $procedure$
+   AS $FUNCTION$
 DECLARE
   v_val UUID;
 BEGIN
@@ -937,7 +937,7 @@ INSERT INTO vm_static(description,
     SET child_count = child_count+1
     WHERE vm_guid = v_vmt_guid;
 
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -948,12 +948,12 @@ LANGUAGE plpgsql;
 
 Create or replace FUNCTION IncrementDbGeneration(v_vm_guid UUID)
 RETURNS VOID
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
       UPDATE vm_static
       SET db_generation  = db_generation + 1
       WHERE vm_guid = v_vm_guid;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -962,12 +962,12 @@ LANGUAGE plpgsql;
 
 Create or replace FUNCTION IncrementDbGenerationForVms(v_vm_guids UUID[])
 RETURNS VOID
-AS $procedure$
+AS $FUNCTION$
 BEGIN
     UPDATE vm_static
     SET db_generation = db_generation + 1
     WHERE vm_guid = ANY(v_vm_guids);
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -976,12 +976,12 @@ LANGUAGE plpgsql;
 
 Create or replace FUNCTION GetDbGeneration(v_vm_guid UUID)
 RETURNS SETOF BIGINT STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
       RETURN QUERY SELECT db_generation
       FROM vm_static
       WHERE vm_guid = v_vm_guid;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -990,7 +990,7 @@ LANGUAGE plpgsql;
 
 Create or replace FUNCTION IncrementDbGenerationForAllInStoragePool(v_storage_pool_id UUID)
 RETURNS VOID
-   AS $procedure$
+   AS $FUNCTION$
 DECLARE
      curs CURSOR FOR SELECT vms.vm_guid FROM vm_static vms
                      WHERE vms.cluster_id IN (SELECT vgs.cluster_id FROM cluster vgs
@@ -1006,7 +1006,7 @@ BEGIN
          END IF;
          UPDATE vm_static SET db_generation  = db_generation + 1 WHERE vm_guid = id;
       END LOOP;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -1017,7 +1017,7 @@ LANGUAGE plpgsql;
 
 Create or replace FUNCTION GetVmsAndTemplatesIdsWithoutAttachedImageDisks(v_storage_pool_id UUID, v_shareable BOOLEAN)
 RETURNS SETOF UUID STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
       RETURN QUERY SELECT vs.vm_guid
       FROM vm_static vs
@@ -1031,7 +1031,7 @@ BEGIN
       AND vs.cluster_id IN (SELECT vg.cluster_id
                               FROM cluster vg, storage_pool sp
                               WHERE vg.storage_pool_id = v_storage_pool_id);
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -1124,7 +1124,7 @@ v_parallel_migrations SMALLINT)
 RETURNS VOID
 
 	--The [vm_static] table doesn't have a timestamp column. Optimistic concurrency logic cannot be generated
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
      UPDATE vm_static
      SET
@@ -1215,7 +1215,7 @@ BEGIN
           v_vm_guid,
           v_dedicated_vm_for_vds);
 
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -1224,7 +1224,7 @@ LANGUAGE plpgsql;
 
 Create or replace FUNCTION DeleteVmStatic(v_vm_guid UUID, v_remove_permissions boolean)
 RETURNS VOID
-   AS $procedure$
+   AS $FUNCTION$
    DECLARE
    v_val  UUID;
    v_vmt_guid  UUID;
@@ -1247,7 +1247,7 @@ BEGIN
       -- set the child_count for the template
       UPDATE vm_static
           SET child_count = child_count - 1 WHERE vm_guid = v_vmt_guid;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -1255,25 +1255,25 @@ LANGUAGE plpgsql;
 
 
 Create or replace FUNCTION GetAllFromVmStatic() RETURNS SETOF vm_static_view STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
 RETURN QUERY SELECT vm_static_view.*
    FROM vm_static_view
    WHERE entity_type = 'VM';
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
 
 
 Create or replace FUNCTION GetVmStaticWithoutIcon() RETURNS SETOF vm_static_view STABLE
-AS $procedure$
+AS $FUNCTION$
 BEGIN
 RETURN QUERY SELECT vm_static_view.*
    FROM vm_static_view
    WHERE entity_type = 'VM'
       AND (small_icon_id IS NULL OR large_icon_id IS NULL);
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -1283,12 +1283,12 @@ Create or replace FUNCTION UpdateOriginalTemplateName(
 v_original_template_id UUID,
 v_original_template_name VARCHAR(255))
 RETURNS VOID
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
       UPDATE vm_static
       SET original_template_name = v_original_template_name
       WHERE original_template_id = v_original_template_id;
-END; $procedure$
+END; $FUNCTION$
 
 
 
@@ -1299,12 +1299,12 @@ Create or replace FUNCTION UpdateVmLeaseInfo(
 v_vm_guid UUID,
 v_lease_info VARCHAR(1000))
 RETURNS VOID
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
       UPDATE vm_dynamic
       SET lease_info = v_lease_info
       WHERE vm_guid = v_vm_guid;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -1314,44 +1314,44 @@ Create or replace FUNCTION UpdateVmLeaseStorageDomainId(
 v_vm_guid UUID,
 v_sd_id UUID)
 RETURNS VOID
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
       UPDATE vm_static
       SET lease_sd_id = v_sd_id
       WHERE vm_guid = v_vm_guid;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
 
 
 Create or replace FUNCTION GetVmStaticByVmGuid(v_vm_guid UUID) RETURNS SETOF vm_static_view STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
 RETURN QUERY SELECT vm_static_view.*
    FROM vm_static_view
    WHERE vm_guid = v_vm_guid
        AND   entity_type = 'VM';
 
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
 
 CREATE OR REPLACE FUNCTION GetVmStaticByVmGuids(v_vm_guids UUID[]) RETURNS SETOF vm_static_view STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
 RETURN QUERY SELECT vm_static_view.*
    FROM vm_static_view
    WHERE vm_guid = ANY(v_vm_guids)
        AND entity_type = 'VM';
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
 
 Create or replace FUNCTION GetAllFromVmStaticByStoragePoolId(v_sp_id uuid) RETURNS SETOF vm_static_view STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
 RETURN QUERY SELECT vm_static_view.*
    FROM vm_static_view INNER JOIN
@@ -1361,20 +1361,20 @@ RETURN QUERY SELECT vm_static_view.*
    WHERE v_sp_id = storage_pool.id
        AND entity_type = 'VM';
 
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
 
 Create or replace FUNCTION GetVmStaticByName(v_vm_name VARCHAR(255)) RETURNS SETOF vm_static_view STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
 RETURN QUERY SELECT vm_static_view.*
    FROM vm_static_view
    WHERE vm_name = v_vm_name
        AND entity_type = 'VM';
 
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -1382,14 +1382,14 @@ LANGUAGE plpgsql;
 
 
 Create or replace FUNCTION GetVmStaticByCluster(v_cluster_id UUID) RETURNS SETOF vm_static_view STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
 RETURN QUERY SELECT vm_static_view.*
    FROM vm_static_view
    WHERE cluster_id = v_cluster_id
        AND entity_type = 'VM';
 
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -1404,7 +1404,7 @@ LANGUAGE plpgsql;
 
 
 Create or replace FUNCTION GetAllFromVms(v_user_id UUID, v_is_filtered boolean) RETURNS SETOF vms STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
 IF v_is_filtered THEN
    RETURN QUERY SELECT vms.*
@@ -1417,7 +1417,7 @@ ELSE
       ORDER BY vm_guid;
 END IF;
 
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -1427,7 +1427,7 @@ LANGUAGE plpgsql;
 
 
 Create or replace FUNCTION GetAllFromVmsFilteredAndSorted(v_user_id UUID, v_offset int, v_limit int) RETURNS SETOF vms STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
    RETURN QUERY SELECT *
       FROM (
@@ -1445,7 +1445,7 @@ BEGIN
       ) result
       ORDER BY vm_name ASC
       LIMIT v_limit OFFSET v_offset;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -1455,7 +1455,7 @@ LANGUAGE plpgsql;
 
 
 Create or replace FUNCTION GetAllRunningVmsForUserAndActionGroup(v_user_id UUID, v_action_group_id INTEGER) RETURNS SETOF vm_dynamic STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
 RETURN QUERY SELECT DISTINCT vm_dynamic.*
       FROM vm_dynamic, vm_permissions_view, permissions_view, engine_session_user_flat_groups
@@ -1468,7 +1468,7 @@ RETURN QUERY SELECT DISTINCT vm_dynamic.*
           AND   permissions_view.ad_element_id = engine_session_user_flat_groups.granted_id
           AND   permissions_view.role_id IN (SELECT role_id FROM roles_groups WHERE action_group_id = v_action_group_id)
       ORDER BY vm_guid;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -1479,12 +1479,12 @@ LANGUAGE plpgsql;
 
 
 Create or replace FUNCTION GetVmsByIds(v_vms_ids UUID[]) RETURNS SETOF vms STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
 RETURN QUERY SELECT vm.*
              FROM vms vm
              WHERE vm.vm_guid = ANY(v_vms_ids);
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -1494,7 +1494,7 @@ LANGUAGE plpgsql;
 
 
 Create or replace FUNCTION GetVmByVmGuid(v_vm_guid UUID, v_user_id UUID, v_is_filtered boolean) RETURNS SETOF vms STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
 RETURN QUERY SELECT DISTINCT vms.*
    FROM vms
@@ -1502,7 +1502,7 @@ RETURN QUERY SELECT DISTINCT vms.*
        AND   (NOT v_is_filtered OR EXISTS (SELECT 1
                                        FROM   user_vm_permissions_view
                                        WHERE  user_id = v_user_id AND entity_id = v_vm_guid));
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -1510,12 +1510,12 @@ LANGUAGE plpgsql;
 
 
 Create or replace FUNCTION GetHostedEngineVm() RETURNS SETOF vms STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
 RETURN QUERY SELECT DISTINCT vms.*
    FROM vms
    WHERE origin = 5 OR origin = 6;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -1523,7 +1523,7 @@ LANGUAGE plpgsql;
 
 
 Create or replace FUNCTION GetVmByVmNameForDataCenter(v_data_center_id UUID, v_vm_name VARCHAR(255), v_user_id UUID, v_is_filtered boolean) RETURNS SETOF vms STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
 RETURN QUERY SELECT DISTINCT vms.*
    FROM vms
@@ -1532,30 +1532,30 @@ RETURN QUERY SELECT DISTINCT vms.*
        AND   (NOT v_is_filtered OR EXISTS (SELECT 1
                                        FROM   user_vm_permissions_view
                                        WHERE  user_id = v_user_id AND entity_id = vms.vm_guid));
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
 Create or replace FUNCTION getByNameAndNamespaceForCluster(v_cluster_id UUID, v_vm_name VARCHAR(255), v_namespace VARCHAR(253)) RETURNS SETOF vms STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
 RETURN QUERY SELECT DISTINCT vms.*
    FROM vms
    WHERE vm_name = v_vm_name
        AND namespace = v_namespace
        AND cluster_id = v_cluster_id;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
 
 Create or replace FUNCTION GetVmsByVmtGuid(v_vmt_guid UUID) RETURNS SETOF vms STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
 RETURN QUERY SELECT DISTINCT vms.*
    FROM vms
    WHERE vmt_guid = v_vmt_guid;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -1565,7 +1565,7 @@ LANGUAGE plpgsql;
 
 
 Create or replace FUNCTION GetVmsByUserId(v_user_id UUID) RETURNS SETOF vms STABLE
-   AS $procedure$
+   AS $FUNCTION$
 
 DECLARE v_vm_ids  UUID[];
 BEGIN
@@ -1577,7 +1577,7 @@ RETURN QUERY
 SELECT vms.*
 FROM vms
    WHERE vm_guid = ANY(v_vm_ids);
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -1587,11 +1587,11 @@ LANGUAGE plpgsql;
 
 
 Create or replace FUNCTION GetVmsByInstanceTypeId(v_instance_type_id UUID) RETURNS SETOF vms STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
 RETURN QUERY select vms.* from vms
    WHERE instance_type_id = v_instance_type_id;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -1601,7 +1601,7 @@ LANGUAGE plpgsql;
 
 
 Create or replace FUNCTION GetVmsByUserIdWithGroupsAndUserRoles(v_user_id UUID) RETURNS SETOF vms STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
 RETURN QUERY SELECT DISTINCT vms.*
    from vms
@@ -1612,23 +1612,23 @@ RETURN QUERY SELECT DISTINCT vms.*
            FROM getUserAndGroupsById(v_user_id)))
        AND perms.role_type = 2;
 
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
 Create or replace FUNCTION GetVmsRunningOnVds(v_vds_id UUID) RETURNS SETOF vms STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
 RETURN QUERY SELECT DISTINCT vms.*
    FROM vms
    WHERE run_on_vds = v_vds_id;
 
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
 CREATE OR REPLACE FUNCTION GetVmsRunningOnMultipleVds(v_vds_ids UUID[])
-RETURNS SETOF vms STABLE AS $procedure$
+RETURNS SETOF vms STABLE AS $FUNCTION$
 BEGIN
    RETURN QUERY
 
@@ -1636,35 +1636,35 @@ BEGIN
    FROM vms
    WHERE run_on_vds = ANY(v_vds_ids);
 
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
 Create or replace FUNCTION GetVmsRunningByVds(v_vds_id UUID) RETURNS SETOF vms_monitoring_view STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
 RETURN QUERY
 SELECT DISTINCT vms_monitoring_view.*
    FROM vms_monitoring_view
    WHERE run_on_vds = v_vds_id;
 
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
 CREATE OR REPLACE FUNCTION GetVmsMigratingToVds(v_vds_id UUID)
 RETURNS SETOF vm_dynamic STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
 RETURN QUERY SELECT DISTINCT vm_dynamic.*
    FROM vm_dynamic
    WHERE migrating_to_vds = v_vds_id;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
 Create or replace FUNCTION GetVmsRunningOnOrMigratingToVds(v_vds_id UUID) RETURNS SETOF vms STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
     -- use migrating_to_vds column when the VM is in status Migrating From
     RETURN QUERY SELECT DISTINCT V.* FROM VMS V
@@ -1672,17 +1672,17 @@ BEGIN
         OR (V.status = 5
             AND V.migrating_to_vds=v_vds_id)
     ORDER BY V.vm_name;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
 Create or replace FUNCTION GetAllForStoragePool(v_storage_pool_id UUID) RETURNS SETOF vms STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
 RETURN QUERY SELECT *
              FROM vms
              WHERE storage_pool_id = v_storage_pool_id;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -1691,13 +1691,13 @@ Create or replace FUNCTION UpdateOvirtGuestAgentStatus(
 	v_ovirt_guest_agent_status INTEGER)
 RETURNS VOID
 
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
       UPDATE vm_dynamic
       SET
       ovirt_guest_agent_status = v_ovirt_guest_agent_status
       WHERE vm_guid = v_vm_guid;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -1706,31 +1706,31 @@ Create or replace FUNCTION UpdateQemuGuestAgentStatus(
 	v_qemu_guest_agent_status INTEGER)
 RETURNS VOID
 
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
       UPDATE vm_dynamic
       SET
       qemu_guest_agent_status = v_qemu_guest_agent_status
       WHERE vm_guid = v_vm_guid;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
 
 Create or replace FUNCTION GetVmsDynamicRunningOnVds(v_vds_id UUID) RETURNS SETOF vm_dynamic STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
       RETURN QUERY SELECT vm_dynamic.*
       FROM vm_dynamic
       WHERE run_on_vds = v_vds_id;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
 
 CREATE OR REPLACE FUNCTION IsAnyVmRunOnVds(v_vds_id UUID)
 RETURNS SETOF booleanResultType STABLE
-    AS $PROCEDURE$
+    AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -1739,14 +1739,14 @@ BEGIN
             FROM vm_dynamic
             WHERE run_on_vds = v_vds_id
            );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 
 
 Create or replace FUNCTION DeleteVm(v_vm_guid UUID)
 RETURNS VOID
-   AS $procedure$
+   AS $FUNCTION$
    DECLARE
    v_vmt_guid  UUID;
 BEGIN
@@ -1763,31 +1763,31 @@ BEGIN
       DELETE FROM vm_dynamic WHERE vm_guid = v_vm_guid;
       DELETE FROM vm_static WHERE vm_guid = v_vm_guid;
       PERFORM DeletePermissionsByEntityId(v_vm_guid);
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
 
 
 Create or replace FUNCTION GetVmsByAdGroupNames(v_ad_group_names VARCHAR(250)) RETURNS SETOF vms STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
 RETURN QUERY select distinct vms.* from vms
    inner join permissions on vms.vm_guid = permissions.object_id
    inner join ad_groups on ad_groups.id = permissions.ad_element_id
    WHERE     (ad_groups.name in(select Id from fnSplitter(v_ad_group_names)));
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
 
 Create or replace FUNCTION GetVmsByDiskId(v_disk_guid UUID) RETURNS SETOF vms_with_plug_info STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
       RETURN QUERY SELECT DISTINCT vms_with_plug_info.*
       FROM vms_with_plug_info
       WHERE device_id = v_disk_guid;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -1795,7 +1795,7 @@ LANGUAGE plpgsql;
 
 
 Create or replace FUNCTION GetAllVMsWithDisksOnOtherStorageDomain(v_storage_domain_id UUID) RETURNS SETOF vms STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
       RETURN QUERY SELECT DISTINCT vms.*
       FROM vms
@@ -1811,11 +1811,11 @@ BEGIN
       INNER JOIN images i ON i.image_group_id = vd.device_id
       INNER JOIN image_storage_domain_map on i.image_guid = image_storage_domain_map.image_id
       WHERE image_storage_domain_map.storage_domain_id != v_storage_domain_id;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 Create or replace FUNCTION GetActiveVmsByStorageDomainId(v_storage_domain_id UUID) RETURNS SETOF vms STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
       RETURN QUERY SELECT DISTINCT vms.*
       FROM vms
@@ -1825,7 +1825,7 @@ BEGIN
       WHERE status not in (0, 13)
       AND is_plugged = TRUE
       AND image_storage_domain_map.storage_domain_id = v_storage_domain_id;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -1833,7 +1833,7 @@ LANGUAGE plpgsql;
 
 
 Create or replace FUNCTION GetVmsByStorageDomainId(v_storage_domain_id UUID) RETURNS SETOF vms STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
       RETURN QUERY SELECT DISTINCT vms.*
       FROM vms
@@ -1842,12 +1842,12 @@ BEGIN
           AND images.active = TRUE
       INNER JOIN image_storage_domain_map on images.image_guid = image_storage_domain_map.image_id
       WHERE image_storage_domain_map.storage_domain_id = v_storage_domain_id;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
 Create or replace FUNCTION getAllVmsRelatedToQuotaId(v_quota_id UUID) RETURNS SETOF vms STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
       RETURN QUERY SELECT vms.*
       FROM vms
@@ -1860,7 +1860,7 @@ BEGIN
           AND images.active = TRUE
       INNER JOIN image_storage_domain_map ON image_storage_domain_map.image_id = images.image_guid
       WHERE image_storage_domain_map.quota_id = v_quota_id;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -1870,13 +1870,13 @@ Create or replace FUNCTION UpdateIsInitialized(v_vm_guid UUID,
 RETURNS VOID
 
 	--The [vm_static] table doesn't have a timestamp column. Optimistic concurrency logic cannot be generated
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
       UPDATE vm_static
       SET is_initialized = v_is_initialized
       WHERE vm_guid = v_vm_guid
           AND entity_type = 'VM';
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -1886,7 +1886,7 @@ LANGUAGE plpgsql;
 DROP TYPE IF EXISTS GetOrderedVmGuidsForRunMultipleActions_rs CASCADE;
 CREATE TYPE GetOrderedVmGuidsForRunMultipleActions_rs AS (vm_guid UUID);
 Create or replace FUNCTION GetOrderedVmGuidsForRunMultipleActions(v_vm_guids VARCHAR(4000)) RETURNS SETOF GetOrderedVmGuidsForRunMultipleActions_rs STABLE
-   AS $procedure$
+   AS $FUNCTION$
    DECLARE
    v_ordered_guids GetOrderedVmGuidsForRunMultipleActions_rs;
 BEGIN
@@ -1896,13 +1896,13 @@ BEGIN
       RETURN NEXT v_ordered_guids;
    END LOOP;
 
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
 
 Create or replace FUNCTION GetVmsByNetworkId(v_network_id UUID) RETURNS SETOF vms STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
    RETURN QUERY SELECT *
    FROM vms
@@ -1913,12 +1913,12 @@ BEGIN
       ON vnic_profiles.id = vm_interface.vnic_profile_id
       WHERE vnic_profiles.network_id = v_network_id
           AND vm_interface.vm_guid = vms.vm_guid);
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
 Create or replace FUNCTION GetVmsByVnicProfileId(v_vnic_profile_id UUID) RETURNS SETOF vms STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
    RETURN QUERY SELECT *
    FROM vms
@@ -1927,51 +1927,51 @@ BEGIN
       FROM vm_interface
       WHERE vm_interface.vnic_profile_id = v_vnic_profile_id
           AND vm_interface.vm_guid = vms.vm_guid);
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
 Create or replace FUNCTION GetVmsByClusterId(v_cluster_id UUID) RETURNS SETOF vms STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
       RETURN QUERY SELECT vms.*
       FROM vms
       WHERE cluster_id = v_cluster_id;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
 
 Create or replace FUNCTION GetVmsByVmPoolId(v_vm_pool_id UUID) RETURNS SETOF vms STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
       RETURN QUERY SELECT vms.*
       FROM vms
       WHERE vm_pool_id = v_vm_pool_id;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
 Create or replace FUNCTION GetFailedAutoStartVms() RETURNS SETOF vms STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
       RETURN QUERY SELECT vms.*
       FROM vms
       WHERE auto_startup = TRUE
           AND status = 0
           AND exit_status = 1;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 -- Get all running vms for cluster
 Create or replace FUNCTION GetRunningVmsByClusterId(v_cluster_id UUID) RETURNS SETOF vms STABLE
-    AS $procedure$
+    AS $FUNCTION$
 BEGIN
     RETURN QUERY SELECT DISTINCT vms.*
     FROM vms
     WHERE run_on_vds IS NOT NULL
         AND cluster_id = v_cluster_id;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 ---------------------
@@ -1979,22 +1979,22 @@ LANGUAGE plpgsql;
 ---------------------
 
 Create or replace FUNCTION GetVmInitByVmId(v_vm_id UUID) RETURNS SETOF vm_init STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
 RETURN QUERY SELECT vm_init.*
    FROM vm_init
    WHERE vm_id = v_vm_id;
 
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 Create or replace FUNCTION GetVmInitByids(v_vm_init_ids UUID[]) RETURNS SETOF vm_init STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
 RETURN QUERY SELECT *
      FROM vm_init
      WHERE vm_init.vm_id = ANY(v_vm_init_ids);
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -2020,7 +2020,7 @@ Create or replace FUNCTION UpdateVmInit(
     v_org_name VARCHAR(256),
     v_cloud_init_network_protocol VARCHAR(32)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE vm_init
     SET host_name = v_host_name,
@@ -2043,16 +2043,16 @@ BEGIN
         org_name = v_org_name,
         cloud_init_network_protocol = v_cloud_init_network_protocol
     WHERE vm_id = v_vm_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteVmInit (v_vm_id UUID)
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM vm_init
     WHERE vm_id = v_vm_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION InsertVmInit (
@@ -2077,7 +2077,7 @@ CREATE OR REPLACE FUNCTION InsertVmInit (
     v_org_name VARCHAR(256),
     v_cloud_init_network_protocol VARCHAR(32)
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO vm_init (
         vm_id,
@@ -2123,11 +2123,11 @@ BEGIN
         v_org_name,
         v_cloud_init_network_protocol
         );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVmIdsForVersionUpdate (v_base_template_id UUID)
-RETURNS SETOF UUID STABLE AS $PROCEDURE$
+RETURNS SETOF UUID STABLE AS $FUNCTION$
 BEGIN
     RETURN QUERY
 
@@ -2161,26 +2161,26 @@ BEGIN
                     )
                 )
             );
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateVmCpuProfileIdForClusterId (
     v_cluster_id UUID,
     v_cpu_profile_id UUID
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE vm_static
     SET cpu_profile_id = v_cpu_profile_id
     WHERE cluster_id = v_cluster_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION InsertDedicatedHostsToVm (
     v_vm_guid UUID,
     v_dedicated_vm_for_vds TEXT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO vm_host_pinning_map (
         vm_id,
@@ -2189,36 +2189,36 @@ BEGIN
     SELECT v_vm_guid,
         vds_id
     FROM fnSplitterUuid(v_dedicated_vm_for_vds) AS vds_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateDedicatedHostsToVm (
     v_vm_guid UUID,
     v_dedicated_vm_for_vds TEXT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     DELETE
     FROM vm_host_pinning_map
     WHERE vm_id = v_vm_guid;
 
     PERFORM InsertDedicatedHostsToVm(v_vm_guid, v_dedicated_vm_for_vds);
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVmsByCpuProfileIds(v_cpu_profile_ids UUID[])
 RETURNS SETOF vms STABLE
-AS $procedure$
+AS $FUNCTION$
 BEGIN
     RETURN QUERY SELECT vms.*
         FROM vms
         WHERE cpu_profile_id = ANY(v_cpu_profile_ids);
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetAllVmsRelatedToDiskProfiles(v_disk_profile_ids UUID[])
 RETURNS SETOF vms STABLE
-AS $procedure$
+AS $FUNCTION$
 BEGIN
   RETURN QUERY SELECT vms.*
       FROM vms
@@ -2227,31 +2227,31 @@ BEGIN
               AND images.active = TRUE
           INNER JOIN image_storage_domain_map ON image_storage_domain_map.image_id = images.image_guid
           WHERE image_storage_domain_map.disk_profile_id = ANY(v_disk_profile_ids);
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVmsByOrigin(v_origins INT[])
 RETURNS SETOF vms STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
     RETURN QUERY
     SELECT vms.*
         FROM vms
         WHERE origin = ANY(v_origins);
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION SetToUnknown (
     v_vm_ids UUID[],
     v_status INT
     )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     UPDATE vm_dynamic
     SET status = v_status
     WHERE vm_guid = ANY(v_vm_ids)
         AND run_on_vds IS NOT NULL;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -2259,13 +2259,13 @@ LANGUAGE plpgsql;
 
 Create or replace FUNCTION GetVmsWithLeaseOnStorageDomain(v_storage_domain_id UUID)
 RETURNS SETOF vm_static_view STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
     RETURN QUERY SELECT vm_static_view.*
     FROM vm_static_view
     WHERE lease_sd_id = v_storage_domain_id
         AND entity_type = 'VM';
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -2273,14 +2273,14 @@ LANGUAGE plpgsql;
 
 Create or replace FUNCTION GetActiveVmNamesWithLeaseOnStorageDomain(v_storage_domain_id UUID)
 RETURNS SETOF varchar(255) STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
     RETURN QUERY SELECT vs.vm_name
     FROM vm_static vs
     JOIN vm_dynamic vd ON vd.vm_guid = vs.vm_guid
     WHERE lease_sd_id = v_storage_domain_id
         AND vd.status <> 0;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -2288,14 +2288,14 @@ LANGUAGE plpgsql;
 
 Create or replace FUNCTION GetActiveVmNamesWithIsoOnStorageDomain(v_storage_domain_id UUID)
 RETURNS SETOF varchar(255) STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
     RETURN QUERY SELECT vd.vm_name
     FROM images_storage_domain_view image, vms_monitoring_view vd
     WHERE image.storage_id = v_storage_domain_id
     AND vd.status not in (0, 14, 15) -- Down, ImageIllegal, ImageLocked
     AND image.image_group_id::VARCHAR = vd.current_cd;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -2303,14 +2303,14 @@ LANGUAGE plpgsql;
 
 Create or replace FUNCTION GetActiveVmNamesWithIsoAttached(v_iso_disk_id UUID)
 RETURNS SETOF varchar(255) STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
     RETURN QUERY SELECT vs.vm_name
     FROM vm_static vs
     JOIN vm_dynamic vd ON vd.vm_guid = vs.vm_guid
     WHERE vs.iso_path = v_iso_disk_id::VARCHAR
         AND vd.status NOT IN (0, 14, 15);
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -2318,12 +2318,12 @@ LANGUAGE plpgsql;
 
 Create or replace FUNCTION GetVmNamesWithSpecificIsoAttached(v_iso_disk_id UUID)
 RETURNS SETOF varchar(255) STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
     RETURN QUERY SELECT vm.vm_name
     FROM vm_static vm
     WHERE vm.iso_path = v_iso_disk_id::VARCHAR;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -2331,12 +2331,12 @@ LANGUAGE plpgsql;
 
 Create or replace FUNCTION GetVmIdsWithSpecificIsoAttached(v_iso_disk_id UUID)
 RETURNS SETOF UUID STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
     RETURN QUERY SELECT vd.vm_guid
     FROM vm_dynamic vd
     WHERE vd.current_cd = v_iso_disk_id::VARCHAR;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -2344,24 +2344,24 @@ LANGUAGE plpgsql;
 
 Create or replace FUNCTION GetVmsStaticRunningOnVds(v_vds_id UUID)
 RETURNS SETOF vm_static_view STABLE
-   AS $procedure$
+   AS $FUNCTION$
 BEGIN
     RETURN QUERY SELECT vs.*
     FROM vm_static_view vs
     JOIN vm_dynamic vd ON vd.vm_guid = vs.vm_guid
     WHERE run_on_vds = v_vds_id;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetVmsPinnedToHost(v_host_id UUID)
 RETURNS SETOF vms STABLE
-    AS $procedure$
+    AS $FUNCTION$
 BEGIN
     RETURN QUERY SELECT vms.*
     FROM vms
         JOIN vm_host_pinning_map pin ON pin.vm_id = vms.vm_guid
     WHERE pin.vds_id = v_host_id;
-END; $procedure$
+END; $FUNCTION$
 LANGUAGE plpgsql;
 
 
@@ -2385,7 +2385,7 @@ CREATE OR REPLACE FUNCTION UpdateTpmData (
     v_tpm_data TEXT,
     v_tpm_hash TEXT
 )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO vm_external_data (
         device_id,
@@ -2400,23 +2400,23 @@ BEGIN
     UPDATE
     SET tpm_data = v_tpm_data,
         tpm_hash = v_tpm_hash;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteTpmData (
     v_vm_id UUID
 )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
     DELETE FROM vm_external_data
     WHERE vm_id = v_vm_id
-$PROCEDURE$
+$FUNCTION$
 LANGUAGE sql;
 
 CREATE OR REPLACE FUNCTION CopyTpmData (
     v_source_vm_id UUID,
     v_target_vm_id UUID
 )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 DECLARE
     v_device_id UUID := (SELECT device_id
                          FROM vm_device
@@ -2433,7 +2433,7 @@ BEGIN
         FROM vm_external_data
         WHERE vm_id = v_source_vm_id;
     END IF;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION GetNvramData (
@@ -2451,7 +2451,7 @@ CREATE OR REPLACE FUNCTION UpdateNvramData (
     v_nvram_data TEXT,
     v_nvram_hash TEXT
 )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO vm_nvram_data (
         vm_id,
@@ -2467,23 +2467,23 @@ BEGIN
     UPDATE
     SET nvram_data = v_nvram_data,
         nvram_hash = v_nvram_hash;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION DeleteNvramData (
     v_vm_id UUID
 )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
     DELETE FROM vm_nvram_data
     WHERE vm_id = v_vm_id
-$PROCEDURE$
+$FUNCTION$
 LANGUAGE sql;
 
 CREATE OR REPLACE FUNCTION CopyNvramData (
     v_source_vm_id UUID,
     v_target_vm_id UUID
 )
-RETURNS VOID AS $PROCEDURE$
+RETURNS VOID AS $FUNCTION$
 BEGIN
     INSERT INTO vm_nvram_data (
         vm_id,
@@ -2493,7 +2493,7 @@ BEGIN
     SELECT v_target_vm_id, nvram_data, nvram_hash
     FROM vm_nvram_data
     WHERE vm_id = v_source_vm_id;
-END;$PROCEDURE$
+END;$FUNCTION$
 LANGUAGE plpgsql;
 
 DROP TRIGGER


### PR DESCRIPTION
According to Postgres documentation a PROCEDURE executes SQL commands
and does not return any data.
In oVirt we are always returning a value (even VOID is considered as a
returned value), So we should use the term FUNCTION instead of PROCEDURE

This patch changes all relevant PROCEDURE declarations to a FUNCTION.
The patch is just a semantic change, was tested and can be safely
merged.

See also  https://bugzilla.redhat.com/2077794

Signed-off-by: Eli Mesika<emesika@redhat.com>