### PR TITLE
Fix "GetDiskSnapshotByImageIdQuery" to be more null-safe

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/snapshots/GetDiskSnapshotByImageIdQuery.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/snapshots/GetDiskSnapshotByImageIdQuery.java
@@ -5,6 +5,7 @@ import javax.inject.Inject;
 import org.ovirt.engine.core.bll.QueriesCommandBase;
 import org.ovirt.engine.core.bll.context.EngineContext;
 import org.ovirt.engine.core.common.businessentities.storage.DiskImage;
+import org.ovirt.engine.core.common.businessentities.storage.Image;
 import org.ovirt.engine.core.common.queries.IdQueryParameters;
 import org.ovirt.engine.core.dao.DiskImageDao;
 import org.ovirt.engine.core.dao.ImageDao;
@@ -23,12 +24,12 @@ public class GetDiskSnapshotByImageIdQuery<P extends IdQueryParameters> extends 
     @Override
     protected void executeQueryCommand() {
         DiskImage diskImage = diskImageDao.getSnapshotById(getParameters().getId());
-        if (diskImage == null) {
-            getQueryReturnValue().setReturnValue(null);
-            return;
+        if (diskImage != null) {
+            Image parentImage = imageDao.get(diskImage.getParentId());
+            if (parentImage != null) {
+                diskImage.setParentDiskId(parentImage.getDiskId());
+            }
+            getQueryReturnValue().setReturnValue(diskImage);
         }
-        diskImage.setParentDiskId(imageDao.get(diskImage.getParentId()).getDiskId());
-
-        getQueryReturnValue().setReturnValue(diskImage);
     }
 }


### PR DESCRIPTION
There was a [fix](https://github.com/oVirt/ovirt-engine/compare/80af2c8e5ea9d81558508eb3602c435ce4bc570c..c3f83f67af84df51cceb337777b599d8f301ca3a) from @ahadas that was somehow missed in the final version that was merged.
Adding this as an addition to the already merged patch by @ArtiomDivak (see [1]).

[1] PR: https://github.com/oVirt/ovirt-engine/pull/549

Bug-Url: https://bugzilla.redhat.com/2013697