### PR TITLE
Fix NPE during ova import

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleRunnerClient.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/common/utils/ansible/AnsibleRunnerClient.java
@@ -130,10 +130,11 @@ public class AnsibleRunnerClient {
 
                 String taskName = "";
                 JsonNode eventNode = currentNode.get("event_data");
-
-                JsonNode taskNode = eventNode.get("task");
-                if (taskNode != null) {
-                    taskName = taskNode.textValue();
+                if (eventNode != null) {
+                    JsonNode taskNode = eventNode.get("task");
+                    if (taskNode != null) {
+                        taskName = taskNode.textValue();
+                    }
                 }
 
                 if (RunnerJsonNode.isEventStart(currentNode) || RunnerJsonNode.playbookStats(currentNode)) {


### PR DESCRIPTION
Title - Fix NPE during ova import
Issue - During ova import, if event node is null, engine log has error as well as NPE
Fix - Check eventNode for the null value

Signed-off-by: Shubha Kulkarni <shubha.kulkarni@oracle.com>
