### PR TITLE
LiveMerge: move getVolumeInfo to executeCommand

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/snapshots/RemoveSnapshotSingleDiskLiveCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/snapshots/RemoveSnapshotSingleDiskLiveCommand.java
@@ -60,6 +60,8 @@ public class RemoveSnapshotSingleDiskLiveCommand<T extends RemoveSnapshotSingleD
         // Let doPolling() drive the execution; we don't have any guarantee that
         // executeCommand() will finish before doPolling() is called, and we don't
         // want to possibly run the first command twice.
+        getParameters().setCommandStep(getInitialMergeStepForImage(getParameters().getImageId()));
+        getParameters().setChildCommands(new HashMap<>());
         setSucceeded(true); // Allow runAction to succeed
     }
 
@@ -83,17 +85,12 @@ public class RemoveSnapshotSingleDiskLiveCommand<T extends RemoveSnapshotSingleD
 
     @Override
     public boolean performNextOperation(int completedChildCount) {
-
         // Steps are executed such that:
         //  a) all logic before the command runs is idempotent
         //  b) the command is the last action in the step
         // This allows for recovery after a crash at any point during command execution.
 
         log.debug("Proceeding with execution of RemoveSnapshotSingleDiskLiveCommand");
-        if (getParameters().getCommandStep() == null) {
-            getParameters().setCommandStep(getInitialMergeStepForImage(getParameters().getImageId()));
-            getParameters().setChildCommands(new HashMap<>());
-        }
 
         // Upon recovery or after invoking a new child command, our map may be missing an entry
         syncChildCommandList(getParameters());


### PR DESCRIPTION
Call to GetVolumeInfo was added to RemoveSnapshotSingleDiskLive
command before performing the steps, in order to check if the
Destination image (or the Top Image) exists on storage. It was added
to the procedure, which is determining the initial merge step during
the first run of performNextOperation.

GetVolumeInfo is a synchronous call, and calling it from
performNextOperation can block the callback thread which may block
other commands from making progress. This change moves the procedure
of setting the initial merge step back to executeCommand(), like it
is in ColdMergeSnapshotSingleDisk command