### PR TITLE
core: fix checking if an active snapshot is set with memory for restoring purpose

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/snapshots/TryBackToAllSnapshotsOfVmCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/snapshots/TryBackToAllSnapshotsOfVmCommand.java
@@ -219,7 +219,7 @@ public class TryBackToAllSnapshotsOfVmCommand<T extends TryBackToAllSnapshotsOfV
                 getCompensationContext(),
                 getCurrentUser(),
                 new VmInterfaceManager(getMacPool()),
-                snapshot.getMemoryDiskId() != null);
+                snapshot.containsMemory());
 
         // custom preview - without leases
         if (!getParameters().isRestoreLease()) {


### PR DESCRIPTION
This is a followup fix for https://github.com/oVirt/ovirt-engine/pull/653 (based on a [comment review](https://github.com/oVirt/ovirt-engine/pull/653#pullrequestreview-1109114915) ) by including the metadata volumes (in addition to memory ones) when checking if an active snapshot is set with memory for restoring.

Signed-off-by: Sharon Gratch <sgratch@redhat.com>