### PR TITLE
Prevent duplicate audit logs for ReduceImage

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/ReduceImageCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/ReduceImageCommand.java
@@ -269,8 +269,16 @@ public class ReduceImageCommand<T extends ImagesActionsParametersBase> extends B
     @Override
     public AuditLogType getAuditLogTypeValue() {
         addAuditLogCustomValues();
-        return getSucceeded() ?
-                AuditLogType.USER_REDUCE_DISK_FINISHED_SUCCESS : AuditLogType.USER_REDUCE_DISK_FINISHED_FAILURE;
+        switch (getActionState()) {
+        case EXECUTE:
+            return getSucceeded() ?
+                    AuditLogType.UNASSIGNED
+                    : AuditLogType.USER_REDUCE_DISK_FINISHED_FAILURE;
+        default:
+            return getSucceeded() ?
+                    AuditLogType.USER_REDUCE_DISK_FINISHED_SUCCESS
+                    : AuditLogType.USER_REDUCE_DISK_FINISHED_FAILURE;
+        }
     }
 
     private void addAuditLogCustomValues() {


### PR DESCRIPTION
ReduceImage is an asynchronous operation. Previously, on positive flow we logged a successful execution message on both 'execute' and 'end-action' phases of the command. The former is incorrect and therefore dropped (we typically log a message that says that the operation has started at this point but we don't plan for another translation cycle so it's not added as part of this change).