### PR TITLE
Skip disk profiles validation on memory disk

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/profiles/DiskProfileHelper.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/profiles/DiskProfileHelper.java
@@ -18,6 +18,7 @@ import org.ovirt.engine.core.common.VdcObjectType;
 import org.ovirt.engine.core.common.businessentities.ActionGroup;
 import org.ovirt.engine.core.common.businessentities.aaa.DbUser;
 import org.ovirt.engine.core.common.businessentities.profiles.DiskProfile;
+import org.ovirt.engine.core.common.businessentities.storage.DiskContentType;
 import org.ovirt.engine.core.common.businessentities.storage.DiskImage;
 import org.ovirt.engine.core.common.businessentities.storage.DiskStorageType;
 import org.ovirt.engine.core.common.errors.EngineMessage;
@@ -61,6 +62,9 @@ public class DiskProfileHelper {
             if (diskImage.getDiskStorageType() != DiskStorageType.IMAGE) {
                 log.info("Disk profiles is not supported for storage type '{}' (Disk '{}')",
                         diskImage.getDiskStorageType(), diskImage.getDiskAlias());
+                continue;
+            }
+            if (!shouldSetDiskProfileOnImage(diskImage)) {
                 continue;
             }
             if (diskImage.getDiskProfileId() == null && storageDomainId != null) {
@@ -148,5 +152,10 @@ public class DiskProfileHelper {
                         ActionGroup.ATTACH_DISK_PROFILE,
                         diskProfile.getId(),
                         VdcObjectType.DiskProfile) != null;
+    }
+
+    private boolean shouldSetDiskProfileOnImage(DiskImage diskImage) {
+        return !(diskImage.getContentType() == DiskContentType.MEMORY_DUMP_VOLUME
+                || diskImage.getContentType() == DiskContentType.MEMORY_METADATA_VOLUME);
     }
 }


### PR DESCRIPTION
When we create the memory or metadata disks they are a result of live
snapshot with memory or hibernation command. In some cases the user can
own the VM, including the option to execute the above command but he may
not have the disk profile permission to add those disks.

This patch will skip the permission validation in those cases, allowing
a user that owns the VM and capable of executing the command to not fail
on the underlying addDisk command.

Change-Id: Ib04048d652c8d98df84ffccc4babd71730b218dc
Bug-Url: https://bugzilla.redhat.com/1565183
Signed-off-by: Liran Rotenberg <lrotenbe@redhat.com>