### PR TITLE
Move lifecycle-mapping plugin into Eclipse specific profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -631,58 +631,6 @@
           <artifactId>exec-maven-plugin</artifactId>
           <version>${exec-maven-plugin.version}</version>
         </plugin>
-        <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
-        <plugin>
-            <groupId>org.eclipse.m2e</groupId>
-            <artifactId>lifecycle-mapping</artifactId>
-            <version>1.0.0</version>
-            <configuration>
-                <lifecycleMappingMetadata>
-                    <pluginExecutions>
-                        <pluginExecution>
-                            <pluginExecutionFilter>
-                                <groupId>org.apache.maven.plugins</groupId>
-                                <artifactId>maven-checkstyle-plugin</artifactId>
-                                <versionRange>[2.6,)</versionRange>
-                                <goals>
-                                    <goal>check</goal>
-                                </goals>
-                            </pluginExecutionFilter>
-                            <action>
-                                <ignore/>
-                            </action>
-                        </pluginExecution>
-                        <pluginExecution>
-                            <pluginExecutionFilter>
-                                <groupId>org.codehaus.mojo</groupId>
-                                <artifactId>javacc-maven-plugin</artifactId>
-                                <versionRange>[${javacc.version},)</versionRange>
-                                <goals>
-                                    <goal>javacc</goal>
-                                </goals>
-                            </pluginExecutionFilter>
-                            <action>
-                                <execute />
-                            </action>
-                        </pluginExecution>
-                        <pluginExecution>
-                            <pluginExecutionFilter>
-                                <groupId>org.codehaus.mojo</groupId>
-                                <artifactId>exec-maven-plugin</artifactId>
-                                <versionRange>[${exec-maven-plugin.version},)</versionRange>
-                                <goals>
-                                    <goal>java</goal>
-                                    <goal>exec</goal>
-                                </goals>
-                            </pluginExecutionFilter>
-                            <action>
-                                <execute />
-                            </action>
-                        </pluginExecution>
-                    </pluginExecutions>
-                </lifecycleMappingMetadata>
-            </configuration>
-        </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>taglist-maven-plugin</artifactId>
@@ -859,6 +807,72 @@
             </configuration>
           </plugin>
         </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>only-eclipse</id>
+      <activation>
+        <property>
+          <name>m2e.version</name>
+        </property>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+            <plugin>
+              <groupId>org.eclipse.m2e</groupId>
+              <artifactId>lifecycle-mapping</artifactId>
+              <version>1.0.0</version>
+              <configuration>
+                <lifecycleMappingMetadata>
+                    <pluginExecutions>
+                        <pluginExecution>
+                            <pluginExecutionFilter>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-checkstyle-plugin</artifactId>
+                                <versionRange>[2.6,)</versionRange>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </pluginExecutionFilter>
+                            <action>
+                                <ignore/>
+                            </action>
+                        </pluginExecution>
+                        <pluginExecution>
+                            <pluginExecutionFilter>
+                                <groupId>org.codehaus.mojo</groupId>
+                                <artifactId>javacc-maven-plugin</artifactId>
+                                <versionRange>[${javacc.version},)</versionRange>
+                                <goals>
+                                    <goal>javacc</goal>
+                                </goals>
+                            </pluginExecutionFilter>
+                            <action>
+                                <execute />
+                            </action>
+                        </pluginExecution>
+                        <pluginExecution>
+                            <pluginExecutionFilter>
+                                <groupId>org.codehaus.mojo</groupId>
+                                <artifactId>exec-maven-plugin</artifactId>
+                                <versionRange>[${exec-maven-plugin.version},)</versionRange>
+                                <goals>
+                                    <goal>java</goal>
+                                    <goal>exec</goal>
+                                </goals>
+                            </pluginExecutionFilter>
+                            <action>
+                                <execute />
+                            </action>
+                        </pluginExecution>
+                    </pluginExecutions>
+                </lifecycleMappingMetadata>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
       </build>
     </profile>
   </profiles>


### PR DESCRIPTION
org.eclipse.m2e:lifecycle-mapping plugin is used only when the project
is edited in Eclipse IDE, it's not relevant for other maven invocation.
Unfortunately it emits bellow warning during maven execution:

 [WARNING] The POM for org.eclipse.m2e:lifecycle-mapping:jar:1.0.0 is missing, no dependency information available
 [WARNING] Failed to retrieve plugin descriptor for org.eclipse.m2e:lifecycle-mapping:1.0.0: Plugin org.eclipse.m2e:lifecycle-mapping:1.0.0 or one of its dependencies could not be resolved: Failed to read artifact descriptor for org.eclipse.m2e:lifecycle-mapping:jar:1.0.0

So this patches moves the plugin invocation into its own profile, which
is automatically invoked only when a project is loaded into Eclipse
IDE.

Signed-off-by: Martin Perina <mperina@redhat.com>
