### PR TITLE
Add glibc-langpack-en requirement

### DIFF
--- a/ovirt-engine.spec.in
+++ b/ovirt-engine.spec.in
@@ -537,6 +537,7 @@ Requires:	ovirt-engine-keycloak-setup
 %endif
 Requires:	ovirt-engine-extension-aaa-jdbc >= 1.2.0
 Requires:	openssh
+Requires:	glibc-langpack-en
 Requires:       postgresql-server >= 12.0
 Requires:       postgresql-contrib >= 12.0
 Conflicts:	%{name} < 4.4.0


### PR DESCRIPTION
## Changes introduced with this PR

Installing on a clean system with Italian locale, engine-setup fails with:

```console
[ INFO  ] Initializing PostgreSQL
[ INFO  ] Creating PostgreSQL 'engine' database
[ ERROR ] Failed to execute stage 'Misc configuration': ERRORE:  nome locale non valido "en_US.UTF-8"
         
[ INFO  ] DNF Performing DNF transaction rollback
[ INFO  ] DNF Repository copr:copr.fedorainfracloud.org:ovirt:ovirt-master-snapshot is listed more than once in the configuration
[ INFO  ] Stage: Clean up
          Log file is located at /var/log/ovirt-engine/setup/ovirt-engine-setup-20230420105508-xx23f2.log
[ INFO  ] Generating answer file '/var/lib/ovirt-engine/setup/answers/20230420105553-setup.conf'
[ INFO  ] Stage: Pre-termination
[ INFO  ] Stage: Termination
[ ERROR ] Execution of setup failed
```

Requiring glibc-langpack-en in order to ensure  "en_US.UTF-8" locale exists.


## Are you the owner of the code you are sending in, or do you have permission of the owner?

y