### PR TITLE
core: Allow RunOnce for single non-bootable disk

### DIFF
--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/utils/VmDeviceCommonUtils.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/utils/VmDeviceCommonUtils.java
@@ -237,21 +237,32 @@ public class VmDeviceCommonUtils {
             Map<VmDeviceId, DiskVmElement> deviceIdTodiskVmElement) {
         LinkedList<VmDevice> diskDevices = new LinkedList<>();
         for (VmDevice device : devices) {
-            if (isDisk(device)) {
-                Guid id = device.getDeviceId();
-                if (id != null && !id.equals(Guid.Empty)) {
-                    if (device.getSnapshotId() == null) {
-                        diskDevices.addFirst(device);
-                    } else {
-                        diskDevices.addLast(device);
-                    }
-                }
+            if (!isDisk(device)) {
+                continue;
             }
+            Guid id = device.getDeviceId();
+            if (id == null || id.equals(Guid.Empty)) {
+                continue;
+            }
+            DiskVmElement dve = deviceIdTodiskVmElement.get(device.getId());
+            if (dve == null) {
+                continue;
+            }
+            if (device.getSnapshotId() == null) {
+                diskDevices.addFirst(device);
+            } else {
+                diskDevices.addLast(device);
+            }
+        }
+
+        if (diskDevices.size() == 1) {
+            diskDevices.get(0).setBootOrder(++bootOrder);
+            return bootOrder;
         }
 
         for (VmDevice device : diskDevices) {
             DiskVmElement dve = deviceIdTodiskVmElement.get(device.getId());
-            if (dve != null && dve.isBoot()) {
+            if (dve.isBoot()) {
                 device.setBootOrder(++bootOrder);
             }
         }

--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/RunOnceModel.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/RunOnceModel.java
@@ -962,6 +962,9 @@ public abstract class RunOnceModel extends Model {
     }
 
     private boolean isDisksContainBootableDisk(List<Disk> disks) {
+        if (disks.size() == 1) {
+            return true;
+        }
         for (Disk disk : disks) {
             if (disk.getDiskVmElementForVm(vm.getId()).isBoot()) {
                 return true;


### PR DESCRIPTION
If a VM contains a single disk not marked as bootable, RunVmCommand
allows to boot OS from this disk. But RunOnce ignores this disk when
setting the boot order. This patch fixes this inconsistence.

Change-Id: Ia5652bb1549bdd5205284be355e3a2903fb6e9f1
Signed-off-by: Shmuel Melamud <smelamud@redhat.com>