### PR TITLE
packaging: setup: remote_engine: manual_files: Read as binary

### DIFF
--- a/packaging/setup/plugins/ovirt-engine-common/base/remote_engine/remote_engine_manual_files.py
+++ b/packaging/setup/plugins/ovirt-engine-common/base/remote_engine/remote_engine_manual_files.py
@@ -83,7 +83,7 @@ class Plugin(plugin.PluginBase):
                 ),
                 prompt=True,
             )
-            with open(resfilename) as f:
+            with open(resfilename, 'rb') as f:
                 res = f.read()
             return res
 


### PR DESCRIPTION
Make remote_engine_manual_files.py match the behavior of remote_engine_root_ssh.py, and so make 'copy_from_engine' return a bytes object, not str.

This should fix the bug that [1] was supposed to fix, but [1] only fixed it for the 'manual files' mode and broke paramiko/ssh.

[1]
https://github.com/oVirt/ovirt-dwh/commit/885d65f0594dee08a48fbe48bdf697de7bcceb6b

Change-Id: I32cd8aff5e851fb053b2cd5b8237455ce2230a35
Signed-off-by: Yedidyah Bar David <didi@redhat.com>