### PR TITLE
core: Imported VM missing in OVFSTORE

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/GetVmFromOvaQuery.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/GetVmFromOvaQuery.java
@@ -41,8 +41,8 @@ public class GetVmFromOvaQuery<T extends GetVmFromOvaQueryParameters> extends Ge
             vm = getVmInfoFromOvaFile();
         }
 
-        if (originOvirt && vm != null) {
-            vm.setOrigin(OriginType.OVIRT);
+        if (vm != null) {
+            vm.setOrigin(originOvirt ? OriginType.OVIRT : OriginType.VMWARE);
         }
 
         return vm;


### PR DESCRIPTION
When importing an OVA that is not originated in oVirt the VM will diappear
after detaching its storage domain. The vm will not be seen in the import VM
tab. From now on even if the imported VM is no originated in ovirt it could
be imported after detaching the storage domain.