### PR TITLE
Upgrade snakeyaml to 1.33

### DIFF
--- a/i18n/pom.xml
+++ b/i18n/pom.xml
@@ -14,7 +14,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <maven-resources-plugin.version>2.5</maven-resources-plugin.version>
     <slf4j.version>1.7.22</slf4j.version>
-    <snakeyaml.version>1.17</snakeyaml.version>
+    <snakeyaml.version>1.33</snakeyaml.version>
 
     <working-zanata-directory>target/zanata</working-zanata-directory>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
     <reflections.version>0.9.9</reflections.version>
     <resteasy.version>3.9.3.Final</resteasy.version>
     <slf4j.version>1.7.22</slf4j.version>
-    <snakeyaml.version>1.26</snakeyaml.version>
+    <snakeyaml.version>1.33</snakeyaml.version>
     <spring.version>5.3.19</spring.version>
     <sshd-core.version>2.9.2</sshd-core.version>
     <validation-api.version>2.0.1.Final</validation-api.version>


### PR DESCRIPTION
Upgrade snakeyaml to 1.33 to resolve all existing security issues
with previous versions

Signed-off-by: Martin Perina <mperina@redhat.com>
