### PR TITLE
fix builds in stable branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,6 @@ jobs:
         include:
           - name: centos-stream-8
             container-name: el8stream
-          - name: centos-stream-9
-            container-name: el9stream
 
     name: ${{ matrix.name }}
 


### PR DESCRIPTION
- Remove EL9 builds
- Force using ovirt-engine-build-dependencies >= 4.5.3.1
