### PR TITLE
Drop python-netaddr dependency

### DIFF
--- a/ovirt-engine.spec.in
+++ b/ovirt-engine.spec.in
@@ -611,7 +611,6 @@ Requires:	ovirt-engine-metrics >= 1.3.4.1
 Requires:	java-11-openjdk-headless >= %{openjdk_version}
 Requires:	logrotate
 Requires:	python3-dateutil
-Requires:	python3-netaddr
 Requires:	python3-psycopg2
 Requires:	python3-six
 Requires(pre):		shadow-utils

--- a/packaging/ansible-runner-service-project/project/ovirt-host-reconfigure-ovn.yml
+++ b/packaging/ansible-runner-service-project/project/ovirt-host-reconfigure-ovn.yml
@@ -38,4 +38,3 @@
     - ovirt_openvswitch_pre.version is version('2.11', '==')
     - ovirt_openvswitch_post.version is version('2.15', '>=')
     - ovn_central is defined
-    - ovn_central | ipaddr

--- a/packaging/ansible-runner-service-project/project/roles/ovirt-provider-ovn-driver/tasks/configure.yml
+++ b/packaging/ansible-runner-service-project/project/roles/ovirt-provider-ovn-driver/tasks/configure.yml
@@ -12,7 +12,7 @@
         enabled: true
 
   when:
-    - cluster_switch == "ovs" or (ovn_central is defined and ovn_central | ipaddr)
+    - cluster_switch == "ovs" or (ovn_central is defined)
 
 - block:
     - name: Install ovirt-provider-ovn-driver
@@ -46,4 +46,3 @@
 
   when:
     - ovn_central is defined
-    - ovn_central | ipaddr


### PR DESCRIPTION
it's nothing but a headache to keep up with ansible's idea of bumping
python every few months. Let's drop it entirely.

Fixes issue # (delete if not relevant)

## Changes introduced with this PR

*

*

*

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n]