### PR TITLE
packaging: spec: Conflict with dwh < 4.5.6

### DIFF
--- a/ovirt-engine.spec.in
+++ b/ovirt-engine.spec.in
@@ -538,7 +538,7 @@ Requires:	python3-paramiko
 Requires:	python3-distro
 Requires(pre):	shadow-utils
 Conflicts:	%{name}-dwh < 4.4.0
-Conflicts:	%{name}-dwh-setup < 4.5.5
+Conflicts:	%{name}-dwh-setup < 4.5.6
 Conflicts:	%{name}-keycloak-setup < 15.0.2-6
 
 %description setup-base


### PR DESCRIPTION
In be73877c I made the engine conflict with a too-old dwh, < 4.5.5. Eventually the changes we need there are in 4.5.6.

Without this, engine-setup (4.5.3 engine, 4.5.5 dwh) fails with:

***L:ERROR Internal error: asked_on must be set when is_secret is set Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/otopi/main.py", line 141, in execute
    self.context.loadPlugins()
  File "/usr/lib/python3.6/site-packages/otopi/context.py", line 803, in loadPlugins
    self._loadPluginGroups(plugindir, needgroups, loadedgroups)
  File "/usr/lib/python3.6/site-packages/otopi/context.py", line 112, in _loadPluginGroups
    self._loadPlugins(path, path, groupname)
  File "/usr/lib/python3.6/site-packages/otopi/context.py", line 69, in _loadPlugins
    self._loadPlugins(base, d, groupname)
  File "/usr/lib/python3.6/site-packages/otopi/context.py", line 69, in _loadPlugins
    self._loadPlugins(base, d, groupname)
  File "/usr/lib/python3.6/site-packages/otopi/context.py", line 100, in _loadPlugins
    os.path.basename(path),
  File "/usr/lib/python3.6/site-packages/otopi/util.py", line 110, in loadModule
    spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/usr/share/ovirt-engine/setup/bin/../plugins/ovirt-engine-common/ovirt-engine-grafana-dwh/config/__init__.py", line 15, in <module>
    from . import grafana_fqdn
  File "/usr/share/ovirt-engine/setup/bin/../plugins/ovirt-engine-common/ovirt-engine-grafana-dwh/config/grafana_fqdn.py", line 16, in <module>
    from ovirt_engine_setup.grafana_dwh import constants as ogdwhcons
  File "/usr/share/ovirt-engine/setup/ovirt_engine_setup/grafana_dwh/constants.py", line 256, in <module>
    class ConfigEnv(object):
  File "/usr/share/ovirt-engine/setup/ovirt_engine_setup/grafana_dwh/constants.py", line 262, in ConfigEnv
    is_secret=True,
  File "/usr/share/ovirt-engine/setup/ovirt_engine_setup/constants.py", line 66, in osetupattrs
    raise RuntimeError('asked_on must be set when is_secret is set')
RuntimeError: asked_on must be set when is_secret is set

Change-Id: I33af8185a25b2f94d5214f430c5c70d49c7518dc
Signed-off-by: Yedidyah Bar David <didi@redhat.com>