### PR TITLE
core: do not use DeserializationFeature.READ_ENUMS_USING_TO_STRING 

### DIFF
--- a/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/serialization/json/JsonObjectDeserializer.java
+++ b/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/serialization/json/JsonObjectDeserializer.java
@@ -1,7 +1,6 @@
 package org.ovirt.engine.core.utils.serialization.json;
 
 import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
-import static com.fasterxml.jackson.databind.DeserializationFeature.READ_ENUMS_USING_TO_STRING;
 import static com.fasterxml.jackson.databind.DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL;
 
 import java.io.IOException;
@@ -56,7 +55,6 @@ public class JsonObjectDeserializer implements Deserializer {
         formattedMapper.addMixIn(EngineFault.class, JsonEngineFaultMixIn.class);
         formattedMapper.configure(FAIL_ON_UNKNOWN_PROPERTIES, false);
         formattedMapper.configure(READ_UNKNOWN_ENUM_VALUES_AS_NULL, true);
-        formattedMapper.configure(READ_ENUMS_USING_TO_STRING, true);
 
         formattedMapper.activateDefaultTyping(LaissezFaireSubTypeValidator.instance);
     }


### PR DESCRIPTION
DeserializationFeature.READ_ENUMS_USING_TO_STRING causes jackson to
deserialize enums using their toString implementation, however, this
implementation may have been overridden to returns a value that does not
match Enum#name(), causing deserialization to fail. Because of this it
would make more sense to use the default, which uses Enum#name() as it
is cannot be overridden.

Additionally, the corresponding serialization config
(WRITE_ENUMS_USING_TO_STRING), which will make jackson use different
methods for serialization and deserialization.

Bug-Url: https://bugzilla.redhat.com/2123008