### PR TITLE
Fix build on system using a language other than English.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -618,7 +618,7 @@
           </dependencies>
           <configuration>
             <reportsDirectory>${ovirt.surefire.reportsDirectory}</reportsDirectory>
-            <argLine>--illegal-access=permit</argLine>
+			<argLine>--illegal-access=permit -Duser.country=US -Duser.language=en</argLine>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
When you build ovirt-engine on a system where a language other than
English is setted, Maven Surefire uses it a default language and select
MessageBundles according to this, making some tests fail.

This commit set English and US explicitly as default language and
country in the POM, allowing Surefire to pick the right properties files
during tests.

Bug-URL: https://bugzilla.redhat.com/show_bug.cgi?id=2120066