### PR TITLE
Add templates for issues and PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,39 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Affected version**
+
+> **IMPORTANT!**: oVirt prior to 4.5 reached end of life.
+> If you have an issue on an older version please
+> upgrade to latest stable release before opening an issue.
+
+* oVirt Engine: (example: ovirt-engine-4.5.0.8-1.el8.noarch)
+* Host OS Variant: (example: oVirt Node 4.5.4)
+* VDSM version: (example: vdsm-4.50.1.4-1.el8.x86_64)
+* Additional relevant package versions: (add whatever seems related to the issue, example: glusterfs-10.2-1.el8s.x86_64)
+
+**Describe the bug**
+
+A clear and concise description of what the bug is
+
+**To reproduce**
+
+Steps to reproduce the behavior
+
+**Expected behavior**
+
+A clear and concise description of what you expected to happen
+
+**Screenshots**
+
+If applicable, add screenshots to help explain your problem
+
+**Additional context**
+
+Add any other context about the problem here

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: oVirt Mailing Lists
+    url: https://lists.ovirt.org/archives/
+    about: Join us on the mailing list for more conversations and community support
+  - name: oVirt User Documentation
+    url: https://ovirt.org/documentation/
+    about: Documentation for oVirt users
+  - name: oVirt Developer Documentation
+    url: https://ovirt.org/develop/devdocs.html
+    about: Documentation for oVirt developers

--- a/.github/ISSUE_TEMPLATE/request-for-enhancement.md
+++ b/.github/ISSUE_TEMPLATE/request-for-enhancement.md
@@ -1,0 +1,20 @@
+---
+name: Request for enhancement
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered
+
+**Additional context**
+Add any other context or screenshots about the feature request here

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+Fixes issue # (delete if not relevant)
+
+## Changes introduced with this PR
+
+*
+
+*
+
+*
+
+## Are you the owner of the code you are sending in, or do you have permission of the owner?
+
+[y/n]


### PR DESCRIPTION
Add templates from https://github.com/oVirt/gerrit-to-gh adding notes about EoL versions and requesting info on the versions of the software being used.

Signed-off-by: Sandro Bonazzola <sbonazzo@redhat.com>