### PR TITLE
backport: fix cbs el9 build issue

### DIFF
--- a/ovirt-engine.spec.in
+++ b/ovirt-engine.spec.in
@@ -44,7 +44,7 @@
 %endif
 
 # Limit GWT resources to pass the build in CBS
-%global ovirt_build_extra_flags_rpm -Dgwt.compiler.localWorkers=1
+%global ovirt_build_extra_flags_rpm -Dgwt.compiler.localWorkers=2
 
 # Set "rhv_build 1" to perform RHV Manager build
 %global rhv_build 0

--- a/ovirt-engine.spec.in
+++ b/ovirt-engine.spec.in
@@ -148,7 +148,6 @@ getent passwd %1 >/dev/null || useradd -r -u %2 -g %3 -c %5 -s /sbin/nologin -d 
 %if %{rhv_build}
 %global wildfly_overlay_modules ""
 %define extra_common_opts \\\
-	BUILD_ENV_VALIDATION=0 \\\
 	JBOSS_HOME=/opt/rh/eap7/root/usr/share/wildfly
 %else
 %global wildfly_overlay_modules "/usr/share/ovirt-engine-wildfly-overlay/modules"
@@ -161,6 +160,7 @@ getent passwd %1 >/dev/null || useradd -r -u %2 -g %3 -c %5 -s /sbin/nologin -d 
 	BUILD_LOCALES=%{ovirt_build_locales} \\\
 	BUILD_UT=%{ovirt_build_ut} \\\
 	BUILD_VALIDATION=0 \\\
+	BUILD_ENV_VALIDATION=0 \\\
 	PACKAGE_NAME=%{name} \\\
 	RPM_VERSION=%{version} \\\
 	RPM_RELEASE=%{release} \\\


### PR DESCRIPTION
- Skip validation of build environment
- Increase GWT localWorkers to 2

