### PR TITLE
Bump model to 4.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <!-- oVirt dependencies versions -->
     <kubevirt-client.version>0.5.0</kubevirt-client.version>
     <metamodel.version>1.3.10</metamodel.version>
-    <model.version>4.5.12</model.version>
+    <model.version>4.6.0</model.version>
     <ovirt-engine-extensions-api.version>1.0.1</ovirt-engine-extensions-api.version>
     <vdsm-jsonrpc-java.version>1.7.2</vdsm-jsonrpc-java.version>
 


### PR DESCRIPTION
Following changes are included in api-model 4.6.0:

* Add loongarch64 architecture type

Signed-off-by: Martin Perina <mperina@redhat.com>
