### PR TITLE
Fix error when changing cluster of diskless vms

### DIFF
--- a/frontend/webadmin/modules/gwt-common/src/main/java/org/ovirt/engine/ui/common/widget/uicommon/storage/DisksAllocationView.java
+++ b/frontend/webadmin/modules/gwt-common/src/main/java/org/ovirt/engine/ui/common/widget/uicommon/storage/DisksAllocationView.java
@@ -1,6 +1,8 @@
 package org.ovirt.engine.ui.common.widget.uicommon.storage;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 import org.ovirt.engine.ui.common.CommonApplicationConstants;
 import org.ovirt.engine.ui.common.PopupSimpleTableResources;
@@ -189,11 +191,15 @@ public class DisksAllocationView extends Composite implements HasEditorDriver<Di
 
     void addDiskList(DisksAllocationModel model) {
         diskListPanel.clear();
-        diskAllocationLabel.setVisible(!model.getDisks().isEmpty());
+        List<DiskModel> disks = model.getDisks();
+        if (disks == null) {
+            disks = Collections.emptyList();
+        }
+        diskAllocationLabel.setVisible(!disks.isEmpty());
 
         int diskIndex = 0;
         String columnWidth = calculateColumnWidthPercentage();
-        for (final DiskModel diskModel : model.getDisks()) {
+        for (final DiskModel diskModel : disks) {
             DisksAllocationItemView disksAllocationItemView = new DisksAllocationItemView(columnWidth);
             disksAllocationItemView.edit(diskModel);
             disksAllocationItemView.setIsAliasChangeable(model.getIsAliasChangeable());


### PR DESCRIPTION
DisksAllocationView#addDiskList wasn't prepared for getting a model
without disks sets (i.e., 'disks' is null) and since https://github.com/oVirt/ovirt-engine/commit/50e0bb96a17ddb18fb065963683d37198609dfd2 this
might happen, therefore proper handling (treating this case as if an
empty list of disks is set) is added to DisksAllocationView#addDiskList.

Bug-Url: https://bugzilla.redhat.com/2121083
Signed-off-by: Arik Hadas <ahadas@redhat.com>