### PR TITLE
core: Remove image if CreateSnapshotFromTemplateCommand failed

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/snapshots/CreateSnapshotFromTemplateCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/snapshots/CreateSnapshotFromTemplateCommand.java
@@ -18,6 +18,7 @@ import org.ovirt.engine.core.compat.Guid;
 import org.ovirt.engine.core.dal.dbbroker.auditloghandling.AuditLogDirector;
 import org.ovirt.engine.core.dao.BaseDiskDao;
 import org.ovirt.engine.core.dao.DiskImageDynamicDao;
+import org.ovirt.engine.core.dao.ImageDao;
 
 /**
  * This command responsible to creating new snapshot. Usually it will be called
@@ -41,6 +42,8 @@ public class CreateSnapshotFromTemplateCommand<T extends CreateSnapshotFromTempl
     private BaseDiskDao baseDiskDao;
     @Inject
     private DiskImageDynamicDao diskImageDynamicDao;
+    @Inject
+    private ImageDao imageDao;
 
     public CreateSnapshotFromTemplateCommand(T parameters, CommandContext cmdContext) {
         super(parameters, cmdContext);
@@ -88,6 +91,9 @@ public class CreateSnapshotFromTemplateCommand<T extends CreateSnapshotFromTempl
             baseDiskDao.remove(getDestinationDiskImage().getId());
             if (diskImageDynamicDao.get(getDestinationDiskImage().getImageId()) != null) {
                 diskImageDynamicDao.remove(getDestinationDiskImage().getImageId());
+            }
+            if (imageDao.get(getDestinationDiskImage().getImageId()) != null) {
+                imageDao.remove(getDestinationDiskImage().getImageId());
             }
         }
 


### PR DESCRIPTION
In some scenarios CreateSnapshotFromTemplateCommand fails after creation
of the record in the images table. In this case the record should be
removed together with other DB records related to the disk.

Change-Id: I201b49b9acd052c733c4d418abbac3b16c9431d5
Bug-Url: https://bugzilla.redhat.com/2110351
Signed-off-by: Shmuel Melamud <smelamud@redhat.com>