### PR TITLE
Restrict user profile write acces to owner and super user

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/AddUserProfilePropertyCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/AddUserProfilePropertyCommand.java
@@ -46,7 +46,8 @@ public class AddUserProfilePropertyCommand<T extends UserProfilePropertyParamete
                 userProfileDao.getProfile(newProp.getUserId()),
                 newProp,
                 getCurrentUser(),
-                this::validate);
+                this::validate,
+                isSystemSuperUser());
     }
 
     public static String buildUserName(DbUserDao userDao, Guid userId) {

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/GetUserProfilePropertiesByUserIdQuery.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/GetUserProfilePropertiesByUserIdQuery.java
@@ -20,7 +20,7 @@ public class GetUserProfilePropertiesByUserIdQuery<P extends UserProfileProperty
     }
 
     private boolean validate() {
-        return validate(validator.authorized(getUser(), getParameters().getId()));
+        return validate(validator.authorized(getUser(), getParameters().getId(), getUser() != null && getUser().isAdmin()));
     }
 
     @Override

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/GetUserProfilePropertyByNameAndUserIdQuery.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/GetUserProfilePropertyByNameAndUserIdQuery.java
@@ -18,7 +18,7 @@ public class GetUserProfilePropertyByNameAndUserIdQuery<P extends IdAndNameQuery
     }
 
     private boolean validate() {
-        return validate(validator.authorized(getUser(), getParameters().getId()));
+        return validate(validator.authorized(getUser(), getParameters().getId(), getUser() != null && getUser().isAdmin()));
     }
 
     @Override

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/GetUserProfilePropertyQuery.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/GetUserProfilePropertyQuery.java
@@ -19,7 +19,7 @@ public class GetUserProfilePropertyQuery<P extends UserProfilePropertyIdQueryPar
     }
 
     private boolean validate(UserProfileProperty prop) {
-        return validate(validator.authorized(getUser(), prop.getUserId()));
+        return validate(validator.authorized(getUser(), prop.getUserId(), getUser() != null && getUser().isAdmin()));
     }
 
     @Override

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/RemoveUserProfilePropertyCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/RemoveUserProfilePropertyCommand.java
@@ -29,7 +29,6 @@ public class RemoveUserProfilePropertyCommand<T extends IdParameters> extends Co
     @Inject
     protected DbUserDao userDao;
 
-
     private final UserProfileValidator validator = new UserProfileValidator();
 
     public RemoveUserProfilePropertyCommand(T parameters, CommandContext commandContext) {
@@ -64,8 +63,10 @@ public class RemoveUserProfilePropertyCommand<T extends IdParameters> extends Co
                         .map(UserProfileProperty::getName)
                         .orElse(getParameters().getId().toString()));
         return validate(validator.propertyProvided(currentProp)) &&
-                validate(validator.authorized(getCurrentUser(),
-                        Optional.ofNullable(currentProp).map(UserProfileProperty::getUserId).orElse(null)));
+                validate(validator.authorized(
+                        getCurrentUser(),
+                        Optional.ofNullable(currentProp).map(UserProfileProperty::getUserId).orElse(null),
+                        isSystemSuperUser()));
     }
 
     @Override

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/UpdateUserProfilePropertyCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/UpdateUserProfilePropertyCommand.java
@@ -64,7 +64,8 @@ public class UpdateUserProfilePropertyCommand<T extends UserProfilePropertyParam
                 userProfileDao.get(propertyToUpdate.getPropertyId()),
                 getCurrentUser(),
                 this::validate,
-                propertyToUpdate
+                propertyToUpdate,
+                isSystemSuperUser()
         );
     }
 

--- a/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/AddUserProfilePropertyCommandTest.java
+++ b/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/AddUserProfilePropertyCommandTest.java
@@ -12,6 +12,8 @@ import static org.ovirt.engine.core.bll.UserProfileTestHelper.checkAssertsForGen
 import static org.ovirt.engine.core.bll.UserProfileTestHelper.checkAssertsForSshProp;
 import static org.ovirt.engine.core.bll.UserProfileTestHelper.createAdmin;
 
+import java.util.function.Predicate;
+
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -30,6 +32,9 @@ class AddUserProfilePropertyCommandTest extends BaseCommandTest {
 
     @Mock
     protected DbUserDao userDaoMock;
+
+    @Mock
+    private Predicate<DbUser> isSystemSuperUserPredicate;
 
     private UserProfilePropertyParameters parameters = mock(UserProfilePropertyParameters.class);
 
@@ -54,6 +59,7 @@ class AddUserProfilePropertyCommandTest extends BaseCommandTest {
         when(userDaoMock.get(any())).thenReturn(mock(DbUser.class));
 
         when(parameters.getUserProfileProperty()).thenReturn(inputProp);
+        when(isSystemSuperUserPredicate.test(any())).thenReturn(true);
         addCommand.setCurrentUser(createAdmin(Guid.newGuid()));
 
         assertTrue(addCommand.validate(), buildValidationMessage(addCommand.getReturnValue()));

--- a/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/RemoveUserProfilePropertyCommandTest.java
+++ b/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/RemoveUserProfilePropertyCommandTest.java
@@ -11,12 +11,15 @@ import static org.mockito.Mockito.when;
 import static org.ovirt.engine.core.bll.UserProfileTestHelper.buildValidationMessage;
 import static org.ovirt.engine.core.bll.UserProfileTestHelper.createWithId;
 
+import java.util.function.Predicate;
+
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.ovirt.engine.core.bll.context.CommandContext;
 import org.ovirt.engine.core.common.action.IdParameters;
 import org.ovirt.engine.core.common.businessentities.UserProfileProperty;
+import org.ovirt.engine.core.common.businessentities.aaa.DbUser;
 import org.ovirt.engine.core.compat.Guid;
 import org.ovirt.engine.core.dao.DbUserDao;
 import org.ovirt.engine.core.dao.UserProfileDao;
@@ -27,6 +30,9 @@ class RemoveUserProfilePropertyCommandTest extends BaseCommandTest {
 
     @Mock
     private DbUserDao userDaoMock;
+
+    @Mock
+    private Predicate<DbUser> isSystemSuperUserPredicate;
 
     private IdParameters parameters = mock(IdParameters.class);
 

--- a/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/UpdateUserProfilePropertyCommandTest.java
+++ b/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/UpdateUserProfilePropertyCommandTest.java
@@ -14,6 +14,8 @@ import static org.ovirt.engine.core.bll.UserProfileTestHelper.checkAssertsForGen
 import static org.ovirt.engine.core.bll.UserProfileTestHelper.checkAssertsForSshProp;
 import static org.ovirt.engine.core.bll.UserProfileTestHelper.createWithId;
 
+import java.util.function.Predicate;
+
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -31,6 +33,9 @@ class UpdateUserProfilePropertyCommandTest extends BaseCommandTest {
 
     @Mock
     private DbUserDao userDaoMock;
+
+    @Mock
+    private Predicate<DbUser> isSystemSuperUserPredicate;
 
     private UserProfilePropertyParameters parameters = mock(UserProfilePropertyParameters.class);
 

--- a/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/validator/UserProfileValidatorTest.java
+++ b/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/validator/UserProfileValidatorTest.java
@@ -1,6 +1,5 @@
 package org.ovirt.engine.core.bll.validator;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -45,41 +44,41 @@ class UserProfileValidatorTest {
 
     @Test
     void notAuthorizedDueToNullCurrentUser() {
-        assertFalse(validator.authorized(null, Guid.Empty).isValid());
+        assertFalse(validator.authorized(null, Guid.Empty, true).isValid());
     }
 
     @Test
     void notAuthorizedDueToNullCurrentUserId() {
-        assertFalse(validator.authorized(mock(DbUser.class), Guid.Empty).isValid());
+        assertFalse(validator.authorized(mock(DbUser.class), Guid.Empty, true).isValid());
     }
 
     @Test
     void notAuthorizedDueToNullTargetId() {
-        assertFalse(validator.authorized(emptyUser(), null).isValid());
+        assertFalse(validator.authorized(emptyUser(), null, true).isValid());
     }
 
     @Test
     void notAuthorizedDueToDifferentTargetId() {
-        assertFalse(validator.authorized(emptyUser(), Guid.newGuid()).isValid());
+        assertFalse(validator.authorized(emptyUser(), Guid.newGuid(), false).isValid());
     }
 
     @Test
     void authorized() {
-        assertTrue(validator.authorized(emptyUser(), Guid.Empty).isValid());
+        assertTrue(validator.authorized(emptyUser(), Guid.Empty, false).isValid());
     }
 
     @Test
     void authorizedAsAdminForOtherUser() {
         DbUser user = emptyUser();
         user.setAdmin(true);
-        assertTrue(validator.authorized(user, Guid.newGuid()).isValid());
+        assertTrue(validator.authorized(user, Guid.newGuid(), true).isValid());
     }
 
     @Test
     void authorizedAsAdminForHimself() {
         DbUser user = emptyUser();
         user.setAdmin(true);
-        assertTrue(validator.authorized(user, Guid.Empty).isValid());
+        assertTrue(validator.authorized(user, Guid.Empty, true).isValid());
     }
 
     @Test
@@ -131,7 +130,7 @@ class UserProfileValidatorTest {
     @Test
     void noSshKeyYet() {
         UserProfileProperty sshProp = UserProfileProperty.builder().withDefaultSshProp().build();
-        assertThat(validator.firstPublicSshKey(new UserProfile(), sshProp).isValid());
+        assertTrue(validator.firstPublicSshKey(new UserProfile(), sshProp).isValid());
     }
 
     @Test


### PR DESCRIPTION
Before, every admin user has full write access to user profiles of other users. 
After this patch only super users will be able to modify user profiles of other users.
Admin users will have read only access. 