### PR TITLE
packaging: setup: Always use formerly-engine-specific PostgreSql conf

### DIFF
--- a/packaging/setup/ovirt_engine_setup/engine_common/database.py
+++ b/packaging/setup/ovirt_engine_setup/engine_common/database.py
@@ -26,6 +26,7 @@ from ovirt_engine import util as outil
 from ovirt_engine_setup import constants as osetupcons
 from ovirt_engine_setup import util as osetuputil
 from ovirt_engine_setup.engine_common import constants as oengcommcons
+from ovirt_engine_setup.engine_common.constants import ProvisioningEnv
 
 from ovirt_setup_lib import dialog
 from ovirt_setup_lib import hostname as osetuphostname
@@ -952,6 +953,78 @@ class OvirtUtils(base.Base):
             oengcommcons.ProvisioningEnv.POSTGRES_EXTRA_CONFIG_ITEMS,
             ()
         ) + (
+            {
+                'key': 'autovacuum_vacuum_scale_factor',
+                'expected': self.environment[
+                    ProvisioningEnv.PG_AUTOVACUUM_VACUUM_SCALE_FACTOR
+                ],
+                'ok': lambda key, current, expected: (
+                    float(current) <= float(expected)
+                ),
+                'check_on_use': True,
+                'needed_on_create': True,
+                'error_msg': '{specific}'.format(
+                    specific='%s' % AT_MOST_EXPECTED,
+                )
+            },
+            {
+                'key': 'autovacuum_analyze_scale_factor',
+                'expected': self.environment[
+                    ProvisioningEnv.PG_AUTOVACUUM_ANALYZE_SCALE_FACTOR
+                ],
+                'ok': lambda key, current, expected: (
+                    float(current) <= float(expected)
+                ),
+                'check_on_use': True,
+                'needed_on_create': True,
+                'error_msg': '{specific}'.format(
+                    specific=AT_MOST_EXPECTED,
+                )
+            },
+            {
+                'key': 'autovacuum_max_workers',
+                'expected': self.environment[
+                    ProvisioningEnv.PG_AUTOVACUUM_MAX_WORKERS
+                ],
+                'ok': lambda key, current, expected: (
+                    int(current) >= int(expected)
+                ),
+                'check_on_use': True,
+                'needed_on_create': True,
+                'error_msg': '{specific}'.format(
+                    specific=AT_LEAST_EXPECTED,
+                )
+            },
+            {
+                'key': 'maintenance_work_mem',
+                'expected': self.environment[
+                    ProvisioningEnv.PG_AUTOVACUUM_MAINTENANCE_WORK_MEM
+                ],
+                'useQueryForValue': True,
+                'ok': lambda key, current, expected: (
+                    int(current) >= int(expected)
+                ),
+                'check_on_use': True,
+                'needed_on_create': True,
+                'error_msg': '{specific}'.format(
+                    specific='%s' % AT_LEAST_EXPECTED,
+                )
+            },
+            {
+                'key': 'work_mem',
+                'expected': self.environment[
+                    ProvisioningEnv.PG_WORK_MEM_KB
+                ],
+                'useQueryForValue': True,
+                'ok': lambda key, current, expected: (
+                    int(current) >= int(expected)
+                ),
+                'check_on_use': True,
+                'needed_on_create': True,
+                'error_msg': '{specific}'.format(
+                    specific='%s' % AT_LEAST_EXPECTED,
+                )
+            },
             {
                 'key': 'server_encoding',
                 'expected': 'UTF8',

--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/db/configuration.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/db/configuration.py
@@ -18,7 +18,6 @@ from ovirt_engine_setup.engine import constants as oenginecons
 from ovirt_engine_setup.engine_common import constants as oengcommcons
 from ovirt_engine_setup.engine_common import database
 from ovirt_engine_setup.engine_common import postgres
-from ovirt_engine_setup.engine_common.constants import ProvisioningEnv
 
 
 def _(m):
@@ -67,82 +66,6 @@ class Plugin(plugin.PluginBase):
         elif autofix_approved.upper() == _("No").upper():
             raise RuntimeError(_('Aborted by user'))
 
-    def _pg_conf_items(self):
-        return (
-            {
-                'key': 'autovacuum_vacuum_scale_factor',
-                'expected': self.environment[
-                    ProvisioningEnv.PG_AUTOVACUUM_VACUUM_SCALE_FACTOR
-                ],
-                'ok': lambda key, current, expected: (
-                    float(current) <= float(expected)
-                ),
-                'check_on_use': True,
-                'needed_on_create': True,
-                'error_msg': '{specific}'.format(
-                    specific='%s' % database.AT_MOST_EXPECTED,
-                )
-            },
-            {
-                'key': 'autovacuum_analyze_scale_factor',
-                'expected': self.environment[
-                    ProvisioningEnv.PG_AUTOVACUUM_ANALYZE_SCALE_FACTOR
-                ],
-                'ok': lambda key, current, expected: (
-                    float(current) <= float(expected)
-                ),
-                'check_on_use': True,
-                'needed_on_create': True,
-                'error_msg': '{specific}'.format(
-                    specific=database.AT_MOST_EXPECTED,
-                )
-            },
-            {
-                'key': 'autovacuum_max_workers',
-                'expected': self.environment[
-                    ProvisioningEnv.PG_AUTOVACUUM_MAX_WORKERS
-                ],
-                'ok': lambda key, current, expected: (
-                    int(current) >= int(expected)
-                ),
-                'check_on_use': True,
-                'needed_on_create': True,
-                'error_msg': '{specific}'.format(
-                    specific=database.AT_LEAST_EXPECTED,
-                )
-            },
-            {
-                'key': 'maintenance_work_mem',
-                'expected': self.environment[
-                    ProvisioningEnv.PG_AUTOVACUUM_MAINTENANCE_WORK_MEM
-                ],
-                'useQueryForValue': True,
-                'ok': lambda key, current, expected: (
-                    int(current) >= int(expected)
-                ),
-                'check_on_use': True,
-                'needed_on_create': True,
-                'error_msg': '{specific}'.format(
-                    specific='%s' % database.AT_LEAST_EXPECTED,
-                )
-            },
-            {
-                'key': 'work_mem',
-                'expected': self.environment[
-                    ProvisioningEnv.PG_WORK_MEM_KB
-                ],
-                'useQueryForValue': True,
-                'ok': lambda key, current, expected: (
-                    int(current) >= int(expected)
-                ),
-                'check_on_use': True,
-                'needed_on_create': True,
-                'error_msg': '{specific}'.format(
-                    specific='%s' % database.AT_LEAST_EXPECTED,
-                )
-            },
-        )
-
     # Checks if uuid-ossp extension was installed in DB
     def _uuidOsspInstalled(self):
         dbstatement = database.Statement(
@@ -178,14 +101,6 @@ class Plugin(plugin.PluginBase):
             oengcommcons.ProvisioningEnv.POSTGRES_EXTRA_CONFIG_ITEMS,
             ()
         )
-
-    @plugin.event(
-        stage=plugin.Stages.STAGE_SETUP,
-    )
-    def _setup(self):
-        self.environment[
-            oengcommcons.ProvisioningEnv.POSTGRES_EXTRA_CONFIG_ITEMS
-        ] += self._pg_conf_items()
 
     @plugin.event(
         stage=plugin.Stages.STAGE_CUSTOMIZATION,


### PR DESCRIPTION
We currently have two sets of configuration items for PG: One is common
to all DBs, another is specific to the engine. Unite them, by moving the
engine-specific set to the common one.

Cases where this is relevant:

1. Right now, 'engine-backup --mode=restore --provision-all-databases'
does not configure the engine-specific items. This causes a next run of
'engine-setup' (which is mandatory) to prompt, asking whether to
configure them.

2. Trying to pre-create DBs using provisiondb, like I am now trying [1],
leaves postgresql.conf without the engine-specific set. This is worse
than in (1.), as the code prompting/asking works only with non-new
databases. It's not a real issue for [1] specifically, because I can
easily do this there, but decided it's better to patch engine-setup
directly.

This has no impact on the common case, where all DBs are local, as this
configuration is PG-cluster-wide, not DB-specific.

The main impact is on DWH running on a separate machine, with the
database local to that machine. If the DWH DB is remote, our
documentation already instructs to configure all items, not separating
to two sets.

[1] https://github.com/oVirt/ovirt-system-tests/pull/241

Change-Id: Ief318aa5551cec2d778cf791926518effe404da2
Signed-off-by: Yedidyah Bar David <didi@redhat.com>