### PR TITLE
github: switch upload-rpms-action to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,6 @@ jobs:
         createrepo_c $ARTIFACTS_DIR
 
     - name: Upload artifacts
-      uses: ovirt/upload-rpms-action@v2
+      uses: ovirt/upload-rpms-action@main
       with:
         directory: ${{ env.ARTIFACTS_DIR }}


### PR DESCRIPTION
following the recommendation change in upload-rpms-action let's use latest commit