### PR TITLE
core: Refresh ISO cache when new guest agent installed

### DIFF
--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/IVdsEventListener.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/IVdsEventListener.java
@@ -86,6 +86,8 @@ public interface IVdsEventListener {
 
     void restartVmsWithLease(List<Guid> vmIds, Guid hostId);
 
+    void refreshIsoCache(Guid storagePoolId);
+
     Map<String, Pair<String, String>> getVdsPoolAndStorageConnectionsLock(Guid vdsId);
 
     ActionReturnValue saveExternalData(SaveVmExternalDataParameters parameters);

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/ResourceManager.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/ResourceManager.java
@@ -470,6 +470,10 @@ public class ResourceManager implements BackendService {
         ReactorFactory.getWorker(this.parallelism, this.eventTimeoutInHours).getPublisher().subscribe(subscriber);
     }
 
+    public void refreshIsoCache(Guid storagePoolId) {
+        getEventListener().refreshIsoCache(storagePoolId);
+    }
+
     @Inject
     @ThreadPools(ThreadPools.ThreadPoolType.EngineThreadMonitoringThreadPool)
     private ManagedScheduledExecutorService monitoringExecutor;

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/monitoring/VmAnalyzer.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/monitoring/VmAnalyzer.java
@@ -746,7 +746,9 @@ public class VmAnalyzer {
             vmGuestAgentNics = filterGuestAgentInterfaces(nullToEmptyList(vdsmVm.getVmGuestAgentInterfaces()));
             dbVm.setIp(extractVmIps(vmGuestAgentNics));
         }
-
+        if (!Objects.equals(vdsmVm.getVmDynamic().getAppList(), dbVm.getAppList())) {
+            resourceManager.refreshIsoCache(vdsManager.getCopyVds().getStoragePoolId());
+        }
         dbVm.updateRuntimeData(vdsmVm.getVmDynamic(), vdsManager.getVdsId());
         saveDynamic(dbVm);
     }


### PR DESCRIPTION
The latest available guest tools version is figured out by analyzing ISO
disks available on ISO and data storage domains. The list of available
ISO disks is cached and this cache is refreshed when user queries the
list of images on a storage domain. At that moment, the latest guest
tools version is refreshed and the guest agent installation hint
(presented to the user) is updated.

But ISO cache refresh does not happen after a new guest agent is
installed. That's why the guest agent installation hint is still shown
after installing the latest guest agent in the VM.

To fix that, this patch adds ISO cache refresh when the list of
applications for a particular VM is changed.

Change-Id: I6c25a97ae14cc40d073b3873c6bae9db3216204d
Bug-Url: https://bugzilla.redhat.com/1983401
Bug-Url: https://bugzilla.redhat.com/2120381
Signed-off-by: Shmuel Melamud <smelamud@redhat.com>