### PR TITLE
Refactor LiveMigrateDiskParameters & MoveOrCopyImageGroupParameters

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/MoveImageGroupCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/MoveImageGroupCommand.java
@@ -64,7 +64,7 @@ public class MoveImageGroupCommand<T extends MoveOrCopyImageGroupParameters> ext
 
     @Override
     protected void endWithFailure() {
-        removeImage(getParameters().getStorageDomainId());
+        removeImage(getParameters().getDestDomainId());
         unLockImage();
     }
 

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/LiveMigrateDiskParameters.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/LiveMigrateDiskParameters.java
@@ -27,10 +27,6 @@ public class LiveMigrateDiskParameters extends MoveOrCopyImageGroupParameters {
         setDiskProfileId(diskProfileId);
     }
 
-    public Guid getSourceStorageDomainId() {
-        return getSourceDomainId();
-    }
-
     public Guid getTargetStorageDomainId() {
         return getStorageDomainId();
     }

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/LiveMigrateDiskParameters.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/LiveMigrateDiskParameters.java
@@ -27,10 +27,6 @@ public class LiveMigrateDiskParameters extends MoveOrCopyImageGroupParameters {
         setDiskProfileId(diskProfileId);
     }
 
-    public Guid getTargetStorageDomainId() {
-        return getStorageDomainId();
-    }
-
     private Guid vmId;
 
     public Guid getVmId() {

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/MoveOrCopyImageGroupParameters.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/MoveOrCopyImageGroupParameters.java
@@ -159,8 +159,8 @@ public class MoveOrCopyImageGroupParameters extends ImagesContainterParametersBa
         return sourceDomainId;
     }
 
-    public void setSourceDomainId(Guid value) {
-        sourceDomainId = value;
+    public void setSourceDomainId(Guid sourceDomainId) {
+        this.sourceDomainId = sourceDomainId;
     }
 
     public ImageDbOperationScope getRevertDbOperationScope() {

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/MoveOrCopyImageGroupParameters.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/MoveOrCopyImageGroupParameters.java
@@ -11,6 +11,8 @@ import org.ovirt.engine.core.common.businessentities.storage.VolumeFormat;
 import org.ovirt.engine.core.common.businessentities.storage.VolumeType;
 import org.ovirt.engine.core.compat.Guid;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 public class MoveOrCopyImageGroupParameters extends ImagesContainterParametersBase {
     private static final long serialVersionUID = -5874446297123213719L;
     private ImageOperation operation;
@@ -41,7 +43,7 @@ public class MoveOrCopyImageGroupParameters extends ImagesContainterParametersBa
             ImageOperation operation) {
         super(imageId);
         setSourceDomainId(sourceDomainId);
-        setStorageDomainId(destDomainId);
+        setDestDomainId(destDomainId);
         setOperation(operation);
         volumeFormat = VolumeFormat.UNUSED0;
         volumeType = VolumeType.Unassigned;
@@ -49,9 +51,9 @@ public class MoveOrCopyImageGroupParameters extends ImagesContainterParametersBa
     }
 
     public MoveOrCopyImageGroupParameters(Guid containerId, Guid imageGroupId, Guid leafSnapshotID,
-            Guid storageDomainId, ImageOperation operation) {
+            Guid destDomainId, ImageOperation operation) {
         super(leafSnapshotID, containerId);
-        setStorageDomainId(storageDomainId);
+        setDestDomainId(destDomainId);
         setImageGroupID(imageGroupId);
         setOperation(operation);
         setUseCopyCollapse(false);
@@ -161,6 +163,15 @@ public class MoveOrCopyImageGroupParameters extends ImagesContainterParametersBa
 
     public void setSourceDomainId(Guid sourceDomainId) {
         this.sourceDomainId = sourceDomainId;
+    }
+
+    @JsonIgnore
+    public Guid getDestDomainId() {
+        return getStorageDomainId();
+    }
+
+    public void setDestDomainId(Guid destDomainId) {
+        setStorageDomainId(destDomainId);
     }
 
     public ImageDbOperationScope getRevertDbOperationScope() {


### PR DESCRIPTION
Commands performing actions on 2 Storage Domains (source & destination) use `MoveOrCopyImageGroupParameters` or its subclasses.
Until `MoveOrCopyImageGroupParameters` there was only 1 Storage Domain used - the one that the action was performed on.
The support for source Storage Domain ID was added in `MoveOrCopyImageGroupParameters`, while the already existing (in `StorageDomainParametersBase` superclass) Storage Domain ID was implicitly used as the destination Storage Domain ID.
Some additional support to easier reference source & destination Storage Domains' IDs was added in `LiveMigrateDiskParameters`.
Still there were a few issues - a missing clear destination Storage Domain ID setter and also inconsistent naming between the classes.

Refactoring the code to add the full and naming-consistent source & destination Storage Domains' IDs getters and setters in the `MoveOrCopyImageGroupParameters` class, which will be inherited by its subclasses (i.e., `LiveMigrateDiskParameters`).