### PR TITLE
Fix pip version for ansible-lint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
         include:
           - name: centos-stream-8
             container-name: el8stream
-            pip-command: pip3.8
+            pip-command: pip3.9
           - name: centos-stream-9
             container-name: el9stream
             pip-command: pip3


### PR DESCRIPTION
Use pip3.9 to install ansible-lint after engine switched to use
ansible-core-2.13+

Signed-off-by: Martin Perina <mperina@redhat.com>
