### PR TITLE
4.5.2.5

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -9,9 +9,9 @@ git_cfg_safe:
 	git config --global --add safe.directory "$(shell pwd)"
 
 srpm: installdeps git_cfg_safe
-       # $(eval SUFFIX=.git$(shell git rev-parse --short HEAD))
+	$(eval SUFFIX=.git$(shell git rev-parse --short HEAD))
 	# changing the spec file as passing -D won't preserve the suffix when rebuilding in mock
-       # sed "s:%{?release_suffix}:${SUFFIX}:" -i ovirt-engine.spec.in
+	sed "s:%{?release_suffix}:${SUFFIX}:" -i ovirt-engine.spec.in
 	mkdir -p tmp.repos/SOURCES
 	make dist
 	rpmbuild \

--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -9,9 +9,9 @@ git_cfg_safe:
 	git config --global --add safe.directory "$(shell pwd)"
 
 srpm: installdeps git_cfg_safe
-	$(eval SUFFIX=.git$(shell git rev-parse --short HEAD))
+       # $(eval SUFFIX=.git$(shell git rev-parse --short HEAD))
 	# changing the spec file as passing -D won't preserve the suffix when rebuilding in mock
-	sed "s:%{?release_suffix}:${SUFFIX}:" -i ovirt-engine.spec.in
+       # sed "s:%{?release_suffix}:${SUFFIX}:" -i ovirt-engine.spec.in
 	mkdir -p tmp.repos/SOURCES
 	make dist
 	rpmbuild \

--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -9,9 +9,9 @@ git_cfg_safe:
 	git config --global --add safe.directory "$(shell pwd)"
 
 srpm: installdeps git_cfg_safe
-    $(eval SUFFIX=.git$(shell git rev-parse --short HEAD))
+	$(eval SUFFIX=.git$(shell git rev-parse --short HEAD))
 	# changing the spec file as passing -D won't preserve the suffix when rebuilding in mock
-    sed "s:%{?release_suffix}:${SUFFIX}:" -i ovirt-engine.spec.in
+	sed "s:%{?release_suffix}:${SUFFIX}:" -i ovirt-engine.spec.in
 	mkdir -p tmp.repos/SOURCES
 	make dist
 	rpmbuild \

--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -9,9 +9,9 @@ git_cfg_safe:
 	git config --global --add safe.directory "$(shell pwd)"
 
 srpm: installdeps git_cfg_safe
-       # $(eval SUFFIX=.git$(shell git rev-parse --short HEAD))
+    $(eval SUFFIX=.git$(shell git rev-parse --short HEAD))
 	# changing the spec file as passing -D won't preserve the suffix when rebuilding in mock
-       # sed "s:%{?release_suffix}:${SUFFIX}:" -i ovirt-engine.spec.in
+    sed "s:%{?release_suffix}:${SUFFIX}:" -i ovirt-engine.spec.in
 	mkdir -p tmp.repos/SOURCES
 	make dist
 	rpmbuild \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,9 @@
 name: build
 on:
   push:
-    branches: [master, ovirt-engine-4.5.0.z]
+    branches: [master, ovirt-engine-4.5.2.z]
   pull_request:
-    branches: [master, ovirt-engine-4.5.0.z]
+    branches: [master, ovirt-engine-4.5.2.z]
   workflow_dispatch:
 
 jobs:

--- a/backend/manager/dependencies/common/pom.xml
+++ b/backend/manager/dependencies/common/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core.manager</groupId>
     <artifactId>dependencies</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
 
   <artifactId>common-dependencies</artifactId>

--- a/backend/manager/dependencies/common/pom.xml
+++ b/backend/manager/dependencies/common/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core.manager</groupId>
     <artifactId>dependencies</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>common-dependencies</artifactId>

--- a/backend/manager/dependencies/common/pom.xml
+++ b/backend/manager/dependencies/common/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core.manager</groupId>
     <artifactId>dependencies</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
 
   <artifactId>common-dependencies</artifactId>

--- a/backend/manager/dependencies/common/pom.xml
+++ b/backend/manager/dependencies/common/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core.manager</groupId>
     <artifactId>dependencies</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>common-dependencies</artifactId>

--- a/backend/manager/dependencies/common/pom.xml
+++ b/backend/manager/dependencies/common/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core.manager</groupId>
     <artifactId>dependencies</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
 
   <artifactId>common-dependencies</artifactId>

--- a/backend/manager/dependencies/common/pom.xml
+++ b/backend/manager/dependencies/common/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core.manager</groupId>
     <artifactId>dependencies</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>common-dependencies</artifactId>

--- a/backend/manager/dependencies/common/pom.xml
+++ b/backend/manager/dependencies/common/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core.manager</groupId>
     <artifactId>dependencies</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>common-dependencies</artifactId>

--- a/backend/manager/dependencies/pom.xml
+++ b/backend/manager/dependencies/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>dependencies</artifactId>

--- a/backend/manager/dependencies/pom.xml
+++ b/backend/manager/dependencies/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
 
   <artifactId>dependencies</artifactId>

--- a/backend/manager/dependencies/pom.xml
+++ b/backend/manager/dependencies/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>dependencies</artifactId>

--- a/backend/manager/dependencies/pom.xml
+++ b/backend/manager/dependencies/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>dependencies</artifactId>

--- a/backend/manager/dependencies/pom.xml
+++ b/backend/manager/dependencies/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
 
   <artifactId>dependencies</artifactId>

--- a/backend/manager/dependencies/pom.xml
+++ b/backend/manager/dependencies/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
 
   <artifactId>dependencies</artifactId>

--- a/backend/manager/dependencies/pom.xml
+++ b/backend/manager/dependencies/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>dependencies</artifactId>

--- a/backend/manager/dependencies/tools/pom.xml
+++ b/backend/manager/dependencies/tools/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core.manager</groupId>
     <artifactId>dependencies</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
 
   <artifactId>tools-dependencies</artifactId>

--- a/backend/manager/dependencies/tools/pom.xml
+++ b/backend/manager/dependencies/tools/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core.manager</groupId>
     <artifactId>dependencies</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>tools-dependencies</artifactId>

--- a/backend/manager/dependencies/tools/pom.xml
+++ b/backend/manager/dependencies/tools/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core.manager</groupId>
     <artifactId>dependencies</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>tools-dependencies</artifactId>

--- a/backend/manager/dependencies/tools/pom.xml
+++ b/backend/manager/dependencies/tools/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core.manager</groupId>
     <artifactId>dependencies</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
 
   <artifactId>tools-dependencies</artifactId>

--- a/backend/manager/dependencies/tools/pom.xml
+++ b/backend/manager/dependencies/tools/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core.manager</groupId>
     <artifactId>dependencies</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>tools-dependencies</artifactId>

--- a/backend/manager/dependencies/tools/pom.xml
+++ b/backend/manager/dependencies/tools/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core.manager</groupId>
     <artifactId>dependencies</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>tools-dependencies</artifactId>

--- a/backend/manager/dependencies/tools/pom.xml
+++ b/backend/manager/dependencies/tools/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core.manager</groupId>
     <artifactId>dependencies</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
 
   <artifactId>tools-dependencies</artifactId>

--- a/backend/manager/extensions-tool/pom.xml
+++ b/backend/manager/extensions-tool/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
 
   <artifactId>extensions-tool</artifactId>

--- a/backend/manager/extensions-tool/pom.xml
+++ b/backend/manager/extensions-tool/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
 
   <artifactId>extensions-tool</artifactId>

--- a/backend/manager/extensions-tool/pom.xml
+++ b/backend/manager/extensions-tool/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
 
   <artifactId>extensions-tool</artifactId>

--- a/backend/manager/extensions-tool/pom.xml
+++ b/backend/manager/extensions-tool/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>extensions-tool</artifactId>

--- a/backend/manager/extensions-tool/pom.xml
+++ b/backend/manager/extensions-tool/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>extensions-tool</artifactId>

--- a/backend/manager/extensions-tool/pom.xml
+++ b/backend/manager/extensions-tool/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>extensions-tool</artifactId>

--- a/backend/manager/extensions-tool/pom.xml
+++ b/backend/manager/extensions-tool/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>extensions-tool</artifactId>

--- a/backend/manager/logutils/pom.xml
+++ b/backend/manager/logutils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>logutils</artifactId>

--- a/backend/manager/logutils/pom.xml
+++ b/backend/manager/logutils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
 
   <artifactId>logutils</artifactId>

--- a/backend/manager/logutils/pom.xml
+++ b/backend/manager/logutils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>logutils</artifactId>

--- a/backend/manager/logutils/pom.xml
+++ b/backend/manager/logutils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
 
   <artifactId>logutils</artifactId>

--- a/backend/manager/logutils/pom.xml
+++ b/backend/manager/logutils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>logutils</artifactId>

--- a/backend/manager/logutils/pom.xml
+++ b/backend/manager/logutils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
 
   <artifactId>logutils</artifactId>

--- a/backend/manager/logutils/pom.xml
+++ b/backend/manager/logutils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>logutils</artifactId>

--- a/backend/manager/modules/aaa/pom.xml
+++ b/backend/manager/modules/aaa/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
 
   <artifactId>aaa</artifactId>

--- a/backend/manager/modules/aaa/pom.xml
+++ b/backend/manager/modules/aaa/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>aaa</artifactId>

--- a/backend/manager/modules/aaa/pom.xml
+++ b/backend/manager/modules/aaa/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
 
   <artifactId>aaa</artifactId>

--- a/backend/manager/modules/aaa/pom.xml
+++ b/backend/manager/modules/aaa/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>aaa</artifactId>

--- a/backend/manager/modules/aaa/pom.xml
+++ b/backend/manager/modules/aaa/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>aaa</artifactId>

--- a/backend/manager/modules/aaa/pom.xml
+++ b/backend/manager/modules/aaa/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
 
   <artifactId>aaa</artifactId>

--- a/backend/manager/modules/aaa/pom.xml
+++ b/backend/manager/modules/aaa/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>aaa</artifactId>

--- a/backend/manager/modules/auth-plugin/pom.xml
+++ b/backend/manager/modules/auth-plugin/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>auth-plugin</artifactId>

--- a/backend/manager/modules/auth-plugin/pom.xml
+++ b/backend/manager/modules/auth-plugin/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
 
   <artifactId>auth-plugin</artifactId>

--- a/backend/manager/modules/auth-plugin/pom.xml
+++ b/backend/manager/modules/auth-plugin/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
 
   <artifactId>auth-plugin</artifactId>

--- a/backend/manager/modules/auth-plugin/pom.xml
+++ b/backend/manager/modules/auth-plugin/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>auth-plugin</artifactId>

--- a/backend/manager/modules/auth-plugin/pom.xml
+++ b/backend/manager/modules/auth-plugin/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>auth-plugin</artifactId>

--- a/backend/manager/modules/auth-plugin/pom.xml
+++ b/backend/manager/modules/auth-plugin/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
 
   <artifactId>auth-plugin</artifactId>

--- a/backend/manager/modules/auth-plugin/pom.xml
+++ b/backend/manager/modules/auth-plugin/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>auth-plugin</artifactId>

--- a/backend/manager/modules/bll/pom.xml
+++ b/backend/manager/modules/bll/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>bll</artifactId>

--- a/backend/manager/modules/bll/pom.xml
+++ b/backend/manager/modules/bll/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>bll</artifactId>

--- a/backend/manager/modules/bll/pom.xml
+++ b/backend/manager/modules/bll/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
 
   <artifactId>bll</artifactId>

--- a/backend/manager/modules/bll/pom.xml
+++ b/backend/manager/modules/bll/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
 
   <artifactId>bll</artifactId>

--- a/backend/manager/modules/bll/pom.xml
+++ b/backend/manager/modules/bll/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>bll</artifactId>

--- a/backend/manager/modules/bll/pom.xml
+++ b/backend/manager/modules/bll/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
 
   <artifactId>bll</artifactId>

--- a/backend/manager/modules/bll/pom.xml
+++ b/backend/manager/modules/bll/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>bll</artifactId>

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/CertificationValidityChecker.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/CertificationValidityChecker.java
@@ -125,6 +125,7 @@ public class CertificationValidityChecker implements BackendService {
             AuditLogType alertExpirationEventType,
             AuditLogType alertAboutToExpireEventType,
             AuditLogType warnAboutToExpireEventType) {
+        log.debug("Checking optional certificate '{}'.", certFile.getAbsolutePath());
         if (certFile == null || !certFile.exists()) {
             // certificate file doesn't exist, which may be OK, as the service using the certificate is optional
             return true;

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleCommandConfig.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleCommandConfig.java
@@ -298,8 +298,11 @@ public class AnsibleCommandConfig implements LogFileConfig, PlaybookConfig {
         File hostFile = new File(String.format("%1$s/hosts", inventory));
         try {
             hostFile.createNewFile();
-            Files.write(hostFile.toPath(),
-                    String.format(this.host.getHostName() + " ansible_port=%1$s", this.host.getSshPort()).getBytes());
+            if (host != null) {
+                // if VDS is null then playbook is running on engine and ansible uses localhost inventory automatically
+                Files.write(hostFile.toPath(),
+                        String.format(this.host.getHostName() + " ansible_port=%1$s", this.host.getSshPort()).getBytes());
+            }
         } catch (IOException ex) {
             throw new AnsibleRunnerCallException(
                     String.format("Failed to create inventory file '%s':", hostFile.toString()),

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleExecutor.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleExecutor.java
@@ -146,9 +146,6 @@ public class AnsibleExecutor {
     }
 
     public AnsibleReturnValue runCommand(AnsibleCommandConfig commandConfig, int timeout, BiConsumer<String, String> fn, boolean async) {
-        if (commandConfig.host() == null) {
-            throw new AnsibleRunnerCallException("Invalid host");
-        }
         if (timeout <= 0) {
             timeout = EngineLocalConfig.getInstance().getInteger("ANSIBLE_PLAYBOOK_EXEC_DEFAULT_TIMEOUT");
         }
@@ -198,6 +195,12 @@ public class AnsibleExecutor {
     }
 
     private AuditLogable createAuditLogable(AnsibleCommandConfig command, String taskName) {
+        if (command.host() == null) {
+                return AuditLogableImpl.createEvent(
+                        command.correlationId(),
+                        Map.of("Message", taskName, "PlayAction", command.playAction())
+                    );
+        }
         return AuditLogableImpl.createHostEvent(
                 command.host(),
                 command.correlationId(),

--- a/backend/manager/modules/branding/pom.xml
+++ b/backend/manager/modules/branding/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
   <artifactId>branding</artifactId>
   <packaging>jar</packaging>

--- a/backend/manager/modules/branding/pom.xml
+++ b/backend/manager/modules/branding/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
   <artifactId>branding</artifactId>
   <packaging>jar</packaging>

--- a/backend/manager/modules/branding/pom.xml
+++ b/backend/manager/modules/branding/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
   <artifactId>branding</artifactId>
   <packaging>jar</packaging>

--- a/backend/manager/modules/branding/pom.xml
+++ b/backend/manager/modules/branding/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
   <artifactId>branding</artifactId>
   <packaging>jar</packaging>

--- a/backend/manager/modules/branding/pom.xml
+++ b/backend/manager/modules/branding/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
   <artifactId>branding</artifactId>
   <packaging>jar</packaging>

--- a/backend/manager/modules/branding/pom.xml
+++ b/backend/manager/modules/branding/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
   <artifactId>branding</artifactId>
   <packaging>jar</packaging>

--- a/backend/manager/modules/branding/pom.xml
+++ b/backend/manager/modules/branding/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
   <artifactId>branding</artifactId>
   <packaging>jar</packaging>

--- a/backend/manager/modules/builtin-extensions/pom.xml
+++ b/backend/manager/modules/builtin-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
   <groupId>org.ovirt.engine.extension.aaa</groupId>
   <artifactId>builtin</artifactId>

--- a/backend/manager/modules/builtin-extensions/pom.xml
+++ b/backend/manager/modules/builtin-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
   <groupId>org.ovirt.engine.extension.aaa</groupId>
   <artifactId>builtin</artifactId>

--- a/backend/manager/modules/builtin-extensions/pom.xml
+++ b/backend/manager/modules/builtin-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
   <groupId>org.ovirt.engine.extension.aaa</groupId>
   <artifactId>builtin</artifactId>

--- a/backend/manager/modules/builtin-extensions/pom.xml
+++ b/backend/manager/modules/builtin-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
   <groupId>org.ovirt.engine.extension.aaa</groupId>
   <artifactId>builtin</artifactId>

--- a/backend/manager/modules/builtin-extensions/pom.xml
+++ b/backend/manager/modules/builtin-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
   <groupId>org.ovirt.engine.extension.aaa</groupId>
   <artifactId>builtin</artifactId>

--- a/backend/manager/modules/builtin-extensions/pom.xml
+++ b/backend/manager/modules/builtin-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
   <groupId>org.ovirt.engine.extension.aaa</groupId>
   <artifactId>builtin</artifactId>

--- a/backend/manager/modules/builtin-extensions/pom.xml
+++ b/backend/manager/modules/builtin-extensions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
   <groupId>org.ovirt.engine.extension.aaa</groupId>
   <artifactId>builtin</artifactId>

--- a/backend/manager/modules/common/pom.xml
+++ b/backend/manager/modules/common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>common</artifactId>

--- a/backend/manager/modules/common/pom.xml
+++ b/backend/manager/modules/common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
 
   <artifactId>common</artifactId>

--- a/backend/manager/modules/common/pom.xml
+++ b/backend/manager/modules/common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>common</artifactId>

--- a/backend/manager/modules/common/pom.xml
+++ b/backend/manager/modules/common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
 
   <artifactId>common</artifactId>

--- a/backend/manager/modules/common/pom.xml
+++ b/backend/manager/modules/common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>common</artifactId>

--- a/backend/manager/modules/common/pom.xml
+++ b/backend/manager/modules/common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
 
   <artifactId>common</artifactId>

--- a/backend/manager/modules/common/pom.xml
+++ b/backend/manager/modules/common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>common</artifactId>

--- a/backend/manager/modules/compat/pom.xml
+++ b/backend/manager/modules/compat/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>compat</artifactId>

--- a/backend/manager/modules/compat/pom.xml
+++ b/backend/manager/modules/compat/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>compat</artifactId>

--- a/backend/manager/modules/compat/pom.xml
+++ b/backend/manager/modules/compat/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>compat</artifactId>

--- a/backend/manager/modules/compat/pom.xml
+++ b/backend/manager/modules/compat/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>compat</artifactId>

--- a/backend/manager/modules/compat/pom.xml
+++ b/backend/manager/modules/compat/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
 
   <artifactId>compat</artifactId>

--- a/backend/manager/modules/compat/pom.xml
+++ b/backend/manager/modules/compat/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
 
   <artifactId>compat</artifactId>

--- a/backend/manager/modules/compat/pom.xml
+++ b/backend/manager/modules/compat/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
 
   <artifactId>compat</artifactId>

--- a/backend/manager/modules/dal/pom.xml
+++ b/backend/manager/modules/dal/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
   <artifactId>dal</artifactId>
   <packaging>jar</packaging>

--- a/backend/manager/modules/dal/pom.xml
+++ b/backend/manager/modules/dal/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
   <artifactId>dal</artifactId>
   <packaging>jar</packaging>

--- a/backend/manager/modules/dal/pom.xml
+++ b/backend/manager/modules/dal/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
   <artifactId>dal</artifactId>
   <packaging>jar</packaging>

--- a/backend/manager/modules/dal/pom.xml
+++ b/backend/manager/modules/dal/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
   <artifactId>dal</artifactId>
   <packaging>jar</packaging>

--- a/backend/manager/modules/dal/pom.xml
+++ b/backend/manager/modules/dal/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
   <artifactId>dal</artifactId>
   <packaging>jar</packaging>

--- a/backend/manager/modules/dal/pom.xml
+++ b/backend/manager/modules/dal/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
   <artifactId>dal</artifactId>
   <packaging>jar</packaging>

--- a/backend/manager/modules/dal/pom.xml
+++ b/backend/manager/modules/dal/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
   <artifactId>dal</artifactId>
   <packaging>jar</packaging>

--- a/backend/manager/modules/docs/pom.xml
+++ b/backend/manager/modules/docs/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>docs</artifactId>

--- a/backend/manager/modules/docs/pom.xml
+++ b/backend/manager/modules/docs/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>docs</artifactId>

--- a/backend/manager/modules/docs/pom.xml
+++ b/backend/manager/modules/docs/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>docs</artifactId>

--- a/backend/manager/modules/docs/pom.xml
+++ b/backend/manager/modules/docs/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
 
   <artifactId>docs</artifactId>

--- a/backend/manager/modules/docs/pom.xml
+++ b/backend/manager/modules/docs/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
 
   <artifactId>docs</artifactId>

--- a/backend/manager/modules/docs/pom.xml
+++ b/backend/manager/modules/docs/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>docs</artifactId>

--- a/backend/manager/modules/docs/pom.xml
+++ b/backend/manager/modules/docs/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
 
   <artifactId>docs</artifactId>

--- a/backend/manager/modules/enginesso/pom.xml
+++ b/backend/manager/modules/enginesso/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>manager-modules</artifactId>
         <groupId>org.ovirt.engine.core</groupId>
-        <version>4.5.2.3</version>
+        <version>4.5.2.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/backend/manager/modules/enginesso/pom.xml
+++ b/backend/manager/modules/enginesso/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>manager-modules</artifactId>
         <groupId>org.ovirt.engine.core</groupId>
-        <version>4.5.2.4</version>
+        <version>4.5.2.5-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/backend/manager/modules/enginesso/pom.xml
+++ b/backend/manager/modules/enginesso/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>manager-modules</artifactId>
         <groupId>org.ovirt.engine.core</groupId>
-        <version>4.5.2.2</version>
+        <version>4.5.2.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/backend/manager/modules/enginesso/pom.xml
+++ b/backend/manager/modules/enginesso/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>manager-modules</artifactId>
         <groupId>org.ovirt.engine.core</groupId>
-        <version>4.5.2.5-SNAPSHOT</version>
+        <version>4.5.2.5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/backend/manager/modules/enginesso/pom.xml
+++ b/backend/manager/modules/enginesso/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>manager-modules</artifactId>
         <groupId>org.ovirt.engine.core</groupId>
-        <version>4.5.2.5</version>
+        <version>4.5.2.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/backend/manager/modules/enginesso/pom.xml
+++ b/backend/manager/modules/enginesso/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>manager-modules</artifactId>
         <groupId>org.ovirt.engine.core</groupId>
-        <version>4.5.2.3-SNAPSHOT</version>
+        <version>4.5.2.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/backend/manager/modules/enginesso/pom.xml
+++ b/backend/manager/modules/enginesso/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>manager-modules</artifactId>
         <groupId>org.ovirt.engine.core</groupId>
-        <version>4.5.2.4-SNAPSHOT</version>
+        <version>4.5.2.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/backend/manager/modules/extensions-manager/pom.xml
+++ b/backend/manager/modules/extensions-manager/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>extensions-manager</artifactId>

--- a/backend/manager/modules/extensions-manager/pom.xml
+++ b/backend/manager/modules/extensions-manager/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
 
   <artifactId>extensions-manager</artifactId>

--- a/backend/manager/modules/extensions-manager/pom.xml
+++ b/backend/manager/modules/extensions-manager/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>extensions-manager</artifactId>

--- a/backend/manager/modules/extensions-manager/pom.xml
+++ b/backend/manager/modules/extensions-manager/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>extensions-manager</artifactId>

--- a/backend/manager/modules/extensions-manager/pom.xml
+++ b/backend/manager/modules/extensions-manager/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
 
   <artifactId>extensions-manager</artifactId>

--- a/backend/manager/modules/extensions-manager/pom.xml
+++ b/backend/manager/modules/extensions-manager/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
 
   <artifactId>extensions-manager</artifactId>

--- a/backend/manager/modules/extensions-manager/pom.xml
+++ b/backend/manager/modules/extensions-manager/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>extensions-manager</artifactId>

--- a/backend/manager/modules/logger/pom.xml
+++ b/backend/manager/modules/logger/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>logger</artifactId>

--- a/backend/manager/modules/logger/pom.xml
+++ b/backend/manager/modules/logger/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>logger</artifactId>

--- a/backend/manager/modules/logger/pom.xml
+++ b/backend/manager/modules/logger/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
 
   <artifactId>logger</artifactId>

--- a/backend/manager/modules/logger/pom.xml
+++ b/backend/manager/modules/logger/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
 
   <artifactId>logger</artifactId>

--- a/backend/manager/modules/logger/pom.xml
+++ b/backend/manager/modules/logger/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>logger</artifactId>

--- a/backend/manager/modules/logger/pom.xml
+++ b/backend/manager/modules/logger/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>logger</artifactId>

--- a/backend/manager/modules/logger/pom.xml
+++ b/backend/manager/modules/logger/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
 
   <artifactId>logger</artifactId>

--- a/backend/manager/modules/microbenchmarks/pom.xml
+++ b/backend/manager/modules/microbenchmarks/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>benchmarks</artifactId>

--- a/backend/manager/modules/microbenchmarks/pom.xml
+++ b/backend/manager/modules/microbenchmarks/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>benchmarks</artifactId>

--- a/backend/manager/modules/microbenchmarks/pom.xml
+++ b/backend/manager/modules/microbenchmarks/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
 
   <artifactId>benchmarks</artifactId>

--- a/backend/manager/modules/microbenchmarks/pom.xml
+++ b/backend/manager/modules/microbenchmarks/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>benchmarks</artifactId>

--- a/backend/manager/modules/microbenchmarks/pom.xml
+++ b/backend/manager/modules/microbenchmarks/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
 
   <artifactId>benchmarks</artifactId>

--- a/backend/manager/modules/microbenchmarks/pom.xml
+++ b/backend/manager/modules/microbenchmarks/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
 
   <artifactId>benchmarks</artifactId>

--- a/backend/manager/modules/microbenchmarks/pom.xml
+++ b/backend/manager/modules/microbenchmarks/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>benchmarks</artifactId>

--- a/backend/manager/modules/pom.xml
+++ b/backend/manager/modules/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>manager-modules</artifactId>

--- a/backend/manager/modules/pom.xml
+++ b/backend/manager/modules/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>manager-modules</artifactId>

--- a/backend/manager/modules/pom.xml
+++ b/backend/manager/modules/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>manager-modules</artifactId>

--- a/backend/manager/modules/pom.xml
+++ b/backend/manager/modules/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
 
   <artifactId>manager-modules</artifactId>

--- a/backend/manager/modules/pom.xml
+++ b/backend/manager/modules/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>manager-modules</artifactId>

--- a/backend/manager/modules/pom.xml
+++ b/backend/manager/modules/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
 
   <artifactId>manager-modules</artifactId>

--- a/backend/manager/modules/pom.xml
+++ b/backend/manager/modules/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
 
   <artifactId>manager-modules</artifactId>

--- a/backend/manager/modules/restapi/apidoc/pom.xml
+++ b/backend/manager/modules/restapi/apidoc/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
 
   <artifactId>restapi-apidoc</artifactId>

--- a/backend/manager/modules/restapi/apidoc/pom.xml
+++ b/backend/manager/modules/restapi/apidoc/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
 
   <artifactId>restapi-apidoc</artifactId>

--- a/backend/manager/modules/restapi/apidoc/pom.xml
+++ b/backend/manager/modules/restapi/apidoc/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>restapi-apidoc</artifactId>

--- a/backend/manager/modules/restapi/apidoc/pom.xml
+++ b/backend/manager/modules/restapi/apidoc/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
 
   <artifactId>restapi-apidoc</artifactId>

--- a/backend/manager/modules/restapi/apidoc/pom.xml
+++ b/backend/manager/modules/restapi/apidoc/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>restapi-apidoc</artifactId>

--- a/backend/manager/modules/restapi/apidoc/pom.xml
+++ b/backend/manager/modules/restapi/apidoc/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>restapi-apidoc</artifactId>

--- a/backend/manager/modules/restapi/apidoc/pom.xml
+++ b/backend/manager/modules/restapi/apidoc/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>restapi-apidoc</artifactId>

--- a/backend/manager/modules/restapi/interface/common/jaxrs/pom.xml
+++ b/backend/manager/modules/restapi/interface/common/jaxrs/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>common-parent</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>interface-common-jaxrs</artifactId>

--- a/backend/manager/modules/restapi/interface/common/jaxrs/pom.xml
+++ b/backend/manager/modules/restapi/interface/common/jaxrs/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>common-parent</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
 
   <artifactId>interface-common-jaxrs</artifactId>

--- a/backend/manager/modules/restapi/interface/common/jaxrs/pom.xml
+++ b/backend/manager/modules/restapi/interface/common/jaxrs/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>common-parent</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>interface-common-jaxrs</artifactId>

--- a/backend/manager/modules/restapi/interface/common/jaxrs/pom.xml
+++ b/backend/manager/modules/restapi/interface/common/jaxrs/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>common-parent</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>interface-common-jaxrs</artifactId>

--- a/backend/manager/modules/restapi/interface/common/jaxrs/pom.xml
+++ b/backend/manager/modules/restapi/interface/common/jaxrs/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>common-parent</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
 
   <artifactId>interface-common-jaxrs</artifactId>

--- a/backend/manager/modules/restapi/interface/common/jaxrs/pom.xml
+++ b/backend/manager/modules/restapi/interface/common/jaxrs/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>common-parent</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>interface-common-jaxrs</artifactId>

--- a/backend/manager/modules/restapi/interface/common/jaxrs/pom.xml
+++ b/backend/manager/modules/restapi/interface/common/jaxrs/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>common-parent</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
 
   <artifactId>interface-common-jaxrs</artifactId>

--- a/backend/manager/modules/restapi/interface/common/pom.xml
+++ b/backend/manager/modules/restapi/interface/common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>interface</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>common-parent</artifactId>

--- a/backend/manager/modules/restapi/interface/common/pom.xml
+++ b/backend/manager/modules/restapi/interface/common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>interface</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
 
   <artifactId>common-parent</artifactId>

--- a/backend/manager/modules/restapi/interface/common/pom.xml
+++ b/backend/manager/modules/restapi/interface/common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>interface</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
 
   <artifactId>common-parent</artifactId>

--- a/backend/manager/modules/restapi/interface/common/pom.xml
+++ b/backend/manager/modules/restapi/interface/common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>interface</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>common-parent</artifactId>

--- a/backend/manager/modules/restapi/interface/common/pom.xml
+++ b/backend/manager/modules/restapi/interface/common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>interface</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
 
   <artifactId>common-parent</artifactId>

--- a/backend/manager/modules/restapi/interface/common/pom.xml
+++ b/backend/manager/modules/restapi/interface/common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>interface</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>common-parent</artifactId>

--- a/backend/manager/modules/restapi/interface/common/pom.xml
+++ b/backend/manager/modules/restapi/interface/common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>interface</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>common-parent</artifactId>

--- a/backend/manager/modules/restapi/interface/definition/pom.xml
+++ b/backend/manager/modules/restapi/interface/definition/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>interface</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>restapi-definition</artifactId>

--- a/backend/manager/modules/restapi/interface/definition/pom.xml
+++ b/backend/manager/modules/restapi/interface/definition/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>interface</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>restapi-definition</artifactId>

--- a/backend/manager/modules/restapi/interface/definition/pom.xml
+++ b/backend/manager/modules/restapi/interface/definition/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>interface</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>restapi-definition</artifactId>

--- a/backend/manager/modules/restapi/interface/definition/pom.xml
+++ b/backend/manager/modules/restapi/interface/definition/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>interface</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
 
   <artifactId>restapi-definition</artifactId>

--- a/backend/manager/modules/restapi/interface/definition/pom.xml
+++ b/backend/manager/modules/restapi/interface/definition/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>interface</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>restapi-definition</artifactId>

--- a/backend/manager/modules/restapi/interface/definition/pom.xml
+++ b/backend/manager/modules/restapi/interface/definition/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>interface</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
 
   <artifactId>restapi-definition</artifactId>

--- a/backend/manager/modules/restapi/interface/definition/pom.xml
+++ b/backend/manager/modules/restapi/interface/definition/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>interface</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
 
   <artifactId>restapi-definition</artifactId>

--- a/backend/manager/modules/restapi/interface/pom.xml
+++ b/backend/manager/modules/restapi/interface/pom.xml
@@ -5,7 +5,7 @@ ven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
 
   <artifactId>interface</artifactId>

--- a/backend/manager/modules/restapi/interface/pom.xml
+++ b/backend/manager/modules/restapi/interface/pom.xml
@@ -5,7 +5,7 @@ ven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
 
   <artifactId>interface</artifactId>

--- a/backend/manager/modules/restapi/interface/pom.xml
+++ b/backend/manager/modules/restapi/interface/pom.xml
@@ -5,7 +5,7 @@ ven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>interface</artifactId>

--- a/backend/manager/modules/restapi/interface/pom.xml
+++ b/backend/manager/modules/restapi/interface/pom.xml
@@ -5,7 +5,7 @@ ven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>interface</artifactId>

--- a/backend/manager/modules/restapi/interface/pom.xml
+++ b/backend/manager/modules/restapi/interface/pom.xml
@@ -5,7 +5,7 @@ ven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>interface</artifactId>

--- a/backend/manager/modules/restapi/interface/pom.xml
+++ b/backend/manager/modules/restapi/interface/pom.xml
@@ -5,7 +5,7 @@ ven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
 
   <artifactId>interface</artifactId>

--- a/backend/manager/modules/restapi/interface/pom.xml
+++ b/backend/manager/modules/restapi/interface/pom.xml
@@ -5,7 +5,7 @@ ven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>interface</artifactId>

--- a/backend/manager/modules/restapi/jaxrs/pom.xml
+++ b/backend/manager/modules/restapi/jaxrs/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>restapi-jaxrs</artifactId>

--- a/backend/manager/modules/restapi/jaxrs/pom.xml
+++ b/backend/manager/modules/restapi/jaxrs/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
 
   <artifactId>restapi-jaxrs</artifactId>

--- a/backend/manager/modules/restapi/jaxrs/pom.xml
+++ b/backend/manager/modules/restapi/jaxrs/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
 
   <artifactId>restapi-jaxrs</artifactId>

--- a/backend/manager/modules/restapi/jaxrs/pom.xml
+++ b/backend/manager/modules/restapi/jaxrs/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
 
   <artifactId>restapi-jaxrs</artifactId>

--- a/backend/manager/modules/restapi/jaxrs/pom.xml
+++ b/backend/manager/modules/restapi/jaxrs/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>restapi-jaxrs</artifactId>

--- a/backend/manager/modules/restapi/jaxrs/pom.xml
+++ b/backend/manager/modules/restapi/jaxrs/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>restapi-jaxrs</artifactId>

--- a/backend/manager/modules/restapi/jaxrs/pom.xml
+++ b/backend/manager/modules/restapi/jaxrs/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>restapi-jaxrs</artifactId>

--- a/backend/manager/modules/restapi/pom.xml
+++ b/backend/manager/modules/restapi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
 
   <artifactId>restapi-parent</artifactId>

--- a/backend/manager/modules/restapi/pom.xml
+++ b/backend/manager/modules/restapi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
 
   <artifactId>restapi-parent</artifactId>

--- a/backend/manager/modules/restapi/pom.xml
+++ b/backend/manager/modules/restapi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>restapi-parent</artifactId>

--- a/backend/manager/modules/restapi/pom.xml
+++ b/backend/manager/modules/restapi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>restapi-parent</artifactId>

--- a/backend/manager/modules/restapi/pom.xml
+++ b/backend/manager/modules/restapi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
 
   <artifactId>restapi-parent</artifactId>

--- a/backend/manager/modules/restapi/pom.xml
+++ b/backend/manager/modules/restapi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>restapi-parent</artifactId>

--- a/backend/manager/modules/restapi/pom.xml
+++ b/backend/manager/modules/restapi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>restapi-parent</artifactId>

--- a/backend/manager/modules/restapi/types/pom.xml
+++ b/backend/manager/modules/restapi/types/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>restapi-types</artifactId>

--- a/backend/manager/modules/restapi/types/pom.xml
+++ b/backend/manager/modules/restapi/types/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
 
   <artifactId>restapi-types</artifactId>

--- a/backend/manager/modules/restapi/types/pom.xml
+++ b/backend/manager/modules/restapi/types/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
 
   <artifactId>restapi-types</artifactId>

--- a/backend/manager/modules/restapi/types/pom.xml
+++ b/backend/manager/modules/restapi/types/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
 
   <artifactId>restapi-types</artifactId>

--- a/backend/manager/modules/restapi/types/pom.xml
+++ b/backend/manager/modules/restapi/types/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>restapi-types</artifactId>

--- a/backend/manager/modules/restapi/types/pom.xml
+++ b/backend/manager/modules/restapi/types/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>restapi-types</artifactId>

--- a/backend/manager/modules/restapi/types/pom.xml
+++ b/backend/manager/modules/restapi/types/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>restapi-types</artifactId>

--- a/backend/manager/modules/restapi/webapp/pom.xml
+++ b/backend/manager/modules/restapi/webapp/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
 
   <artifactId>restapi-webapp</artifactId>

--- a/backend/manager/modules/restapi/webapp/pom.xml
+++ b/backend/manager/modules/restapi/webapp/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>restapi-webapp</artifactId>

--- a/backend/manager/modules/restapi/webapp/pom.xml
+++ b/backend/manager/modules/restapi/webapp/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>restapi-webapp</artifactId>

--- a/backend/manager/modules/restapi/webapp/pom.xml
+++ b/backend/manager/modules/restapi/webapp/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>restapi-webapp</artifactId>

--- a/backend/manager/modules/restapi/webapp/pom.xml
+++ b/backend/manager/modules/restapi/webapp/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
 
   <artifactId>restapi-webapp</artifactId>

--- a/backend/manager/modules/restapi/webapp/pom.xml
+++ b/backend/manager/modules/restapi/webapp/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
 
   <artifactId>restapi-webapp</artifactId>

--- a/backend/manager/modules/restapi/webapp/pom.xml
+++ b/backend/manager/modules/restapi/webapp/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.ovirt.engine.api</groupId>
     <artifactId>restapi-parent</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>restapi-webapp</artifactId>

--- a/backend/manager/modules/root/pom.xml
+++ b/backend/manager/modules/root/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>root-war</artifactId>

--- a/backend/manager/modules/root/pom.xml
+++ b/backend/manager/modules/root/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>root-war</artifactId>

--- a/backend/manager/modules/root/pom.xml
+++ b/backend/manager/modules/root/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
 
   <artifactId>root-war</artifactId>

--- a/backend/manager/modules/root/pom.xml
+++ b/backend/manager/modules/root/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
 
   <artifactId>root-war</artifactId>

--- a/backend/manager/modules/root/pom.xml
+++ b/backend/manager/modules/root/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
 
   <artifactId>root-war</artifactId>

--- a/backend/manager/modules/root/pom.xml
+++ b/backend/manager/modules/root/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>root-war</artifactId>

--- a/backend/manager/modules/root/pom.xml
+++ b/backend/manager/modules/root/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>root-war</artifactId>

--- a/backend/manager/modules/scheduler/pom.xml
+++ b/backend/manager/modules/scheduler/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>scheduler</artifactId>

--- a/backend/manager/modules/scheduler/pom.xml
+++ b/backend/manager/modules/scheduler/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>scheduler</artifactId>

--- a/backend/manager/modules/scheduler/pom.xml
+++ b/backend/manager/modules/scheduler/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
 
   <artifactId>scheduler</artifactId>

--- a/backend/manager/modules/scheduler/pom.xml
+++ b/backend/manager/modules/scheduler/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>scheduler</artifactId>

--- a/backend/manager/modules/scheduler/pom.xml
+++ b/backend/manager/modules/scheduler/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
 
   <artifactId>scheduler</artifactId>

--- a/backend/manager/modules/scheduler/pom.xml
+++ b/backend/manager/modules/scheduler/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
 
   <artifactId>scheduler</artifactId>

--- a/backend/manager/modules/scheduler/pom.xml
+++ b/backend/manager/modules/scheduler/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>scheduler</artifactId>

--- a/backend/manager/modules/searchbackend/pom.xml
+++ b/backend/manager/modules/searchbackend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>searchbackend</artifactId>

--- a/backend/manager/modules/searchbackend/pom.xml
+++ b/backend/manager/modules/searchbackend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>searchbackend</artifactId>

--- a/backend/manager/modules/searchbackend/pom.xml
+++ b/backend/manager/modules/searchbackend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>searchbackend</artifactId>

--- a/backend/manager/modules/searchbackend/pom.xml
+++ b/backend/manager/modules/searchbackend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
 
   <artifactId>searchbackend</artifactId>

--- a/backend/manager/modules/searchbackend/pom.xml
+++ b/backend/manager/modules/searchbackend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>searchbackend</artifactId>

--- a/backend/manager/modules/searchbackend/pom.xml
+++ b/backend/manager/modules/searchbackend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
 
   <artifactId>searchbackend</artifactId>

--- a/backend/manager/modules/searchbackend/pom.xml
+++ b/backend/manager/modules/searchbackend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
 
   <artifactId>searchbackend</artifactId>

--- a/backend/manager/modules/services/pom.xml
+++ b/backend/manager/modules/services/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
 
   <artifactId>services</artifactId>

--- a/backend/manager/modules/services/pom.xml
+++ b/backend/manager/modules/services/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
 
   <artifactId>services</artifactId>

--- a/backend/manager/modules/services/pom.xml
+++ b/backend/manager/modules/services/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>services</artifactId>

--- a/backend/manager/modules/services/pom.xml
+++ b/backend/manager/modules/services/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>services</artifactId>

--- a/backend/manager/modules/services/pom.xml
+++ b/backend/manager/modules/services/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>services</artifactId>

--- a/backend/manager/modules/services/pom.xml
+++ b/backend/manager/modules/services/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
 
   <artifactId>services</artifactId>

--- a/backend/manager/modules/services/pom.xml
+++ b/backend/manager/modules/services/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>services</artifactId>

--- a/backend/manager/modules/utils/pom.xml
+++ b/backend/manager/modules/utils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>utils</artifactId>

--- a/backend/manager/modules/utils/pom.xml
+++ b/backend/manager/modules/utils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>utils</artifactId>

--- a/backend/manager/modules/utils/pom.xml
+++ b/backend/manager/modules/utils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>utils</artifactId>

--- a/backend/manager/modules/utils/pom.xml
+++ b/backend/manager/modules/utils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
 
   <artifactId>utils</artifactId>

--- a/backend/manager/modules/utils/pom.xml
+++ b/backend/manager/modules/utils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
 
   <artifactId>utils</artifactId>

--- a/backend/manager/modules/utils/pom.xml
+++ b/backend/manager/modules/utils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>utils</artifactId>

--- a/backend/manager/modules/utils/pom.xml
+++ b/backend/manager/modules/utils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
 
   <artifactId>utils</artifactId>

--- a/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/EngineLocalConfig.java
+++ b/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/EngineLocalConfig.java
@@ -213,7 +213,7 @@ public class EngineLocalConfig extends ShellLikeConfd {
     }
 
     public File getPKIOvirtProviderOVNCert() {
-        return Paths.get(getProperty("ENGINE_PKI"), "ovirt-provider-ovn.cer").toFile();
+        return Paths.get(getProperty("ENGINE_PKI"), "certs", "ovirt-provider-ovn.cer").toFile();
     }
 
     public String getPKITrustStoreType() {

--- a/backend/manager/modules/uutils/pom.xml
+++ b/backend/manager/modules/uutils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
 
   <artifactId>uutils</artifactId>

--- a/backend/manager/modules/uutils/pom.xml
+++ b/backend/manager/modules/uutils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
 
   <artifactId>uutils</artifactId>

--- a/backend/manager/modules/uutils/pom.xml
+++ b/backend/manager/modules/uutils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>uutils</artifactId>

--- a/backend/manager/modules/uutils/pom.xml
+++ b/backend/manager/modules/uutils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>uutils</artifactId>

--- a/backend/manager/modules/uutils/pom.xml
+++ b/backend/manager/modules/uutils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
 
   <artifactId>uutils</artifactId>

--- a/backend/manager/modules/uutils/pom.xml
+++ b/backend/manager/modules/uutils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>uutils</artifactId>

--- a/backend/manager/modules/uutils/pom.xml
+++ b/backend/manager/modules/uutils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>uutils</artifactId>

--- a/backend/manager/modules/vdsbroker/pom.xml
+++ b/backend/manager/modules/vdsbroker/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
 
   <artifactId>vdsbroker</artifactId>

--- a/backend/manager/modules/vdsbroker/pom.xml
+++ b/backend/manager/modules/vdsbroker/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
 
   <artifactId>vdsbroker</artifactId>

--- a/backend/manager/modules/vdsbroker/pom.xml
+++ b/backend/manager/modules/vdsbroker/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>vdsbroker</artifactId>

--- a/backend/manager/modules/vdsbroker/pom.xml
+++ b/backend/manager/modules/vdsbroker/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>vdsbroker</artifactId>

--- a/backend/manager/modules/vdsbroker/pom.xml
+++ b/backend/manager/modules/vdsbroker/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>vdsbroker</artifactId>

--- a/backend/manager/modules/vdsbroker/pom.xml
+++ b/backend/manager/modules/vdsbroker/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>vdsbroker</artifactId>

--- a/backend/manager/modules/vdsbroker/pom.xml
+++ b/backend/manager/modules/vdsbroker/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
 
   <artifactId>vdsbroker</artifactId>

--- a/backend/manager/modules/welcome/pom.xml
+++ b/backend/manager/modules/welcome/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>welcome</artifactId>

--- a/backend/manager/modules/welcome/pom.xml
+++ b/backend/manager/modules/welcome/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
 
   <artifactId>welcome</artifactId>

--- a/backend/manager/modules/welcome/pom.xml
+++ b/backend/manager/modules/welcome/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>welcome</artifactId>

--- a/backend/manager/modules/welcome/pom.xml
+++ b/backend/manager/modules/welcome/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
 
   <artifactId>welcome</artifactId>

--- a/backend/manager/modules/welcome/pom.xml
+++ b/backend/manager/modules/welcome/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>welcome</artifactId>

--- a/backend/manager/modules/welcome/pom.xml
+++ b/backend/manager/modules/welcome/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
 
   <artifactId>welcome</artifactId>

--- a/backend/manager/modules/welcome/pom.xml
+++ b/backend/manager/modules/welcome/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager-modules</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>welcome</artifactId>

--- a/backend/manager/pom.xml
+++ b/backend/manager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>backend</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
   <artifactId>manager</artifactId>
   <packaging>pom</packaging>

--- a/backend/manager/pom.xml
+++ b/backend/manager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>backend</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
   <artifactId>manager</artifactId>
   <packaging>pom</packaging>

--- a/backend/manager/pom.xml
+++ b/backend/manager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>backend</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
   <artifactId>manager</artifactId>
   <packaging>pom</packaging>

--- a/backend/manager/pom.xml
+++ b/backend/manager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>backend</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
   <artifactId>manager</artifactId>
   <packaging>pom</packaging>

--- a/backend/manager/pom.xml
+++ b/backend/manager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>backend</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
   <artifactId>manager</artifactId>
   <packaging>pom</packaging>

--- a/backend/manager/pom.xml
+++ b/backend/manager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>backend</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
   <artifactId>manager</artifactId>
   <packaging>pom</packaging>

--- a/backend/manager/pom.xml
+++ b/backend/manager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>backend</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
   <artifactId>manager</artifactId>
   <packaging>pom</packaging>

--- a/backend/manager/sso-client-registration-tool/pom.xml
+++ b/backend/manager/sso-client-registration-tool/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>sso-client-registration-tool</artifactId>

--- a/backend/manager/sso-client-registration-tool/pom.xml
+++ b/backend/manager/sso-client-registration-tool/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
 
   <artifactId>sso-client-registration-tool</artifactId>

--- a/backend/manager/sso-client-registration-tool/pom.xml
+++ b/backend/manager/sso-client-registration-tool/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>sso-client-registration-tool</artifactId>

--- a/backend/manager/sso-client-registration-tool/pom.xml
+++ b/backend/manager/sso-client-registration-tool/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>sso-client-registration-tool</artifactId>

--- a/backend/manager/sso-client-registration-tool/pom.xml
+++ b/backend/manager/sso-client-registration-tool/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>sso-client-registration-tool</artifactId>

--- a/backend/manager/sso-client-registration-tool/pom.xml
+++ b/backend/manager/sso-client-registration-tool/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
 
   <artifactId>sso-client-registration-tool</artifactId>

--- a/backend/manager/sso-client-registration-tool/pom.xml
+++ b/backend/manager/sso-client-registration-tool/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
 
   <artifactId>sso-client-registration-tool</artifactId>

--- a/backend/manager/tools/pom.xml
+++ b/backend/manager/tools/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
 
   <artifactId>tools</artifactId>

--- a/backend/manager/tools/pom.xml
+++ b/backend/manager/tools/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
 
   <artifactId>tools</artifactId>

--- a/backend/manager/tools/pom.xml
+++ b/backend/manager/tools/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
 
   <artifactId>tools</artifactId>

--- a/backend/manager/tools/pom.xml
+++ b/backend/manager/tools/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>tools</artifactId>

--- a/backend/manager/tools/pom.xml
+++ b/backend/manager/tools/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>tools</artifactId>

--- a/backend/manager/tools/pom.xml
+++ b/backend/manager/tools/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>tools</artifactId>

--- a/backend/manager/tools/pom.xml
+++ b/backend/manager/tools/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.core</groupId>
     <artifactId>manager</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>tools</artifactId>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>backend</artifactId>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
 
   <artifactId>backend</artifactId>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>backend</artifactId>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
 
   <artifactId>backend</artifactId>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
 
   <artifactId>backend</artifactId>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>backend</artifactId>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>backend</artifactId>

--- a/build-tools-root/checkstyles/pom.xml
+++ b/build-tools-root/checkstyles/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>build-tools-root</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
   <artifactId>checkstyles</artifactId>
   <packaging>jar</packaging>

--- a/build-tools-root/checkstyles/pom.xml
+++ b/build-tools-root/checkstyles/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>build-tools-root</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
   <artifactId>checkstyles</artifactId>
   <packaging>jar</packaging>

--- a/build-tools-root/checkstyles/pom.xml
+++ b/build-tools-root/checkstyles/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>build-tools-root</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
   <artifactId>checkstyles</artifactId>
   <packaging>jar</packaging>

--- a/build-tools-root/checkstyles/pom.xml
+++ b/build-tools-root/checkstyles/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>build-tools-root</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
   <artifactId>checkstyles</artifactId>
   <packaging>jar</packaging>

--- a/build-tools-root/checkstyles/pom.xml
+++ b/build-tools-root/checkstyles/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>build-tools-root</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
   <artifactId>checkstyles</artifactId>
   <packaging>jar</packaging>

--- a/build-tools-root/checkstyles/pom.xml
+++ b/build-tools-root/checkstyles/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>build-tools-root</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
   <artifactId>checkstyles</artifactId>
   <packaging>jar</packaging>

--- a/build-tools-root/checkstyles/pom.xml
+++ b/build-tools-root/checkstyles/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>build-tools-root</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
   <artifactId>checkstyles</artifactId>
   <packaging>jar</packaging>

--- a/build-tools-root/ovirt-checkstyle-extension/pom.xml
+++ b/build-tools-root/ovirt-checkstyle-extension/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>build-tools-root</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
   <artifactId>ovirt-checkstyle-extension</artifactId>
   <name>oVirt Checkstyle Checks</name>

--- a/build-tools-root/ovirt-checkstyle-extension/pom.xml
+++ b/build-tools-root/ovirt-checkstyle-extension/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>build-tools-root</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
   <artifactId>ovirt-checkstyle-extension</artifactId>
   <name>oVirt Checkstyle Checks</name>

--- a/build-tools-root/ovirt-checkstyle-extension/pom.xml
+++ b/build-tools-root/ovirt-checkstyle-extension/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>build-tools-root</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
   <artifactId>ovirt-checkstyle-extension</artifactId>
   <name>oVirt Checkstyle Checks</name>

--- a/build-tools-root/ovirt-checkstyle-extension/pom.xml
+++ b/build-tools-root/ovirt-checkstyle-extension/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>build-tools-root</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
   <artifactId>ovirt-checkstyle-extension</artifactId>
   <name>oVirt Checkstyle Checks</name>

--- a/build-tools-root/ovirt-checkstyle-extension/pom.xml
+++ b/build-tools-root/ovirt-checkstyle-extension/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>build-tools-root</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
   <artifactId>ovirt-checkstyle-extension</artifactId>
   <name>oVirt Checkstyle Checks</name>

--- a/build-tools-root/ovirt-checkstyle-extension/pom.xml
+++ b/build-tools-root/ovirt-checkstyle-extension/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>build-tools-root</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
   <artifactId>ovirt-checkstyle-extension</artifactId>
   <name>oVirt Checkstyle Checks</name>

--- a/build-tools-root/ovirt-checkstyle-extension/pom.xml
+++ b/build-tools-root/ovirt-checkstyle-extension/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>build-tools-root</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
   <artifactId>ovirt-checkstyle-extension</artifactId>
   <name>oVirt Checkstyle Checks</name>

--- a/build-tools-root/ovirt-findbugs-filters/pom.xml
+++ b/build-tools-root/ovirt-findbugs-filters/pom.xml
@@ -14,7 +14,7 @@ SPDX-License-Identifier: Apache-2.0
 
   <groupId>org.ovirt.engine</groupId>
   <artifactId>ovirt-findbugs-filters</artifactId>
-  <version>4.5.2.2</version>
+  <version>4.5.2.3</version>
   <packaging>jar</packaging>
 
   <name>oVirt Findbugs Filters</name>

--- a/build-tools-root/ovirt-findbugs-filters/pom.xml
+++ b/build-tools-root/ovirt-findbugs-filters/pom.xml
@@ -14,7 +14,7 @@ SPDX-License-Identifier: Apache-2.0
 
   <groupId>org.ovirt.engine</groupId>
   <artifactId>ovirt-findbugs-filters</artifactId>
-  <version>4.5.2.4-SNAPSHOT</version>
+  <version>4.5.2.4</version>
   <packaging>jar</packaging>
 
   <name>oVirt Findbugs Filters</name>

--- a/build-tools-root/ovirt-findbugs-filters/pom.xml
+++ b/build-tools-root/ovirt-findbugs-filters/pom.xml
@@ -14,7 +14,7 @@ SPDX-License-Identifier: Apache-2.0
 
   <groupId>org.ovirt.engine</groupId>
   <artifactId>ovirt-findbugs-filters</artifactId>
-  <version>4.5.2.3-SNAPSHOT</version>
+  <version>4.5.2.4-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>oVirt Findbugs Filters</name>

--- a/build-tools-root/ovirt-findbugs-filters/pom.xml
+++ b/build-tools-root/ovirt-findbugs-filters/pom.xml
@@ -14,7 +14,7 @@ SPDX-License-Identifier: Apache-2.0
 
   <groupId>org.ovirt.engine</groupId>
   <artifactId>ovirt-findbugs-filters</artifactId>
-  <version>4.5.2.5</version>
+  <version>4.5.2.6-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>oVirt Findbugs Filters</name>

--- a/build-tools-root/ovirt-findbugs-filters/pom.xml
+++ b/build-tools-root/ovirt-findbugs-filters/pom.xml
@@ -14,7 +14,7 @@ SPDX-License-Identifier: Apache-2.0
 
   <groupId>org.ovirt.engine</groupId>
   <artifactId>ovirt-findbugs-filters</artifactId>
-  <version>4.5.2.4</version>
+  <version>4.5.2.5-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>oVirt Findbugs Filters</name>

--- a/build-tools-root/ovirt-findbugs-filters/pom.xml
+++ b/build-tools-root/ovirt-findbugs-filters/pom.xml
@@ -14,7 +14,7 @@ SPDX-License-Identifier: Apache-2.0
 
   <groupId>org.ovirt.engine</groupId>
   <artifactId>ovirt-findbugs-filters</artifactId>
-  <version>4.5.2.5-SNAPSHOT</version>
+  <version>4.5.2.5</version>
   <packaging>jar</packaging>
 
   <name>oVirt Findbugs Filters</name>

--- a/build-tools-root/ovirt-findbugs-filters/pom.xml
+++ b/build-tools-root/ovirt-findbugs-filters/pom.xml
@@ -14,7 +14,7 @@ SPDX-License-Identifier: Apache-2.0
 
   <groupId>org.ovirt.engine</groupId>
   <artifactId>ovirt-findbugs-filters</artifactId>
-  <version>4.5.2.3</version>
+  <version>4.5.2.3-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>oVirt Findbugs Filters</name>

--- a/build-tools-root/pom.xml
+++ b/build-tools-root/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
   <artifactId>build-tools-root</artifactId>
   <packaging>pom</packaging>

--- a/build-tools-root/pom.xml
+++ b/build-tools-root/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
   <artifactId>build-tools-root</artifactId>
   <packaging>pom</packaging>

--- a/build-tools-root/pom.xml
+++ b/build-tools-root/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
   <artifactId>build-tools-root</artifactId>
   <packaging>pom</packaging>

--- a/build-tools-root/pom.xml
+++ b/build-tools-root/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
   <artifactId>build-tools-root</artifactId>
   <packaging>pom</packaging>

--- a/build-tools-root/pom.xml
+++ b/build-tools-root/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
   <artifactId>build-tools-root</artifactId>
   <packaging>pom</packaging>

--- a/build-tools-root/pom.xml
+++ b/build-tools-root/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
   <artifactId>build-tools-root</artifactId>
   <packaging>pom</packaging>

--- a/build-tools-root/pom.xml
+++ b/build-tools-root/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
   <artifactId>build-tools-root</artifactId>
   <packaging>pom</packaging>

--- a/ear/pom.xml
+++ b/ear/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>engine-server-ear</artifactId>

--- a/ear/pom.xml
+++ b/ear/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>engine-server-ear</artifactId>

--- a/ear/pom.xml
+++ b/ear/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
 
   <artifactId>engine-server-ear</artifactId>

--- a/ear/pom.xml
+++ b/ear/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
 
   <artifactId>engine-server-ear</artifactId>

--- a/ear/pom.xml
+++ b/ear/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>engine-server-ear</artifactId>

--- a/ear/pom.xml
+++ b/ear/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
 
   <artifactId>engine-server-ear</artifactId>

--- a/ear/pom.xml
+++ b/ear/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>engine-server-ear</artifactId>

--- a/frontend/brands/ovirt-brand/pom.xml
+++ b/frontend/brands/ovirt-brand/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>brands-all</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
 
   <artifactId>ovirt-brand</artifactId>

--- a/frontend/brands/ovirt-brand/pom.xml
+++ b/frontend/brands/ovirt-brand/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>brands-all</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>ovirt-brand</artifactId>

--- a/frontend/brands/ovirt-brand/pom.xml
+++ b/frontend/brands/ovirt-brand/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>brands-all</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
 
   <artifactId>ovirt-brand</artifactId>

--- a/frontend/brands/ovirt-brand/pom.xml
+++ b/frontend/brands/ovirt-brand/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>brands-all</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
 
   <artifactId>ovirt-brand</artifactId>

--- a/frontend/brands/ovirt-brand/pom.xml
+++ b/frontend/brands/ovirt-brand/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>brands-all</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>ovirt-brand</artifactId>

--- a/frontend/brands/ovirt-brand/pom.xml
+++ b/frontend/brands/ovirt-brand/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>brands-all</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>ovirt-brand</artifactId>

--- a/frontend/brands/ovirt-brand/pom.xml
+++ b/frontend/brands/ovirt-brand/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>brands-all</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>ovirt-brand</artifactId>

--- a/frontend/brands/pom.xml
+++ b/frontend/brands/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>frontend-all</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
   <artifactId>brands-all</artifactId>
   <packaging>pom</packaging>

--- a/frontend/brands/pom.xml
+++ b/frontend/brands/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>frontend-all</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
   <artifactId>brands-all</artifactId>
   <packaging>pom</packaging>

--- a/frontend/brands/pom.xml
+++ b/frontend/brands/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>frontend-all</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
   <artifactId>brands-all</artifactId>
   <packaging>pom</packaging>

--- a/frontend/brands/pom.xml
+++ b/frontend/brands/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>frontend-all</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
   <artifactId>brands-all</artifactId>
   <packaging>pom</packaging>

--- a/frontend/brands/pom.xml
+++ b/frontend/brands/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>frontend-all</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
   <artifactId>brands-all</artifactId>
   <packaging>pom</packaging>

--- a/frontend/brands/pom.xml
+++ b/frontend/brands/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>frontend-all</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
   <artifactId>brands-all</artifactId>
   <packaging>pom</packaging>

--- a/frontend/brands/pom.xml
+++ b/frontend/brands/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>frontend-all</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
   <artifactId>brands-all</artifactId>
   <packaging>pom</packaging>

--- a/frontend/pom.xml
+++ b/frontend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
   <artifactId>frontend-all</artifactId>
   <groupId>org.ovirt.engine.ui</groupId>

--- a/frontend/pom.xml
+++ b/frontend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
   <artifactId>frontend-all</artifactId>
   <groupId>org.ovirt.engine.ui</groupId>

--- a/frontend/pom.xml
+++ b/frontend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
   <artifactId>frontend-all</artifactId>
   <groupId>org.ovirt.engine.ui</groupId>

--- a/frontend/pom.xml
+++ b/frontend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
   <artifactId>frontend-all</artifactId>
   <groupId>org.ovirt.engine.ui</groupId>

--- a/frontend/pom.xml
+++ b/frontend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
   <artifactId>frontend-all</artifactId>
   <groupId>org.ovirt.engine.ui</groupId>

--- a/frontend/pom.xml
+++ b/frontend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
   <artifactId>frontend-all</artifactId>
   <groupId>org.ovirt.engine.ui</groupId>

--- a/frontend/pom.xml
+++ b/frontend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine</groupId>
     <artifactId>root</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
   <artifactId>frontend-all</artifactId>
   <groupId>org.ovirt.engine.ui</groupId>

--- a/frontend/webadmin/modules/frontend-assemblies/pom.xml
+++ b/frontend/webadmin/modules/frontend-assemblies/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>webadmin-modules</artifactId>
     <groupId>org.ovirt.engine.ui</groupId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
   <artifactId>frontend-assemblies</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/frontend-assemblies/pom.xml
+++ b/frontend/webadmin/modules/frontend-assemblies/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>webadmin-modules</artifactId>
     <groupId>org.ovirt.engine.ui</groupId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
   <artifactId>frontend-assemblies</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/frontend-assemblies/pom.xml
+++ b/frontend/webadmin/modules/frontend-assemblies/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>webadmin-modules</artifactId>
     <groupId>org.ovirt.engine.ui</groupId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
   <artifactId>frontend-assemblies</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/frontend-assemblies/pom.xml
+++ b/frontend/webadmin/modules/frontend-assemblies/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>webadmin-modules</artifactId>
     <groupId>org.ovirt.engine.ui</groupId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
   <artifactId>frontend-assemblies</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/frontend-assemblies/pom.xml
+++ b/frontend/webadmin/modules/frontend-assemblies/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>webadmin-modules</artifactId>
     <groupId>org.ovirt.engine.ui</groupId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
   <artifactId>frontend-assemblies</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/frontend-assemblies/pom.xml
+++ b/frontend/webadmin/modules/frontend-assemblies/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>webadmin-modules</artifactId>
     <groupId>org.ovirt.engine.ui</groupId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
   <artifactId>frontend-assemblies</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/frontend-assemblies/pom.xml
+++ b/frontend/webadmin/modules/frontend-assemblies/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>webadmin-modules</artifactId>
     <groupId>org.ovirt.engine.ui</groupId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
   <artifactId>frontend-assemblies</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/frontend/pom.xml
+++ b/frontend/webadmin/modules/frontend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
   <artifactId>frontend</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/frontend/pom.xml
+++ b/frontend/webadmin/modules/frontend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
   <artifactId>frontend</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/frontend/pom.xml
+++ b/frontend/webadmin/modules/frontend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
   <artifactId>frontend</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/frontend/pom.xml
+++ b/frontend/webadmin/modules/frontend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
   <artifactId>frontend</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/frontend/pom.xml
+++ b/frontend/webadmin/modules/frontend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
   <artifactId>frontend</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/frontend/pom.xml
+++ b/frontend/webadmin/modules/frontend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
   <artifactId>frontend</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/frontend/pom.xml
+++ b/frontend/webadmin/modules/frontend/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
   <artifactId>frontend</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/gwt-aop/pom.xml
+++ b/frontend/webadmin/modules/gwt-aop/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
   <artifactId>gwt-aop</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/gwt-aop/pom.xml
+++ b/frontend/webadmin/modules/gwt-aop/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
   <artifactId>gwt-aop</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/gwt-aop/pom.xml
+++ b/frontend/webadmin/modules/gwt-aop/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
   <artifactId>gwt-aop</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/gwt-aop/pom.xml
+++ b/frontend/webadmin/modules/gwt-aop/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
   <artifactId>gwt-aop</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/gwt-aop/pom.xml
+++ b/frontend/webadmin/modules/gwt-aop/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
   <artifactId>gwt-aop</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/gwt-aop/pom.xml
+++ b/frontend/webadmin/modules/gwt-aop/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
   <artifactId>gwt-aop</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/gwt-aop/pom.xml
+++ b/frontend/webadmin/modules/gwt-aop/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
   <artifactId>gwt-aop</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/gwt-common/pom.xml
+++ b/frontend/webadmin/modules/gwt-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
   <artifactId>gwt-common</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/gwt-common/pom.xml
+++ b/frontend/webadmin/modules/gwt-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
   <artifactId>gwt-common</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/gwt-common/pom.xml
+++ b/frontend/webadmin/modules/gwt-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
   <artifactId>gwt-common</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/gwt-common/pom.xml
+++ b/frontend/webadmin/modules/gwt-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
   <artifactId>gwt-common</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/gwt-common/pom.xml
+++ b/frontend/webadmin/modules/gwt-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
   <artifactId>gwt-common</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/gwt-common/pom.xml
+++ b/frontend/webadmin/modules/gwt-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
   <artifactId>gwt-common</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/gwt-common/pom.xml
+++ b/frontend/webadmin/modules/gwt-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
   <artifactId>gwt-common</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/gwt-extension/pom.xml
+++ b/frontend/webadmin/modules/gwt-extension/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
   <artifactId>gwt-extension</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/gwt-extension/pom.xml
+++ b/frontend/webadmin/modules/gwt-extension/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
   <artifactId>gwt-extension</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/gwt-extension/pom.xml
+++ b/frontend/webadmin/modules/gwt-extension/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
   <artifactId>gwt-extension</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/gwt-extension/pom.xml
+++ b/frontend/webadmin/modules/gwt-extension/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
   <artifactId>gwt-extension</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/gwt-extension/pom.xml
+++ b/frontend/webadmin/modules/gwt-extension/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
   <artifactId>gwt-extension</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/gwt-extension/pom.xml
+++ b/frontend/webadmin/modules/gwt-extension/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
   <artifactId>gwt-extension</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/gwt-extension/pom.xml
+++ b/frontend/webadmin/modules/gwt-extension/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
   <artifactId>gwt-extension</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/pom.xml
+++ b/frontend/webadmin/modules/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-all</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
   <artifactId>webadmin-modules</artifactId>
   <packaging>pom</packaging>

--- a/frontend/webadmin/modules/pom.xml
+++ b/frontend/webadmin/modules/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-all</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
   <artifactId>webadmin-modules</artifactId>
   <packaging>pom</packaging>

--- a/frontend/webadmin/modules/pom.xml
+++ b/frontend/webadmin/modules/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-all</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
   <artifactId>webadmin-modules</artifactId>
   <packaging>pom</packaging>

--- a/frontend/webadmin/modules/pom.xml
+++ b/frontend/webadmin/modules/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-all</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
   <artifactId>webadmin-modules</artifactId>
   <packaging>pom</packaging>

--- a/frontend/webadmin/modules/pom.xml
+++ b/frontend/webadmin/modules/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-all</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
   <artifactId>webadmin-modules</artifactId>
   <packaging>pom</packaging>

--- a/frontend/webadmin/modules/pom.xml
+++ b/frontend/webadmin/modules/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-all</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
   <artifactId>webadmin-modules</artifactId>
   <packaging>pom</packaging>

--- a/frontend/webadmin/modules/pom.xml
+++ b/frontend/webadmin/modules/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-all</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
   <artifactId>webadmin-modules</artifactId>
   <packaging>pom</packaging>

--- a/frontend/webadmin/modules/uicommonweb/pom.xml
+++ b/frontend/webadmin/modules/uicommonweb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.ovirt.engine.ui</groupId>
         <artifactId>webadmin-modules</artifactId>
-        <version>4.5.2.4-SNAPSHOT</version>
+        <version>4.5.2.4</version>
     </parent>
 
     <artifactId>uicommonweb</artifactId>

--- a/frontend/webadmin/modules/uicommonweb/pom.xml
+++ b/frontend/webadmin/modules/uicommonweb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.ovirt.engine.ui</groupId>
         <artifactId>webadmin-modules</artifactId>
-        <version>4.5.2.2</version>
+        <version>4.5.2.3</version>
     </parent>
 
     <artifactId>uicommonweb</artifactId>

--- a/frontend/webadmin/modules/uicommonweb/pom.xml
+++ b/frontend/webadmin/modules/uicommonweb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.ovirt.engine.ui</groupId>
         <artifactId>webadmin-modules</artifactId>
-        <version>4.5.2.4</version>
+        <version>4.5.2.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>uicommonweb</artifactId>

--- a/frontend/webadmin/modules/uicommonweb/pom.xml
+++ b/frontend/webadmin/modules/uicommonweb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.ovirt.engine.ui</groupId>
         <artifactId>webadmin-modules</artifactId>
-        <version>4.5.2.3</version>
+        <version>4.5.2.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>uicommonweb</artifactId>

--- a/frontend/webadmin/modules/uicommonweb/pom.xml
+++ b/frontend/webadmin/modules/uicommonweb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.ovirt.engine.ui</groupId>
         <artifactId>webadmin-modules</artifactId>
-        <version>4.5.2.5</version>
+        <version>4.5.2.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>uicommonweb</artifactId>

--- a/frontend/webadmin/modules/uicommonweb/pom.xml
+++ b/frontend/webadmin/modules/uicommonweb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.ovirt.engine.ui</groupId>
         <artifactId>webadmin-modules</artifactId>
-        <version>4.5.2.5-SNAPSHOT</version>
+        <version>4.5.2.5</version>
     </parent>
 
     <artifactId>uicommonweb</artifactId>

--- a/frontend/webadmin/modules/uicommonweb/pom.xml
+++ b/frontend/webadmin/modules/uicommonweb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.ovirt.engine.ui</groupId>
         <artifactId>webadmin-modules</artifactId>
-        <version>4.5.2.3-SNAPSHOT</version>
+        <version>4.5.2.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>uicommonweb</artifactId>

--- a/frontend/webadmin/modules/uicompat/pom.xml
+++ b/frontend/webadmin/modules/uicompat/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
   <artifactId>uicompat</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/uicompat/pom.xml
+++ b/frontend/webadmin/modules/uicompat/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
   <artifactId>uicompat</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/uicompat/pom.xml
+++ b/frontend/webadmin/modules/uicompat/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
   <artifactId>uicompat</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/uicompat/pom.xml
+++ b/frontend/webadmin/modules/uicompat/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
   <artifactId>uicompat</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/uicompat/pom.xml
+++ b/frontend/webadmin/modules/uicompat/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
   <artifactId>uicompat</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/uicompat/pom.xml
+++ b/frontend/webadmin/modules/uicompat/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
   <artifactId>uicompat</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/uicompat/pom.xml
+++ b/frontend/webadmin/modules/uicompat/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>webadmin-modules</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
   <artifactId>uicompat</artifactId>
   <packaging>jar</packaging>

--- a/frontend/webadmin/modules/webadmin/pom.xml
+++ b/frontend/webadmin/modules/webadmin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>webadmin-modules</artifactId>
     <groupId>org.ovirt.engine.ui</groupId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
   <artifactId>webadmin</artifactId>
   <packaging>war</packaging>

--- a/frontend/webadmin/modules/webadmin/pom.xml
+++ b/frontend/webadmin/modules/webadmin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>webadmin-modules</artifactId>
     <groupId>org.ovirt.engine.ui</groupId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
   <artifactId>webadmin</artifactId>
   <packaging>war</packaging>

--- a/frontend/webadmin/modules/webadmin/pom.xml
+++ b/frontend/webadmin/modules/webadmin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>webadmin-modules</artifactId>
     <groupId>org.ovirt.engine.ui</groupId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
   <artifactId>webadmin</artifactId>
   <packaging>war</packaging>

--- a/frontend/webadmin/modules/webadmin/pom.xml
+++ b/frontend/webadmin/modules/webadmin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>webadmin-modules</artifactId>
     <groupId>org.ovirt.engine.ui</groupId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
   <artifactId>webadmin</artifactId>
   <packaging>war</packaging>

--- a/frontend/webadmin/modules/webadmin/pom.xml
+++ b/frontend/webadmin/modules/webadmin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>webadmin-modules</artifactId>
     <groupId>org.ovirt.engine.ui</groupId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
   <artifactId>webadmin</artifactId>
   <packaging>war</packaging>

--- a/frontend/webadmin/modules/webadmin/pom.xml
+++ b/frontend/webadmin/modules/webadmin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>webadmin-modules</artifactId>
     <groupId>org.ovirt.engine.ui</groupId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
   <artifactId>webadmin</artifactId>
   <packaging>war</packaging>

--- a/frontend/webadmin/modules/webadmin/pom.xml
+++ b/frontend/webadmin/modules/webadmin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>webadmin-modules</artifactId>
     <groupId>org.ovirt.engine.ui</groupId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
   <artifactId>webadmin</artifactId>
   <packaging>war</packaging>

--- a/frontend/webadmin/pom.xml
+++ b/frontend/webadmin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>frontend-all</artifactId>
-    <version>4.5.2.5</version>
+    <version>4.5.2.6-SNAPSHOT</version>
   </parent>
   <artifactId>webadmin-all</artifactId>
   <packaging>pom</packaging>

--- a/frontend/webadmin/pom.xml
+++ b/frontend/webadmin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>frontend-all</artifactId>
-    <version>4.5.2.3-SNAPSHOT</version>
+    <version>4.5.2.4-SNAPSHOT</version>
   </parent>
   <artifactId>webadmin-all</artifactId>
   <packaging>pom</packaging>

--- a/frontend/webadmin/pom.xml
+++ b/frontend/webadmin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>frontend-all</artifactId>
-    <version>4.5.2.4</version>
+    <version>4.5.2.5-SNAPSHOT</version>
   </parent>
   <artifactId>webadmin-all</artifactId>
   <packaging>pom</packaging>

--- a/frontend/webadmin/pom.xml
+++ b/frontend/webadmin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>frontend-all</artifactId>
-    <version>4.5.2.4-SNAPSHOT</version>
+    <version>4.5.2.4</version>
   </parent>
   <artifactId>webadmin-all</artifactId>
   <packaging>pom</packaging>

--- a/frontend/webadmin/pom.xml
+++ b/frontend/webadmin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>frontend-all</artifactId>
-    <version>4.5.2.3</version>
+    <version>4.5.2.3-SNAPSHOT</version>
   </parent>
   <artifactId>webadmin-all</artifactId>
   <packaging>pom</packaging>

--- a/frontend/webadmin/pom.xml
+++ b/frontend/webadmin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>frontend-all</artifactId>
-    <version>4.5.2.2</version>
+    <version>4.5.2.3</version>
   </parent>
   <artifactId>webadmin-all</artifactId>
   <packaging>pom</packaging>

--- a/frontend/webadmin/pom.xml
+++ b/frontend/webadmin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.ovirt.engine.ui</groupId>
     <artifactId>frontend-all</artifactId>
-    <version>4.5.2.5-SNAPSHOT</version>
+    <version>4.5.2.5</version>
   </parent>
   <artifactId>webadmin-all</artifactId>
   <packaging>pom</packaging>

--- a/mavenmake/pom.xml
+++ b/mavenmake/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.ovirt.engine</groupId>
         <artifactId>root</artifactId>
-        <version>4.5.2.4</version>
+        <version>4.5.2.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>make</artifactId>

--- a/mavenmake/pom.xml
+++ b/mavenmake/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.ovirt.engine</groupId>
         <artifactId>root</artifactId>
-        <version>4.5.2.5</version>
+        <version>4.5.2.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>make</artifactId>

--- a/mavenmake/pom.xml
+++ b/mavenmake/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.ovirt.engine</groupId>
         <artifactId>root</artifactId>
-        <version>4.5.2.5-SNAPSHOT</version>
+        <version>4.5.2.5</version>
     </parent>
 
     <artifactId>make</artifactId>

--- a/mavenmake/pom.xml
+++ b/mavenmake/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.ovirt.engine</groupId>
         <artifactId>root</artifactId>
-        <version>4.5.2.4-SNAPSHOT</version>
+        <version>4.5.2.4</version>
     </parent>
 
     <artifactId>make</artifactId>

--- a/mavenmake/pom.xml
+++ b/mavenmake/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.ovirt.engine</groupId>
         <artifactId>root</artifactId>
-        <version>4.5.2.2</version>
+        <version>4.5.2.3</version>
     </parent>
 
     <artifactId>make</artifactId>

--- a/mavenmake/pom.xml
+++ b/mavenmake/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.ovirt.engine</groupId>
         <artifactId>root</artifactId>
-        <version>4.5.2.3</version>
+        <version>4.5.2.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>make</artifactId>

--- a/mavenmake/pom.xml
+++ b/mavenmake/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.ovirt.engine</groupId>
         <artifactId>root</artifactId>
-        <version>4.5.2.3-SNAPSHOT</version>
+        <version>4.5.2.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>make</artifactId>

--- a/ovirt-engine.spec.in
+++ b/ovirt-engine.spec.in
@@ -1415,6 +1415,9 @@ fi
 %{engine_data}/setup/bin/ovirt-engine-health
 
 %changelog
+* Fri Aug 19 2022 Martin Perina <mperina@redhat.com> - 4.5.2.4
+- Bump version to 4.5.2.4
+
 * Tue Aug 16 2022 Michal Skrivanek <michal.skrivanek@redhat.com> - 4.5.2.3
 - Bump version to 4.5.2.3
 

--- a/ovirt-engine.spec.in
+++ b/ovirt-engine.spec.in
@@ -1415,6 +1415,9 @@ fi
 %{engine_data}/setup/bin/ovirt-engine-health
 
 %changelog
+* Wed Aug 31 2022 Michal Skrivanek <michal.skrivanek@redhat.com> - 4.5.2.5
+- Bump version to 4.5.2.5
+
 * Fri Aug 19 2022 Martin Perina <mperina@redhat.com> - 4.5.2.4
 - Bump version to 4.5.2.4
 

--- a/ovirt-engine.spec.in
+++ b/ovirt-engine.spec.in
@@ -1415,6 +1415,9 @@ fi
 %{engine_data}/setup/bin/ovirt-engine-health
 
 %changelog
+* Tue Aug 16 2022 Michal Skrivanek <michal.skrivanek@redhat.com> - 4.5.2.3
+- Bump version to 4.5.2.3
+
 * Tue Aug 09 2022 Martin Perina <mperina@redhat.com> - 4.5.2.2
 - Bump version to 4.5.2.2
 

--- a/packaging/setup/ovirt_engine_setup/constants.py
+++ b/packaging/setup/ovirt_engine_setup/constants.py
@@ -219,6 +219,8 @@ class Stages(object):
 
     SETUP_SELINUX = 'osetup.setup.selinux'
 
+    REMOTE_ENGINE_CLEANUP = 'osetup.remote.engine.cleanup'
+
 
 @util.export
 @util.codegen

--- a/packaging/setup/plugins/ovirt-engine-common/base/remote_engine/remote_engine.py
+++ b/packaging/setup/plugins/ovirt-engine-common/base/remote_engine/remote_engine.py
@@ -65,6 +65,7 @@ class Plugin(plugin.PluginBase):
         ] = remote_engine.RemoteEngine(plugin=self)
 
     @plugin.event(
+        name=osetupcons.Stages.REMOTE_ENGINE_CLEANUP,
         stage=plugin.Stages.STAGE_CLOSEUP,
     )
     def _cleanup(self):

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.ovirt.engine</groupId>
   <artifactId>root</artifactId>
-  <version>4.5.2.3</version>
+  <version>4.5.2.3-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>ovirt-root</name>
   <description>oVirt Engine Root Project</description>
@@ -773,7 +773,7 @@
             <dependency>
               <groupId>org.ovirt.engine</groupId>
               <artifactId>ovirt-findbugs-filters</artifactId>
-              <version>4.5.2.3</version>
+              <version>4.5.2.3-SNAPSHOT</version>
             </dependency>
           </dependencies>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.ovirt.engine</groupId>
   <artifactId>root</artifactId>
-  <version>4.5.2.4</version>
+  <version>4.5.2.5-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>ovirt-root</name>
   <description>oVirt Engine Root Project</description>
@@ -773,7 +773,7 @@
             <dependency>
               <groupId>org.ovirt.engine</groupId>
               <artifactId>ovirt-findbugs-filters</artifactId>
-              <version>4.5.2.4</version>
+              <version>4.5.2.5-SNAPSHOT</version>
             </dependency>
           </dependencies>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.ovirt.engine</groupId>
   <artifactId>root</artifactId>
-  <version>4.5.2.5</version>
+  <version>4.5.2.6-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>ovirt-root</name>
   <description>oVirt Engine Root Project</description>
@@ -773,7 +773,7 @@
             <dependency>
               <groupId>org.ovirt.engine</groupId>
               <artifactId>ovirt-findbugs-filters</artifactId>
-              <version>4.5.2.5</version>
+              <version>4.5.2.6-SNAPSHOT</version>
             </dependency>
           </dependencies>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.ovirt.engine</groupId>
   <artifactId>root</artifactId>
-  <version>4.5.2.2</version>
+  <version>4.5.2.3</version>
   <packaging>pom</packaging>
   <name>ovirt-root</name>
   <description>oVirt Engine Root Project</description>
@@ -773,7 +773,7 @@
             <dependency>
               <groupId>org.ovirt.engine</groupId>
               <artifactId>ovirt-findbugs-filters</artifactId>
-              <version>4.5.2.2</version>
+              <version>4.5.2.3</version>
             </dependency>
           </dependencies>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.ovirt.engine</groupId>
   <artifactId>root</artifactId>
-  <version>4.5.2.5-SNAPSHOT</version>
+  <version>4.5.2.5</version>
   <packaging>pom</packaging>
   <name>ovirt-root</name>
   <description>oVirt Engine Root Project</description>
@@ -773,7 +773,7 @@
             <dependency>
               <groupId>org.ovirt.engine</groupId>
               <artifactId>ovirt-findbugs-filters</artifactId>
-              <version>4.5.2.5-SNAPSHOT</version>
+              <version>4.5.2.5</version>
             </dependency>
           </dependencies>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.ovirt.engine</groupId>
   <artifactId>root</artifactId>
-  <version>4.5.2.4-SNAPSHOT</version>
+  <version>4.5.2.4</version>
   <packaging>pom</packaging>
   <name>ovirt-root</name>
   <description>oVirt Engine Root Project</description>
@@ -773,7 +773,7 @@
             <dependency>
               <groupId>org.ovirt.engine</groupId>
               <artifactId>ovirt-findbugs-filters</artifactId>
-              <version>4.5.2.4-SNAPSHOT</version>
+              <version>4.5.2.4</version>
             </dependency>
           </dependencies>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.ovirt.engine</groupId>
   <artifactId>root</artifactId>
-  <version>4.5.2.3-SNAPSHOT</version>
+  <version>4.5.2.4-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>ovirt-root</name>
   <description>oVirt Engine Root Project</description>
@@ -773,7 +773,7 @@
             <dependency>
               <groupId>org.ovirt.engine</groupId>
               <artifactId>ovirt-findbugs-filters</artifactId>
-              <version>4.5.2.3-SNAPSHOT</version>
+              <version>4.5.2.4-SNAPSHOT</version>
             </dependency>
           </dependencies>
         </plugin>


### PR DESCRIPTION
- Enable CI on ovirt-engine-4.5.2.z branch
- ansible: do not raise on missing host
- build: ovirt-engine-4.5.2.3
- build: post ovirt-engine-4.5.2.3
- build: Fix post ovirt-engine-4.5.2.3
- Fix checking ovirt-provider-ovn certificate validity
- build: ovirt-engine-4.5.2.4
- build: post ovirt-engine-4.5.2.4
- setup: Put unique name to remote engine cleanup event
- build: ovirt-engine-4.5.2.5
- build: post ovirt-engine-4.5.2.5
