### PR TITLE
core: use fips-compatible padding for provider passwords

### DIFF
--- a/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/crypt/EngineEncryptionUtils.java
+++ b/backend/manager/modules/utils/src/main/java/org/ovirt/engine/core/utils/crypt/EngineEncryptionUtils.java
@@ -151,11 +151,13 @@ public class EngineEncryptionUtils {
         if (source == null || source.length() == 0) {
             return source;
         } else {
-            Cipher rsa = Cipher.getInstance("RSA");
+            String encrypted = "$";
+            Cipher rsa = Cipher.getInstance("RSA/ECB/OAEPWITHSHA-256ANDMGF1PADDING");
             rsa.init(Cipher.ENCRYPT_MODE, getCertificate().getPublicKey());
-            return new Base64(0).encodeToString(
+            encrypted += new Base64(0).encodeToString(
                 rsa.doFinal(source.getBytes(StandardCharsets.UTF_8))
             );
+            return encrypted;
         }
     }
 
@@ -170,7 +172,14 @@ public class EngineEncryptionUtils {
         if (source == null || source.length() == 0) {
             return source;
         } else {
-            Cipher rsa = Cipher.getInstance("RSA");
+            String cipherString = "RSA";
+
+            if (source.charAt(0) == '$') {
+                cipherString = "RSA/ECB/OAEPWITHSHA-256ANDMGF1PADDING";
+                source = source.substring(1);
+            }
+
+            Cipher rsa = Cipher.getInstance(cipherString);
             rsa.init(Cipher.DECRYPT_MODE, getPrivateKeyEntry().getPrivateKey());
             return new String(
                 rsa.doFinal(new Base64().decode(source)),

--- a/backend/manager/modules/utils/src/test/java/org/ovirt/engine/core/utils/crypt/EngineEncryptionUtilsTest.java
+++ b/backend/manager/modules/utils/src/test/java/org/ovirt/engine/core/utils/crypt/EngineEncryptionUtilsTest.java
@@ -38,6 +38,20 @@ public class EngineEncryptionUtilsTest {
     }
 
     @Test
+    public void testDecryptLegacyPKCS1Padding() throws Exception {
+        String plain = "Test123!32@";
+        String encrypted = "Qqvu8XdQUQpXI4NRElDcgg+kcL9aFuN/ypbLacLNxZvOgBzMumg" +
+                           "yx8WcZZIHHuKBXpBgrIjoNiZ1Xa4NxG5PBtwrWVc1aw5Ax59m3u" +
+                           "AN46O4wtz2hNAQTjIHAPvAiXqxwZAeeX7+FxqNsDso4UofujCoT" +
+                           "X/crOpNZmBTm7Y4TIsQ4oYiM2J2viGgK6GlvnpIfI5L6vKzXA/k" +
+                           "nq3ht5h8bPipNJmDMY7xD3HBf9Dac5SPV/A20ouL62CISmXexyp" +
+                           "YxKhRCur7KPWFk86o2h9L0wKQDYr7VxJ9fEi6ciPWtXZUqxnftu" +
+                           "E/Zb6XqnQK/M+cb2k26mDRhPqBL332rz4Hvg==";
+        String plain2 = EngineEncryptionUtils.decrypt(encrypted);
+        assertEquals(plain, plain2);
+    }
+
+    @Test
     public void testEncryptThreads() throws Exception {
         List<Thread> l = new LinkedList<>();
         final String plain = "Test123!32@";

--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/network/ovirtproviderovn.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/network/ovirtproviderovn.py
@@ -409,7 +409,7 @@ class Plugin(plugin.PluginBase):
                 padding.MGF1(hashes.SHA256()), hashes.SHA256(), None
             ),
         )
-        return base64.b64encode(encrypted_password)
+        return b'$' + base64.b64encode(encrypted_password)
 
     def _query_install_ovn(self):
         return dialog.queryBoolean(

--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/network/ovirtproviderovn.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/network/ovirtproviderovn.py
@@ -23,6 +23,7 @@ import uuid
 from collections import namedtuple
 
 from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import padding
 
@@ -404,10 +405,9 @@ class Plugin(plugin.PluginBase):
 
         encrypted_password = _getRSA().public_key().encrypt(
             password.encode(),
-            # TODO replace PKCS1v15 with PSS if/when we know we do not
-            # need m2crypto compatibility. Would likely require changes
-            # also in the engine and in the ovn provider.
-            padding=padding.PKCS1v15(),
+            padding=padding.OAEP(
+                padding.MGF1(hashes.SHA256()), hashes.SHA256(), None
+            ),
         )
         return base64.b64encode(encrypted_password)
 


### PR DESCRIPTION
Use OAEP with SHA256 and MGF1 padding in password encryption and
decryption during authenticating with ovirt-ovn-provieder on el9
deployments where FIPS is enabled.

This change should not be merged until all code paths using the modified
EngineEncryptionUtils facility are evaluated for correctness and until
this modification is made active only when FIPS is enabled.

Signed-off-by: Eitan Raviv <eraviv@redhat.com>
Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
Change-Id: Ie895d2249716d6aafd64d79ae2d61083181b9703
