### PR TITLE
engine: Fix update cluster with numa VMs

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/UpdateClusterCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/UpdateClusterCommand.java
@@ -542,6 +542,7 @@ public class UpdateClusterCommand<T extends ClusterOperationParameters> extends
             updateParams.setClusterLevelChangeFromVersion(oldCluster.getCompatibilityVersion());
         }
         updateParams.setCompensationEnabled(true);
+        updateParams.setUpdateNuma(false);
 
         if (updateParams.getVmStaticData().getCustomCompatibilityVersion() == null) {
             new CompatibilityVersionUpdater().updateVmBaseCompatibilityVersion(


### PR DESCRIPTION
When editing a cluster's CPU or version, an update of the underlying VMs and templates is performed.
If any of them has numa enabled, the update cluster command would fail because paramters's updateNuma = null is changed to updateNuma = true in UpdateVmCommand.

Tnis patch makes it explicit that we are not updating the numa by setting updateNuma = false parameter.