### PR TITLE
Make register-vm a sync operation

### DIFF
--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/AbstractBackendCollectionResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/AbstractBackendCollectionResource.java
@@ -264,28 +264,6 @@ public abstract class AbstractBackendCollectionResource<R extends BaseResource, 
     }
 
     /**
-     * Returns true if there are still processes running in the
-     * background, associated with the current request.
-     *
-     * For vdsm-task polling, the indication is the existence of running
-     * vdsm tasks.
-     *
-     * For job polling, the indication is that the job is in PENDING or
-     * IN_PROGRESS status.
-     */
-    private boolean isAsyncTaskOrJobExists(PollingType pollingType, ActionReturnValue createResult) {
-        if (pollingType==PollingType.VDSM_TASKS) {
-            //when the polling-type is vdsm_tasks, check for existing async-tasks
-            return createResult.getHasAsyncTasks();
-        } else if (pollingType==PollingType.JOB) {
-            //when the polling-type is job, check if the job is pending or in progress
-            CreationStatus status = getJobIdStatus(createResult);
-            return status==CreationStatus.PENDING || status==CreationStatus.IN_PROGRESS;
-        }
-        return false; //shouldn't reach here
-    }
-
-    /**
      * In rare cases, after entity creation there is a need to make modifications
      * to the created entity. Such changes should be done here
      *

--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/AbstractBackendResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/AbstractBackendResource.java
@@ -119,6 +119,28 @@ public abstract class AbstractBackendResource<R extends BaseResource, Q>
         return asyncStatus;
     }
 
+    /**
+     * Returns true if there are still processes running in the
+     * background, associated with the current request.
+     *
+     * For vdsm-task polling, the indication is the existence of running
+     * vdsm tasks.
+     *
+     * For job polling, the indication is that the job is in PENDING or
+     * IN_PROGRESS status.
+     */
+    protected boolean isAsyncTaskOrJobExists(PollingType pollingType, ActionReturnValue createResult) {
+        if (pollingType==PollingType.VDSM_TASKS) {
+            //when the polling-type is vdsm_tasks, check for existing async-tasks
+            return createResult.getHasAsyncTasks();
+        } else if (pollingType==PollingType.JOB) {
+            //when the polling-type is job, check if the job is pending or in progress
+            CreationStatus status = getJobIdStatus(createResult);
+            return status==CreationStatus.PENDING || status==CreationStatus.IN_PROGRESS;
+        }
+        return false; //shouldn't reach here
+    }
+
     protected CreationStatus getJobIdStatus(ActionReturnValue result) {
         Guid jobId = result.getJobId();
         if (jobId == null || jobId.equals(Guid.Empty)) {

--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendStorageDomainVmResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendStorageDomainVmResource.java
@@ -104,6 +104,10 @@ public class BackendStorageDomainVmResource
             params.setClusterId(getClusterId(action));
         }
         params.setImagesExistOnTargetStorageDomain(true);
+        // disable async mode by default since this operation should be fairly quick
+        if (!action.isSetAsync()) {
+            action.setAsync(false);
+        }
 
         if (action.isSetClone()) {
             params.setImportAsNewEntity(action.isClone());
@@ -117,7 +121,7 @@ public class BackendStorageDomainVmResource
         if (action.isSetName()) {
             params.setName(action.getName());
         }
-        return doAction(ActionType.ImportVmFromConfiguration, params, action);
+        return doAction(ActionType.ImportVmFromConfiguration, params, action, PollingType.JOB);
     }
 
     @Override


### PR DESCRIPTION
In https://github.com/oVirt/ovirt-engine/commit/38d5120a50c5fde814f229117922d658d3bff531 we've changed add VM from configuration to
be a blocking/sync operation. Here we do something similar for
register-vm, setting it to blocking/sync by default, for the
same reason - this operation doesn't involve copying the disks,
only add-lease is asynchronous and it is a relatively short
operation, so the caller won't wait much and at the end of the
call the VM is ready to be used.

This is particularly important for disaster recovery as we try
to start highly available VMs right after registering them. It
might have been better to change the disaster recovery scripts
to specify async=false, but that would require more efforts.

That change revealed an issue with the tests of ExportVmTemplate
since it is monitored by polling the job but tested as if it
was monitored by polling the VDSM tasks. Therefore the API
tests of ExportVmTemplate are also changed here.

Bug-Url: https://bugzilla.redhat.com/1968433
Signed-off-by: Arik Hadas <ahadas@redhat.com>