### PR TITLE
backport: add debug info

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/validator/AnsibleRunnerCleanUpService.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/validator/AnsibleRunnerCleanUpService.java
@@ -62,6 +62,12 @@ public class AnsibleRunnerCleanUpService implements BackendService {
                 return;
             }
             long todayInDays = FileTime.fromMillis(new Date().getTime()).to(TimeUnit.DAYS);
+            log.debug(
+                    "'{}' creation time in days: {}. Current date in days: {}. Artifacts life time is set to: {}",
+                    file.getAbsolutePath(),
+                    creationInDays,
+                    todayInDays,
+                    artifactsLifeTime);
             if (todayInDays - creationInDays > artifactsLifeTime) {
                 log.debug("Deleting directory '{}'", file.getAbsolutePath());
                 try {


### PR DESCRIPTION
Adding info regarding the file's creation time in days, current date in days
and the config value artifacts life time is set to, for easier debugging

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=2151549
Signed-off-by: dangel101 <dangel101@gmail.com>
