### PR TITLE
Removing a duplicate "setStoragePoolId()" call at the "LiveMigrateDiskCommand" class

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/lsm/LiveMigrateDiskCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/lsm/LiveMigrateDiskCommand.java
@@ -86,7 +86,8 @@ import org.ovirt.engine.core.vdsbroker.ResourceManager;
 import org.ovirt.engine.core.vdsbroker.builder.vminfo.VmInfoBuildUtils;
 
 @NonTransactiveCommandAttribute(forceCompensation = true)
-public class LiveMigrateDiskCommand<T extends LiveMigrateDiskParameters> extends MoveOrCopyDiskCommand<T>implements SerialChildExecutingCommand {
+public class LiveMigrateDiskCommand<T extends LiveMigrateDiskParameters> extends MoveOrCopyDiskCommand<T>
+        implements SerialChildExecutingCommand {
 
     private Guid sourceQuotaId;
     private Guid sourceDiskProfileId;
@@ -617,8 +618,6 @@ public class LiveMigrateDiskCommand<T extends LiveMigrateDiskParameters> extends
         if (!getVm().isRunningAndQualifyForDisksMigration()) {
             return failValidation(EngineMessage.CANNOT_LIVE_MIGRATE_VM_SHOULD_BE_IN_PAUSED_OR_UP_STATUS);
         }
-
-        setStoragePoolId(getVm().getStoragePoolId());
 
         if (!validate(new StorageDomainValidator(getDstStorageDomain()).isNotBackupDomain())
                 || !validateDestDomainsSpaceRequirements()) {


### PR DESCRIPTION
Exactly the same call to `setStoragePoolId()` is already performed in `init()`, see [1].
So I see no reason why the same code should be executed again in `validate()`, especially that `validate()` is designed for other purposes.

[1] https://github.com/oVirt/ovirt-engine/blob/ovirt-engine-4.5.2/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/lsm/LiveMigrateDiskCommand.java#L143

Signed-off-by: Pavel Bar <pbar@redhat.com>