### PR TITLE
Allow OVA import when origin is null and destination is block SD

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ImportVmFromExternalProviderCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ImportVmFromExternalProviderCommand.java
@@ -372,7 +372,8 @@ implements SerialChildExecutingCommand, QuotaStorageDependent {
         // can be larger then the actual size.
         // Separately, setting the Volume Type to Preallocated avoids Sparseness when the
         // Destination is a Block SD
-        if (getVm().getOrigin() == OriginType.KVM
+        // Allow this workaround for Vms that do not have origin set
+        if ((getVm().getOrigin() == null || getVm().getOrigin() == OriginType.KVM)
                 && getActionState() == CommandActionState.EXECUTE
                 && getStorageDomain() != null
                 && getStorageDomain().getStorageType().isBlockDomain()) {


### PR DESCRIPTION

Allow OVA import when origin is null and destination is block SD.

Issue: 	
Importing certain OVA image fails with "No space left on device".		
Certain OVA images exported from VMware fail to import because vm origin was not set. 
Fix:
Check for vm.origin null when importing ova to block storage 


Signed-off-by: Shubha Kulkarni <shubha.kulkarni@oracle.com>
