### PR TITLE
webadmin: remove the validation for a new template

### DIFF
--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/VmListModel.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/VmListModel.java
@@ -1303,9 +1303,7 @@ public class VmListModel<E> extends VmBaseListModel<E, VM>
             return;
         }
 
-        if (!model.validate(false)) {
-            model.setIsValid(false);
-        } else  if (model.getIsSubTemplate().getEntity()) {
+        if (model.getIsSubTemplate().getEntity()) {
             postNameUniqueCheck();
         } else {
             String name = model.getName().getEntity();


### PR DESCRIPTION
When we create a new template, it is not possible to change almost any value defined in the original VM.
Therefore, it does not make sense to validate on the UI, because the user cannot do anything if the validation fails.
Moreover, if the validation fails, there is no way to display the results to the user - the dialog just stays open with no message displayed.

When we remove the validation on the UI, we will depend on the backend validations and if something fails, the backend error messages would be displayed to the user.

Note that the exception from this is the check for the duplicate name, that is performed separately and will be preserved as frontend check. In this case, the name field is marked as not valid with proper error message.