### PR TITLE
limit ansible-lint version to 6.8.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
     - name: Install required PyPI packages
-      run: ${{ matrix.pip-command }} install "ansible-lint>=6.0.0,<7.0.0"
+      run: ${{ matrix.pip-command }} install "ansible-lint>=6.0.0,<6.8.3"
 
     - name: Checkout sources
       uses: ovirt/checkout-action@main


### PR DESCRIPTION
Unfortunately latest version is broken, so let's use older one until the fix is there