### PR TITLE
Backport: Add missing copies of TPM parameters

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/utils/VmDeviceUtils.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/utils/VmDeviceUtils.java
@@ -1494,6 +1494,7 @@ public class VmDeviceUtils {
         params.setSoundDeviceEnabled(containsDeviceWithType(devices, VmDeviceGeneralType.SOUND));
         params.setConsoleEnabled(containsDeviceWithType(devices, VmDeviceGeneralType.CONSOLE));
         params.setVirtioScsiEnabled(containsDeviceWithType(devices, VmDeviceGeneralType.CONTROLLER, VmDeviceType.VIRTIOSCSI));
+        params.setTpmEnabled(containsDeviceWithType(devices, VmDeviceGeneralType.TPM));
 
         updateVmGraphicDevicesInParameters(params, devices);
         updateWatchdogInParameters(params, devices);

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/VmManagementParametersBase.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/VmManagementParametersBase.java
@@ -190,6 +190,8 @@ public class VmManagementParametersBase extends VmOperationParameterBase
         setRngDevice(baseParams.getRngDevice());
         setUpdateWatchdog(baseParams.isUpdateWatchdog());
         setWatchdog(baseParams.getWatchdog());
+        setTpmEnabled(baseParams.isTpmEnabled());
+        setVmExternalData(baseParams.getVmExternalData());
         setAffinityGroups(baseParams.getAffinityGroups());
         setAffinityLabels(baseParams.getAffinityLabels());
 

--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/VmSnapshotListModel.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/VmSnapshotListModel.java
@@ -809,6 +809,7 @@ public class VmSnapshotListModel extends SearchableListModel<VM, Snapshot> {
         parameters.setDiskInfoDestinationMap(imageToDestinationDomainMap);
         parameters.setConsoleEnabled(model.getIsConsoleDeviceEnabled().getEntity());
         parameters.setVirtioScsiEnabled(model.getIsVirtioScsiEnabled().getEntity());
+        parameters.setTpmEnabled(model.getTpmEnabled().getEntity());
 
         BuilderExecutor.build(model, parameters, new UnitToGraphicsDeviceParamsBuilder());
 


### PR DESCRIPTION
- core: Add missing items in VmManagementParametersBase copy constructor
- frontend: Add TPM parameter when cloning a VM from a snapshot
- core: Update TPM device in parameters
