### PR TITLE
webadmin: Add validation to new template

### DIFF
--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/UnitVmModel.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/UnitVmModel.java
@@ -3250,7 +3250,7 @@ public class UnitVmModel extends Model implements HasValidatedTabs, ModelWithMig
         ValidationCompleteEvent.fire(getEventBus(), this);
     }
 
-    private boolean validateNaming() {
+    public boolean validateNaming() {
         getName().validateEntity(
                 new IValidation[] {
                         new NotEmptyValidation(),

--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/VmListModel.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/VmListModel.java
@@ -1303,6 +1303,10 @@ public class VmListModel<E> extends VmBaseListModel<E, VM>
             return;
         }
 
+        if (!model.validateNaming()) {
+            return;
+        }
+
         if (model.getIsSubTemplate().getEntity()) {
             postNameUniqueCheck();
         } else {


### PR DESCRIPTION
In https://github.com/oVirt/ovirt-engine/pull/621, the validation of a new template was removed from the UI in assumption that the backend can validate the template properly. However, the backend does not contain validation for the name and if the name is not provided, it fails on inserting null to a not null database column. This patch adds the name validation back to the fronted.
