### PR TITLE
core: Prevent writing TPM device twice to OVA

### DIFF
--- a/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfWriter.java
+++ b/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/ovf/OvfWriter.java
@@ -481,6 +481,10 @@ public abstract class OvfWriter implements IOvfBuilder {
                     // mdev_type predefined property is written instead
                     continue;
                 }
+                if (device.getType() == VmDeviceGeneralType.TPM) {
+                    // TPM device has its own write method
+                    continue;
+                }
                 devices.add(device);
             }
         }


### PR DESCRIPTION
TPM device has its own method writing its OVF entry.  But as a special
device, it’s written the second time to OVF among other devices.  When
such an OVF is imported, the VM has two TPM devices, which is not
allowed by libvirt and the VM fails to start.

This patch prevents writing the second TPM device entry to OVF.

Bug-Url: https://bugzilla.redhat.com/2112702