### PR TITLE
ovirt-engine-setup database checks: being member of the database owner is also ok

### DIFF
--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/db/schema.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/db/schema.py
@@ -323,7 +323,7 @@ class Plugin(plugin.PluginBase):
                     nsp.nspname not in ('information_schema', 'pg_catalog') and
                     nsp.nspname not like 'pg_%%' and
                     cls.relname not like 'pg_%%' and
-                    rol.rolname != %(user)s
+                    not pg_catalog.pg_has_role(%(user)s, rol.rolname, 'usage')
                 order by
                     nsp.nspname,
                     cls.relname


### PR DESCRIPTION
fixes issue  #841

This PR makes the database check succeed also when some object is not owned by the user, but the user is member of some role which owns the object.

The `pg_catalog.pg_has_role` function is available since postgres 8.1 (released in 2005).
The argument `'usage'` means that the user does not need to explicitly switch to the owner role using `SET ROLE`, which may be necessary with the alternative `'member'`.