### PR TITLE
core: fail storage domain attach if getImagesList fails - attempt

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/GetUnregisteredDisksQuery.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/GetUnregisteredDisksQuery.java
@@ -81,6 +81,7 @@ public class GetUnregisteredDisksQuery<P extends GetUnregisteredDisksQueryParame
                 log.debug("Could not get populated disk: {}", unregQueryReturn.getExceptionString());
             }
         }
+        getQueryReturnValue().setSucceeded(true);
         getQueryReturnValue().setReturnValue(unregisteredDisks);
     }
 


### PR DESCRIPTION
If getImagesList fails due to an error we should not continue with attaching the SD assuming there no disks on the storage as this will corrupt the OVF stores.

Instead fail the attach operation and have the user retry once the issue is resolved.

Bug-Url: https://bugzilla.redhat.com/2126602
Signed-off-by: Benny Zlotnik <bzlotnik@redhat.com>