### PR TITLE
build: fix release_suffix for GH builds

### DIFF
--- a/.automation/build-rpm.sh
+++ b/.automation/build-rpm.sh
@@ -14,7 +14,7 @@ BUILD_LOCALES=0
 rpmbuild \
     -D "_topmdir rpmbuild" \
     -D "_rpmdir rpmbuild" \
-    ${RELEASE:+-D "release_suffix ${RELEASE}"} \
+    ${SUFFIX:+-D "release_suffix ${SUFFIX}"} \
     -D "ovirt_build_ut ${BUILD_UT}" \
     -D "ovirt_build_all_user_agents ${BUILD_ALL_USER_AGENTS}" \
     -D "ovirt_build_locales ${BUILD_LOCALES}" \

--- a/Makefile
+++ b/Makefile
@@ -78,8 +78,7 @@ OFFLINE_BUILD_MAVEN_SETTINGS=$(shell pwd)/build/offline-build-maven-settings.xml
 
 include version.mak
 # major, minor, seq
-ENGINE_VERSION:=$(shell cat pom.xml | head -n 20 | grep '<version>' | head -n 1 | sed -e 's/.*>\(.*\)<.*/\1/' -e 's/-SNAPSHOT//')
-PACKAGE_VERSION=$(ENGINE_VERSION)$(if $(MILESTONE),_$(MILESTONE))
+PACKAGE_VERSION=$(RPM_VERSION)$(if $(MILESTONE),_$(MILESTONE))
 DISPLAY_VERSION=$(PACKAGE_VERSION)
 
 DEV_BUILD_FLAGS:=-P brand-source-maps
@@ -172,7 +171,7 @@ BUILD_TARGET=install
 	-e "s|@SETUP_VAR@|$(PKG_STATE_DIR)|g" \
 	-e "s|@DEV_PYTHON_DIR@|$(DEV_PYTHON_DIR)|g" \
 	-e "s|@DEV_SETUP_ENV_DIR@|$(DEV_SETUP_ENV_DIR)|g" \
-	-e "s|@RPM_VERSION@|$(ENGINE_VERSION)|g" \
+	-e "s|@RPM_VERSION@|$(RPM_VERSION)|g" \
 	-e "s|@RPM_RELEASE@|$(RPM_RELEASE)|g" \
 	-e "s|@MILESTONE@|$(MILESTONE)|g" \
 	-e "s|@PACKAGE_NAME@|$(PACKAGE_NAME)|g" \

--- a/version.mak
+++ b/version.mak
@@ -20,31 +20,23 @@ MILESTONE_IF_NEEDED=master
 # RPM_RELEASE_ON_RELEASE should be set to the rpm release to have on release (non-SNAPSHOT) builds.
 RPM_RELEASE_ON_RELEASE=1
 
-# AUTO_MILESTONE is set to MILESTONE_IF_NEEDED on SNAPSHOT builds, empty otherwise.
-AUTO_MILESTONE=$(shell cat pom.xml | head -n 20 | grep '<version>' | head -n 1 | sed -e 's/.*>\(.*\)<.*/\1/' | grep -q 'SNAPSHOT$$' && echo $(MILESTONE_IF_NEEDED))
+# MILESTONE is set to MILESTONE_IF_NEEDED on SNAPSHOT builds, empty otherwise.
+ifndef MILESTONE
+MILESTONE=$(shell cat pom.xml | head -n 20 | grep '<version>' | head -n 1 | sed -e 's/.*>\(.*\)<.*/\1/' | grep -q 'SNAPSHOT$$' && echo $(MILESTONE_IF_NEEDED))
+endif
 
-# AUTO_RPM_RELEASE is set to 0.0.something on SNAPSHOT builds, and to RPM_RELEASE_ON_RELEASE otherwise.
-AUTO_RPM_RELEASE=$(shell if cat pom.xml | head -n 20 | grep '<version>' | head -n 1 | sed -e 's/.*>\(.*\)<.*/\1/' | grep -q 'SNAPSHOT$$'; then echo 0.2.$(MILESTONE).$$(date -u +%Y%m%d%H%M%S); else echo $(RPM_RELEASE_ON_RELEASE); fi)
+# RPM_VERSION is set to pom version without -SNAPSHOT
+ifndef RPM_VERSION
+RPM_VERSION:=$(shell cat pom.xml | head -n 20 | grep '<version>' | head -n 1 | sed -e 's/.*>\(.*\)<.*/\1/' -e 's/-SNAPSHOT//')
+endif
 
-MILESTONE=$(AUTO_MILESTONE)
 
-# RPM release should be automatic. If needed to be set manually:
+# RPM release should be automatic.
+# Set to 0.something on SNAPSHOT builds, and to RPM_RELEASE_ON_RELEASE otherwise.
+# If needed to be set manually:
 # For pre-release:
-# RPM_RELEASE=0.N.$(MILESTONE).$(shell date -u +%Y%m%d%H%M%S)
-# While N is incremented when milestone is changed.
+# RPM_RELEASE=0.$(MILESTONE).$(shell date -u +%Y%m%d%H%M%S)
 #
-# For release:
-# RPM_RELEASE=N
-# while N is incremented each re-release
-#
-RPM_RELEASE=$(AUTO_RPM_RELEASE)
-
-#
-# Downstream only release prefix
-# Downstream (mead) does not use RPM_RELEASE but internal
-# mead versioning.
-# Increment the variable bellow after every milestone is
-# released.
-# Or leave empty to have only mead numbering.
-#
-DOWNSTREAM_RPM_RELEASE_PREFIX=0.
+ifndef RPM_RELEASE
+RPM_RELEASE=$(shell if cat pom.xml | head -n 20 | grep '<version>' | head -n 1 | sed -e 's/.*>\(.*\)<.*/\1/' | grep -q 'SNAPSHOT$$'; then echo 0.$(MILESTONE).$$(date -u +%Y%m%d%H%M%S); else echo $(RPM_RELEASE_ON_RELEASE); fi)
+endif


### PR DESCRIPTION
GitHub builds had duplicated dates in RPM names. Also swapped date and
githash so that RPMs are time-sorted.
