### PR TITLE
Propagate backup mode to template disks

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/CreateImageTemplateCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/CreateImageTemplateCommand.java
@@ -107,6 +107,9 @@ public class CreateImageTemplateCommand<T extends CreateImageTemplateParameters>
                         getParameters().getStorageDomainId(),
                         getParameters().getDestinationStorageDomainId()));
 
+        if (targetFormat == VolumeFormat.COW) {
+            newImage.setBackup(getDiskImage().getBackup());
+        }
         newImage.setId(destinationImageGroupID);
         newImage.setDiskDescription(getParameters().getDescription() != null ?
                 getParameters().getDescription() : getDiskImage().getDiskDescription());


### PR DESCRIPTION
Previously, all template disks were created with backup mode = NONE regardless of the backup mode of the disks of the VM that the template is created from.

Now the backup mode would propagte from the VM disks to the template disks when their format is qcow2. If the template disks are created as raw their backup mode would be NONE. Enabing to create template disks with incremental backup enabled from VM disks that are raw is outside of the scope of this change.