### PR TITLE
[NOT MERGE]ovn provider: use fips-compatible padding for enc/dec-ryption

### DIFF
--- a/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/crypt/EngineEncryptionUtils.java
+++ b/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/crypt/EngineEncryptionUtils.java
@@ -151,7 +151,7 @@ public class EngineEncryptionUtils {
         if (source == null || source.length() == 0) {
             return source;
         } else {
-            Cipher rsa = Cipher.getInstance("RSA");
+            Cipher rsa = Cipher.getInstance("RSA/ECB/OAEPWITHSHA-256ANDMGF1PADDING");
             rsa.init(Cipher.ENCRYPT_MODE, getCertificate().getPublicKey());
             return new Base64(0).encodeToString(
                 rsa.doFinal(source.getBytes(StandardCharsets.UTF_8))
@@ -170,7 +170,7 @@ public class EngineEncryptionUtils {
         if (source == null || source.length() == 0) {
             return source;
         } else {
-            Cipher rsa = Cipher.getInstance("RSA");
+            Cipher rsa = Cipher.getInstance("RSA/ECB/OAEPWITHSHA-256ANDMGF1PADDING");
             rsa.init(Cipher.DECRYPT_MODE, getPrivateKeyEntry().getPrivateKey());
             return new String(
                 rsa.doFinal(new Base64().decode(source)),

--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/network/ovirtproviderovn.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/network/ovirtproviderovn.py
@@ -23,6 +23,7 @@ import uuid
 from collections import namedtuple
 
 from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import padding
 
@@ -404,10 +405,9 @@ class Plugin(plugin.PluginBase):
 
         encrypted_password = _getRSA().public_key().encrypt(
             password.encode(),
-            # TODO replace PKCS1v15 with PSS if/when we know we do not
-            # need m2crypto compatibility. Would likely require changes
-            # also in the engine and in the ovn provider.
-            padding=padding.PKCS1v15(),
+            padding=padding.OAEP(
+                padding.MGF1(hashes.SHA256()), hashes.SHA256(), None
+            ),
         )
         return base64.b64encode(encrypted_password)
 


### PR DESCRIPTION
Change-Id: I5b6e34bfe979f2d71a136573c4048cd817ba0faa
Signed-off-by: Eitan Raviv <eraviv@redhat.com>