### PR TITLE
Allow running CI on master and any ovirt-engine-4.5* branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,9 @@
 name: build
 on:
   push:
-    branches: [master, ovirt-engine-4.5.0.z]
+    branches: [master, ovirt-engine-4.5*]
   pull_request:
-    branches: [master, ovirt-engine-4.5.0.z]
+    branches: [master, ovirt-engine-4.5*]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Add ovirt-engine-4.5* string to branches specification to remove the
need to allow running CI on every new 4.5 branch in future

Signed-off-by: Martin Perina <mperina@redhat.com>
