### PR TITLE
Fix checking ovirt-provider-ovn certificate validity

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/CertificationValidityChecker.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/CertificationValidityChecker.java
@@ -125,6 +125,7 @@ public class CertificationValidityChecker implements BackendService {
             AuditLogType alertExpirationEventType,
             AuditLogType alertAboutToExpireEventType,
             AuditLogType warnAboutToExpireEventType) {
+        log.debug("Checking optional certificate '{}'.", certFile.getAbsolutePath());
         if (certFile == null || !certFile.exists()) {
             // certificate file doesn't exist, which may be OK, as the service using the certificate is optional
             return true;

--- a/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/EngineLocalConfig.java
+++ b/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/EngineLocalConfig.java
@@ -213,7 +213,7 @@ public class EngineLocalConfig extends ShellLikeConfd {
     }
 
     public File getPKIOvirtProviderOVNCert() {
-        return Paths.get(getProperty("ENGINE_PKI"), "ovirt-provider-ovn.cer").toFile();
+        return Paths.get(getProperty("ENGINE_PKI"), "certs", "ovirt-provider-ovn.cer").toFile();
     }
 
     public String getPKITrustStoreType() {


### PR DESCRIPTION
There was added an ovirt-provider-ovn certificate validity check as
a part of https://github.com/oVirt/ovirt-engine/pull/576 but
unfortunately the path to certificate file was wrong and as this
certificate is optional (it doesn't exists on setup with OVN integration
disable), the certificate validity checker didn't raise any error even
for setups with OVN integration enabled and ovirt-provider-ovn
certificate going to expire soon.

Bug-Url: https://bugzilla.redhat.com/2097560
Signed-off-by: Martin Perina <mperina@redhat.com>
