### PR TITLE
pack_ova: Use tarfile.GNU_FORMAT

### DIFF
--- a/packaging/ansible-runner-service-project/project/roles/ovirt-ova-pack/files/pack_ova.py
+++ b/packaging/ansible-runner-service-project/project/roles/ovirt-ova-pack/files/pack_ova.py
@@ -67,7 +67,9 @@ def write_padding_file(ova_file, padding_size):
     # file_size - the size of the padding file
     #             (minus one block for the header).
     tar_info = create_tar_info("pad", file_size)
-    ova_file.write(tar_info.tobuf())
+    buf = (tar_info.tobuf() if python2 else
+           tar_info.tobuf(format=tarfile.GNU_FORMAT))
+    ova_file.write(buf)
     pad_to_block_size(ova_file)
     if file_size:
         ova_file.write(NUL * file_size)


### PR DESCRIPTION
We missed one place in https://github.com/oVirt/ovirt-engine/pull/374.

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
