### PR TITLE
Trigger OvfDataUpdater when detaching a storage domain

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/domain/DetachStorageDomainFromPoolCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/domain/DetachStorageDomainFromPoolCommand.java
@@ -12,6 +12,7 @@ import org.ovirt.engine.core.bll.NonTransactiveCommandAttribute;
 import org.ovirt.engine.core.bll.context.CommandContext;
 import org.ovirt.engine.core.bll.storage.connection.CINDERStorageHelper;
 import org.ovirt.engine.core.bll.storage.connection.ManagedBlockStorageHelper;
+import org.ovirt.engine.core.bll.storage.ovfstore.OvfDataUpdater;
 import org.ovirt.engine.core.common.AuditLogType;
 import org.ovirt.engine.core.common.action.DetachStorageDomainFromPoolParameters;
 import org.ovirt.engine.core.common.action.LockProperties;
@@ -52,6 +53,8 @@ public class DetachStorageDomainFromPoolCommand<T extends DetachStorageDomainFro
     private StorageDomainDao storageDomainDao;
     @Inject
     private AuditLogDirector auditLogDirector;
+    @Inject
+    private OvfDataUpdater ovfDataUpdater;
 
     public DetachStorageDomainFromPoolCommand(T parameters, CommandContext commandContext) {
         super(parameters, commandContext);
@@ -111,6 +114,7 @@ public class DetachStorageDomainFromPoolCommand<T extends DetachStorageDomainFro
             detachSucceeded = detachNonMasterStorageDomain();
         }
         auditOnExistingLeasesIfExist();
+        ovfDataUpdater.triggerNow();
         log.info("End detach storage domain");
         setSucceeded(detachSucceeded);
     }


### PR DESCRIPTION
This patch adds a call to OvfDataUpdater#triggerNow right after detaching
a storage domain in order to clean VMs/templates that were removed when
the storage domain was detached from the vm_ovf_generations table
immediately rather than in the next cycle we update the OVFs.

In 78d21eee4 we fixed an issue that caused importing VMs/templates with
old (stale) data. That fix could very well also fix the issue described
in the below mentioned bug, however, it is safer to also ensure that the
removed VMs/templates are also removed from the vm_ovf_generations table
to stop having old/stale data in the database that should never be used.


Bug-Url: https://bugzilla.redhat.com/1705338
Signed-off-by: Arik Hadas <ahadas@redhat.com>