### PR TITLE
backport: executing ansible runner artifacts clean up with fixed delay

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/validator/AnsibleRunnerCleanUpService.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/validator/AnsibleRunnerCleanUpService.java
@@ -40,7 +40,8 @@ public class AnsibleRunnerCleanUpService implements BackendService {
         final int HOURS_TO_MINUTES = 60;
         long intervalInMinutes = Math.round(interval * HOURS_TO_MINUTES);
 
-        executor.schedule(this::checkExecutionTimeStamp,
+        executor.scheduleWithFixedDelay(this::checkExecutionTimeStamp,
+                10,
                 intervalInMinutes,
                 TimeUnit.MINUTES);
     }


### PR DESCRIPTION
Ansible-Runner artifacts are cleaned up periodically according to the properties
configured in engine-config:
AnsibleRunnerArtifactsLifetimeInDays: How many days artifacts will be kept before
they are cleaned up
AnsibleRunnerArtifactsCleanupCheckTimeInHours: The periodic time to execute the clean up

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=2151549
Signed-off-by: dangel101 <dangel101@gmail.com>
