### PR TITLE
Resize and pin with suspended VM

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/StopVmCommandBase.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/StopVmCommandBase.java
@@ -30,6 +30,7 @@ import org.ovirt.engine.core.compat.Guid;
 import org.ovirt.engine.core.dao.SnapshotDao;
 import org.ovirt.engine.core.dao.VmDynamicDao;
 import org.ovirt.engine.core.dao.VmStaticDao;
+import org.ovirt.engine.core.vdsbroker.ResourceManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,6 +49,9 @@ public abstract class StopVmCommandBase<T extends StopVmParametersBase> extends 
 
     @Inject
     private KubevirtMonitoring kubevirt;
+
+    @Inject
+    protected ResourceManager resourceManager;
 
     private boolean suspendedVm;
 
@@ -174,6 +178,7 @@ public abstract class StopVmCommandBase<T extends StopVmParametersBase> extends 
 
         suspendedVm = getVm().getStatus() == VMStatus.Suspended;
         if (suspendedVm) {
+            resourceManager.internalSetVmStatus(getVm().getDynamicData(), VMStatus.Down);
             endVmCommand();
             setCommandShouldBeLogged(true);
         } else {

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/VmHandler.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/VmHandler.java
@@ -1324,9 +1324,15 @@ public class VmHandler implements BackendService {
     }
 
     public void updateCpuAndNumaPinning(VM vm, Guid vdsId) {
-        if (vm.getCpuPinningPolicy() == CpuPinningPolicy.RESIZE_AND_PIN_NUMA && vm.getCurrentCpuPinning() == null) {
+        if (vm.getCpuPinningPolicy() == CpuPinningPolicy.RESIZE_AND_PIN_NUMA) {
             VdsDynamic host = vdsDynamicDao.get(vdsId);
-            NumaPinningHelper.applyAutoPinningPolicy(vm, host, vdsNumaNodeDao.getAllVdsNumaNodeByVdsId(host.getId()));
+            List<VdsNumaNode> hostNumaNodes = vdsNumaNodeDao.getAllVdsNumaNodeByVdsId(host.getId());
+
+            if (vm.getCurrentCpuPinning() == null) {
+                NumaPinningHelper.applyAutoPinningPolicy(vm, host, hostNumaNodes);
+            } else {
+                vm.setCurrentCpuPinning(NumaPinningHelper.getSapHanaCpuPinning(vm, host, hostNumaNodes));
+            }
         }
     }
 


### PR DESCRIPTION
When shutting down the suspended VM, the dynamic cpu pinning data were not cleared. This could
make it impossible to run again as these data are supposed to be generated every time the VM is run.

When migrating or suspending/resuming a VM with Resize and Pin policy, the destination host's numa topology
might be different (e.g more CPUs in the numa node). While the VM is able to run there, the CPU pinning might be different.

This patch re-generates the CPU pinning according to the numa pinning for VMs with Resize and Pin policy when the VM has already defined "current" CPU topology and "current" cpu pinning.

Bug-Url: https://bugzilla.redhat.com/2093948