### PR TITLE
core: fail storage domain attach if getImagesList fails

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/StorageHandlingCommandBase.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/StorageHandlingCommandBase.java
@@ -60,6 +60,7 @@ import org.ovirt.engine.core.common.config.ConfigValues;
 import org.ovirt.engine.core.common.errors.EngineException;
 import org.ovirt.engine.core.common.errors.EngineMessage;
 import org.ovirt.engine.core.common.queries.GetUnregisteredDisksQueryParameters;
+import org.ovirt.engine.core.common.queries.QueryReturnValue;
 import org.ovirt.engine.core.common.queries.QueryType;
 import org.ovirt.engine.core.common.utils.Pair;
 import org.ovirt.engine.core.common.vdscommands.IrsBaseVDSCommandParameters;
@@ -431,16 +432,23 @@ public abstract class StorageHandlingCommandBase<T extends StoragePoolParameters
             ovfDisks = new ArrayList<>();
 
             // Get all unregistered disks.
-            List<DiskImage> disksFromStorage = backend.runInternalQuery(QueryType.GetUnregisteredDisks,
+            QueryReturnValue queryReturnValue = backend.runInternalQuery(QueryType.GetUnregisteredDisks,
                     new GetUnregisteredDisksQueryParameters(storageDomainId,
-                            storagePoolId)).getReturnValue();
-            if (disksFromStorage == null) {
+                            storagePoolId));
+            StorageDomain sd = storageDomainDao.get(storageDomainId);
+            if (sd.getStorageDomainType() == StorageDomainType.Data && !queryReturnValue.getSucceeded()) {
                 log.error("An error occurred while fetching unregistered disks from Storage Domain id '{}'",
                         storageDomainId);
+                throw new RuntimeException("Failed to retrieve unregistered disks");
+            }
+
+            List<DiskImage> disksFromStorage = queryReturnValue.getReturnValue();
+            if (disksFromStorage == null) {
                 return ovfDisks;
             } else {
                 castDiskImagesToUnregisteredDisks(disksFromStorage, storageDomainId);
             }
+
             for (Disk disk : disksFromStorage) {
                 DiskImage ovfStoreDisk = (DiskImage) disk;
                 String diskDescription = ovfStoreDisk.getDescription();


### PR DESCRIPTION
If getImagesList fails due to an error we should not continue with
attaching the SD assuming there no disks on the storage as this will
corrupt the OVF stores.

Instead fail the attach operation and have the user retry once the issue
is resolved.

Bug-Url: https://bugzilla.redhat.com/2126602
Signed-off-by: Benny Zlotnik <bzlotnik@redhat.com>