### PR TITLE
Set new templates with specified vm-init

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/AddVmTemplateCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/AddVmTemplateCommand.java
@@ -1003,10 +1003,10 @@ public class AddVmTemplateCommand<T extends AddVmTemplateParameters> extends VmT
         vmTemplateDao.save(getVmTemplate());
         getCompensationContext().snapshotNewEntity(getVmTemplate());
         setActionReturnValue(getVmTemplate().getId());
-        // Load Vm Init from DB and set it to the template
-        vmHandler.updateVmInitFromDB(getParameters().getMasterVm(), false);
         getVmTemplate().setVmInit(getParameters().getMasterVm().getVmInit());
-        vmHandler.addVmInitToDB(getVmTemplate().getVmInit());
+        if (getVmTemplate().getVmInit() != null) {
+            vmHandler.addVmInitToDB(getVmTemplate().getVmInit());
+        }
     }
 
     private void updateVmIcons() {


### PR DESCRIPTION
Previously, the backend (AddVmTemplate) set new templates with the vm-init configuration of the VM that they were created from. This prevented users from creating templates with modified vm-init configuration or without vm- init configuration from VMs that are set with vm-init. Users could either change the VM first or modify the created template to achieve this.

Now, the backend respects the vm-init configuration that is specified by clients. While the handling of vm-init in REST-API works well, the UI did not pass the vm-init configuration of the VM that templates were created from. Therefore, the webadmin is changed to load the vm-init configuration of the VM that a template is created from and pass it to the backend now.