### PR TITLE
core: Fails to start an incremental backup when the checkpoint id does not exist

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/backup/StartVmBackupCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/backup/StartVmBackupCommand.java
@@ -151,17 +151,16 @@ public class StartVmBackupCommand<T extends VmBackupParameters> extends VmComman
         if (vmBackup.getFromCheckpointId() != null) {
             if (!FeatureSupported.isIncrementalBackupSupported(getCluster().getCompatibilityVersion())) {
                 return failValidation(EngineMessage.ACTION_TYPE_FAILED_INCREMENTAL_BACKUP_NOT_SUPPORTED);
+            } else {
+              log.info("The fromCheckpoint entity is null");
             }
 
             VmCheckpoint fromCheckpoint = vmCheckpointDao.get(vmBackup.getFromCheckpointId());
-            if (fromCheckpoint == null) {
-                return failValidation(EngineMessage.ACTION_TYPE_FAILED_CHECKPOINT_NOT_EXIST,
-                        String.format("$checkpointId %s", vmBackup.getFromCheckpointId()));
-            }
-
-            if (fromCheckpoint.getState().equals(VmCheckpointState.INVALID)) {
-                return failValidation(EngineMessage.ACTION_TYPE_FAILED_CHECKPOINT_INVALID,
-                        String.format("$checkpointId %s", vmBackup.getFromCheckpointId()));
+            if (fromCheckpoint != null) {
+                if (fromCheckpoint.getState().equals(VmCheckpointState.INVALID)) {
+                    return failValidation(EngineMessage.ACTION_TYPE_FAILED_CHECKPOINT_INVALID,
+                            String.format("$checkpointId %s", vmBackup.getFromCheckpointId()));
+                }
             }
 
             if (!FeatureSupported.isBackupModeAndBitmapsOperationsSupported(getCluster().getCompatibilityVersion())) {

--- a/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/storage/backup/StartVmBackupCommandTest.java
+++ b/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/storage/backup/StartVmBackupCommandTest.java
@@ -228,18 +228,6 @@ public class StartVmBackupCommandTest extends BaseCommandTest {
 
     @Test
     @MockedConfig("mockConfigIsIncrementalBackupSupported")
-    public void validateFailedMissingCheckpoint() {
-        mockVm(VMStatus.Up);
-        mockVds(true, true);
-        mockVmDevice(true);
-        when(vmBackupDao.getAllForVm(vmId)).thenReturn(List.of(mockVmBackup()));
-        when(vmCheckpointDao.get(fromCheckpointId)).thenReturn(null);
-        ValidateTestUtils.runAndAssertValidateFailure(command,
-                EngineMessage.ACTION_TYPE_FAILED_CHECKPOINT_NOT_EXIST);
-    }
-
-    @Test
-    @MockedConfig("mockConfigIsIncrementalBackupSupported")
     public void validateFailedInvalidCheckpoint() {
         mockVm(VMStatus.Up);
         mockVds(true, true);


### PR DESCRIPTION
core: Fails to start an incremental backup when the checkpoint id does not exist

If a user tries to start an incremental backup with a checkpoint id that does not exist it will not fail from now on. The backup will be full instead of incremental.

Bug-Url: https://bugzilla.redhat.com/2097863
Signed-off-by: Artiom Divak <adivak@redhat.com>