### PR TITLE
TENTATIVE: setup: Use a FIPS-compatible padding to encrypt OVN password

### DIFF
--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/network/ovirtproviderovn.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/network/ovirtproviderovn.py
@@ -23,6 +23,7 @@ import uuid
 from collections import namedtuple
 
 from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import padding
 
@@ -404,10 +405,9 @@ class Plugin(plugin.PluginBase):
 
         encrypted_password = _getRSA().public_key().encrypt(
             password.encode(),
-            # TODO replace PKCS1v15 with PSS if/when we know we do not
-            # need m2crypto compatibility. Would likely require changes
-            # also in the engine and in the ovn provider.
-            padding=padding.PKCS1v15(),
+            padding=padding.OAEP(
+                padding.MGF1(hashes.SHA256()), hashes.SHA256(), None
+            ),
         )
         return base64.b64encode(encrypted_password)
 


### PR DESCRIPTION
The current padding results in encryption error if FIPS crypto policy is enabled on CentOS Stream 9.