### PR TITLE
setup: Put unique name to remote engine cleanup event

### DIFF
--- a/packaging/setup/ovirt_engine_setup/constants.py
+++ b/packaging/setup/ovirt_engine_setup/constants.py
@@ -223,6 +223,8 @@ class Stages(object):
 
     SETUP_SELINUX = 'osetup.setup.selinux'
 
+    REMOTE_ENGINE_CLEANUP = 'osetup.remote.engine.cleanup'
+
 
 @util.export
 @util.codegen

--- a/packaging/setup/plugins/ovirt-engine-common/base/remote_engine/remote_engine.py
+++ b/packaging/setup/plugins/ovirt-engine-common/base/remote_engine/remote_engine.py
@@ -65,6 +65,7 @@ class Plugin(plugin.PluginBase):
         ] = remote_engine.RemoteEngine(plugin=self)
 
     @plugin.event(
+        name=osetupcons.Stages.REMOTE_ENGINE_CLEANUP,
         stage=plugin.Stages.STAGE_CLOSEUP,
     )
     def _cleanup(self):


### PR DESCRIPTION
Some actions need to be executed in closeup stage before remote engine
is cleaned up, so the clean up action need to have unique name.

Bug-Url: https://bugzilla.redhat.com/2122174
Signed-off-by: Martin Perina <mperina@redhat.com>

Corresponding DWH change: https://github.com/oVirt/ovirt-dwh/pull/49