### PR TITLE
keycloak: do not invalidate session without refresh_token

### DIFF
--- a/backend/manager/modules/enginesso/src/main/java/org/ovirt/engine/core/sso/service/TokenCleanupService.java
+++ b/backend/manager/modules/enginesso/src/main/java/org/ovirt/engine/core/sso/service/TokenCleanupService.java
@@ -66,9 +66,10 @@ public class TokenCleanupService {
                 }
             }
             if (ssoContext.getSsoLocalConfig().getBoolean("ENGINE_SSO_ENABLE_EXTERNAL_SSO")) {
-                log.debug("Existing Session found for token: {}, invalidating session on external OP",
-                        ssoSession.getAccessToken());
-                ExternalOIDCService.logout(ssoContext, refreshToken);
+                if (refreshToken != null) {
+                    log.debug("invalidating session on external OIDC, refreshToken: {}", refreshToken);
+                    ExternalOIDCService.logout(ssoContext, refreshToken);
+                }
             }
             invokeAuthnLogout(ssoContext, ssoSession);
             SsoService.notifyClientsOfLogoutEvent(ssoContext,


### PR DESCRIPTION
if there are multiple sessions for the same user (i.e. with different
scopes) we only get the refresh_token for the first established one and
we cannot invalidate it on first logout, so let's keep keycloak session
active until the one that established it first logs out
