### PR TITLE
Bump jackson to 2.12.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <httpcore.version>4.4.14</httpcore.version>
     <infinispan.version>9.4.18.Final</infinispan.version>
     <istack-commons-runtime.version>3.0.10</istack-commons-runtime.version>
-    <jackson2.version>2.12.1</jackson2.version>
+    <jackson2.version>2.12.7</jackson2.version>
     <jakarta-el.version>3.0.3</jakarta-el.version>
     <javacc.version>2.6</javacc.version>
     <javassist.version>3.23.1-GA</javassist.version>


### PR DESCRIPTION
Bump jackson to 2.12.7, which is available in the latest EAP

Signed-off-by: Martin Perina <mperina@redhat.com>
