### PR TITLE
Don't stop clean up when a file cannot be removed

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/validator/AnsibleRunnerCleanUpService.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/validator/AnsibleRunnerCleanUpService.java
@@ -1,7 +1,6 @@
 package org.ovirt.engine.core.bll.validator;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -56,7 +55,7 @@ public class AnsibleRunnerCleanUpService implements BackendService {
                 creationInDays = Files.readAttributes(file.toPath(), BasicFileAttributes.class)
                         .creationTime()
                         .to(TimeUnit.DAYS);
-            } catch (IOException e) {
+            } catch (Exception e) {
                 log.error("Failed to read file '{}' attributes: {}", file.getAbsolutePath(), e.getMessage());
                 log.debug("Exception: ", e);
                 return;
@@ -75,7 +74,7 @@ public class AnsibleRunnerCleanUpService implements BackendService {
                             .sorted(Comparator.reverseOrder())
                             .map(Path::toFile)
                             .forEach(File::delete);
-                } catch (IOException e) {
+                } catch (Exception e) {
                     log.error("Failed to delete dir '{}' content: {}", file.getAbsolutePath(), e.getMessage());
                     log.debug("Exception: ", e);
                 }


### PR DESCRIPTION
WE have handled only IOException, but when a file cannot be removed due
to insufficient permissions then SecurityException is raised and because
of that we didn't continue with the removal of other directories.

Bug-Url: https://bugzilla.redhat.com/2151549
Signed-off-by: Martin Perina <mperina@redhat.com>
