### PR TITLE
backport: Search correctly entities with user role (#766)

### DIFF
--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendClustersResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendClustersResource.java
@@ -50,7 +50,7 @@ public class BackendClustersResource extends AbstractBackendCollectionResource<o
     private Clusters listVirtOnly() {
         if (isFiltered()) {
             return mapVirtOnlyCollection(getBackendCollection(QueryType.GetAllClusters,
-                    new QueryParametersBase()));
+                    new QueryParametersBase(), SearchType.Cluster));
         } else {
             return mapVirtOnlyCollection(getBackendCollection(SearchType.Cluster));
         }
@@ -59,7 +59,7 @@ public class BackendClustersResource extends AbstractBackendCollectionResource<o
     private Clusters listAll() {
         if (isFiltered()) {
             return mapCollection(getBackendCollection(QueryType.GetAllClusters,
-                    new QueryParametersBase()));
+                    new QueryParametersBase(), SearchType.Cluster));
         } else {
             return mapCollection(getBackendCollection(SearchType.Cluster));
         }

--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendDataCentersResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendDataCentersResource.java
@@ -29,7 +29,7 @@ public class BackendDataCentersResource extends
     public DataCenters list() {
         if (isFiltered()) {
             return mapCollection(getBackendCollection(QueryType.GetAllStoragePools,
-                    new QueryParametersBase()));
+                    new QueryParametersBase(), SearchType.StoragePool));
         } else {
             return mapCollection(getBackendCollection(SearchType.StoragePool));
         }

--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendVnicProfilesResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendVnicProfilesResource.java
@@ -10,6 +10,7 @@ import org.ovirt.engine.api.resource.VnicProfileResource;
 import org.ovirt.engine.api.resource.VnicProfilesResource;
 import org.ovirt.engine.api.restapi.util.LinkHelper;
 import org.ovirt.engine.core.common.businessentities.network.Network;
+import org.ovirt.engine.core.common.interfaces.SearchType;
 import org.ovirt.engine.core.common.queries.IdQueryParameters;
 import org.ovirt.engine.core.common.queries.QueryParametersBase;
 import org.ovirt.engine.core.common.queries.QueryType;
@@ -23,7 +24,7 @@ public class BackendVnicProfilesResource extends AbstractBackendVnicProfilesReso
 
     @Override
     protected List<org.ovirt.engine.core.common.businessentities.network.VnicProfile> getVnicProfilesCollection() {
-        return getBackendCollection(QueryType.GetAllVnicProfiles, new QueryParametersBase());
+        return getBackendCollection(QueryType.GetAllVnicProfiles, new QueryParametersBase(), SearchType.VnicProfile);
     }
 
     public Response add(VnicProfile vnicProfile) {


### PR DESCRIPTION
When a user is asking for data via the API with some filter (name of the
required entity for example), we should call implicitly the search
engine from one hand to implement the filter and from the other hand we
are getting all the entities that the user can access according to the
permissions via a pre-defined query.
Given the search and the query results, both are intersected to given a
result that matches the given filter with the user authorization.

In AbstractBackendCollectionResource we have two signatures for getBackendCollection method:

protected List<Q> getBackendCollection(QueryType query, QueryParametersBase queryParams)
protected List<Q> getBackendCollection(QueryType query, QueryParametersBase queryParams, SearchType searchType)

The 1st just brings the query results, teh 2nd brings query and search
results and intersect them.

When a user tries to search for a specific entity and the 1st signature
is used instead of the 2nd, the result is that the first item is picked
from the resulted collection and mismatch the requested entity, this may
cause an error where an operation is attempted to be excuted with the
wrong information (for example, creating a template and giving the wrong
template cluster)

This patch fixes a wrong call to the 1st signature when the 2nd
signature should be used in the following entities:

Data Centers
Clusters
VNIC Profiles

Signed-Off-By: Eli Mesika <emesika@redhat.com>
Bug-Url: https://bugzilla.redhat.com/2144346

Signed-off-by: Eli Mesika <emesika@redhat.com>