### PR TITLE
Require extra 8 GiB free space on the destination Storage Domain in the LSM flows

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/MoveOrCopyDiskCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/MoveOrCopyDiskCommand.java
@@ -270,16 +270,7 @@ public class MoveOrCopyDiskCommand<T extends MoveOrCopyImageGroupParameters> ext
             return true;
         }
 
-        List<Guid> sdsToValidate = new ArrayList<>();
-        sdsToValidate.add(getStorageDomainId());
-
-        if (getActionType() == ActionType.LiveMigrateDisk) {
-            sdsToValidate.add(getParameters().getSourceDomainId());
-        }
-
-        MultipleStorageDomainsValidator storageDomainsValidator =
-                createMultipleStorageDomainsValidator(sdsToValidate);
-
+        MultipleStorageDomainsValidator storageDomainsValidator = createMultipleStorageDomainsValidator();
         if (validate(storageDomainsValidator.allDomainsWithinThresholds())) {
             // If we are copying a template's disk we do not want all its copies
             if (getImage().getVmEntityType() == VmEntityType.TEMPLATE) {
@@ -724,7 +715,10 @@ public class MoveOrCopyDiskCommand<T extends MoveOrCopyImageGroupParameters> ext
                 diskVmElementDao.getAllDiskVmElementsByDiskId(getParameters().getImageGroupID()));
     }
 
-    public MultipleStorageDomainsValidator createMultipleStorageDomainsValidator(List<Guid> sdsToValidate) {
+    protected MultipleStorageDomainsValidator createMultipleStorageDomainsValidator() {
+        List<Guid> sdsToValidate = new ArrayList<>();
+        sdsToValidate.add(getStorageDomainId());
+
         return new MultipleStorageDomainsValidator(getStoragePoolId(), sdsToValidate);
     }
 

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/lsm/LiveMigrateDiskCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/lsm/LiveMigrateDiskCommand.java
@@ -1,5 +1,6 @@
 package org.ovirt.engine.core.bll.storage.lsm;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -25,6 +26,7 @@ import org.ovirt.engine.core.bll.storage.utils.VdsCommandsHelper;
 import org.ovirt.engine.core.bll.tasks.CommandHelper;
 import org.ovirt.engine.core.bll.tasks.interfaces.CommandCallback;
 import org.ovirt.engine.core.bll.utils.PermissionSubject;
+import org.ovirt.engine.core.bll.validator.storage.MultipleStorageDomainsValidator;
 import org.ovirt.engine.core.bll.validator.storage.StorageDomainValidator;
 import org.ovirt.engine.core.common.AuditLogType;
 import org.ovirt.engine.core.common.FeatureSupported;
@@ -656,10 +658,6 @@ public class LiveMigrateDiskCommand<T extends LiveMigrateDiskParameters> extends
     }
 
     protected boolean validateDestDomainsSpaceRequirements() {
-        if (!isStorageDomainWithinThresholds(getDstStorageDomain())) {
-            return false;
-        }
-
         DiskImage diskImage = getDiskImageByImageId(getParameters().getImageId());
         List<DiskImage> allImageSnapshots = diskImageDao.getAllSnapshotsForLeaf(diskImage.getImageId());
         diskImage.getSnapshots().addAll(allImageSnapshots);
@@ -672,8 +670,14 @@ public class LiveMigrateDiskCommand<T extends LiveMigrateDiskParameters> extends
         return true;
     }
 
-    protected boolean isStorageDomainWithinThresholds(StorageDomain storageDomain) {
-        return validate(new StorageDomainValidator(storageDomain).isDomainWithinThresholds());
+    @Override
+    protected MultipleStorageDomainsValidator createMultipleStorageDomainsValidator() {
+        List<Guid> sdsToValidate = new ArrayList<>();
+
+        sdsToValidate.add(getParameters().getSourceDomainId());
+        sdsToValidate.add(getParameters().getDestDomainId());
+
+        return new MultipleStorageDomainsValidator(getStoragePoolId(), sdsToValidate);
     }
 
     private DiskImage getDiskImageByImageId(Guid imageId) {

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/lsm/LiveMigrateDiskCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/lsm/LiveMigrateDiskCommand.java
@@ -707,7 +707,17 @@ public class LiveMigrateDiskCommand<T extends LiveMigrateDiskParameters> extends
     }
 
     protected StorageDomainValidator createStorageDomainValidator(StorageDomain storageDomain) {
-        return new StorageDomainValidator(storageDomain);
+        return new StorageDomainValidator(storageDomain) {
+            @Override
+            protected double getTotalSizeForClonedDisk(DiskImage diskImage) {
+                double basicSize = super.getTotalSizeForClonedDisk(diskImage);
+                // Add additional snapshot overhead (relevant only for Live Storage flow, cluster version 4.7 or above).
+                if (FeatureSupported.isReplicateExtendSupported(getCluster().getCompatibilityVersion())) {
+                    basicSize += ImagesHandler.computeImageInitialSizeInBytes(diskImage.getImage());
+                }
+                return basicSize;
+            }
+        };
     }
 
     @Override

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/validator/storage/StorageDomainValidator.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/validator/storage/StorageDomainValidator.java
@@ -159,7 +159,7 @@ public class StorageDomainValidator {
      * currently in the VDSM code.
      *
      * */
-    private double getTotalSizeForClonedDisk(DiskImage diskImage) {
+    protected double getTotalSizeForClonedDisk(DiskImage diskImage) {
         double sizeForDisk = ImagesHandler.getTotalActualSizeOfDisk(diskImage, storageDomain.getStorageStaticData());
 
         if (diskImage.getVolumeFormat() == VolumeFormat.COW) {

--- a/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/storage/disk/MoveOrCopyDiskCommandTest.java
+++ b/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/storage/disk/MoveOrCopyDiskCommandTest.java
@@ -394,7 +394,7 @@ public class MoveOrCopyDiskCommandTest extends BaseCommandTest {
         vm.setStatus(VMStatus.Down);
         when(vmDao.get(any())).thenReturn(vm);
 
-        doReturn(multipleStorageDomainsValidator).when(command).createMultipleStorageDomainsValidator(any());
+        doReturn(multipleStorageDomainsValidator).when(command).createMultipleStorageDomainsValidator();
         doReturn(multipleDiskVmElementValidator).when(command).createMultipleDiskVmElementValidator();
         doReturn(diskValidator).when(command).createDiskValidator(disk);
         doReturn(diskImagesValidator).when(command).createDiskImagesValidator(disk);

--- a/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/storage/lsm/LiveMigrateDiskCommandTest.java
+++ b/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/storage/lsm/LiveMigrateDiskCommandTest.java
@@ -251,6 +251,6 @@ public class LiveMigrateDiskCommandTest extends BaseCommandTest {
     private void mockValidators() {
         doReturn(diskValidator).when(command).createDiskValidator(any());
         doReturn(diskImagesValidator).when(command).createDiskImagesValidator(any());
-        doReturn(multipleStorageDomainsValidator).when(command).createMultipleStorageDomainsValidator(any());
+        doReturn(multipleStorageDomainsValidator).when(command).createMultipleStorageDomainsValidator();
     }
 }


### PR DESCRIPTION
Update Live Storage Migration flow validation to require additional 3 chunks (approximately 8 GiB) of free space on the destination Storage Domain.

Bug-Url: https://bugzilla.redhat.com/2116309