### PR TITLE
Use default values for OVN encrypted connections

### DIFF
--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/network/ovirtproviderovn.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/network/ovirtproviderovn.py
@@ -72,9 +72,8 @@ class Plugin(plugin.PluginBase):
 
     CONNECTION_TCP = 'tcp'
     CONNECTION_SSL = 'ssl'
-    SSL_PROTOCOLS = 'TLSv1.2'
-    ALLOWED_CIPHERS = 'kRSA:-aDSS:-3DES:!DES:!RC4:!RC2:!IDEA:-SEED:!eNULL:' \
-                      '!aNULL:!MD5:-SHA384:-CAMELLIA:-ARIA:-AESCCM8'
+    SSL_PROTOCOLS = ''
+    ALLOWED_CIPHERS = ''
 
     PROVIDER_NAME = 'ovirt-provider-ovn'
 


### PR DESCRIPTION
Use default values for OVN encrypted connections, which should be
inherited from the exactp crypto policy being used.

Signed-off-by: Martin Perina <mperina@redhat.com>
