### PR TITLE
core:  Avoid NPE on refreshlun call without plugged VMs

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/pool/SyncDirectLunsCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/pool/SyncDirectLunsCommand.java
@@ -1,5 +1,6 @@
 package org.ovirt.engine.core.bll.storage.pool;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -218,7 +219,12 @@ public class SyncDirectLunsCommand<T extends SyncDirectLunsParameters> extends A
     }
 
     private List<VM> getPluggedVms(Guid diskId) {
-        return vmDao.getForDisk(diskId, false).get(Boolean.TRUE);
+        List<VM> result = vmDao.getForDisk(diskId, false).get(Boolean.TRUE);
+        // Return an empty list if no plugged VMs found
+        if (result == null) {
+             result = new ArrayList<>();
+        }
+        return result;
     }
 
     private Stream<Guid> getIdsOfDirectLunsToSync() {

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/pool/SyncDirectLunsCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/pool/SyncDirectLunsCommand.java
@@ -1,6 +1,5 @@
 package org.ovirt.engine.core.bll.storage.pool;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -219,12 +218,7 @@ public class SyncDirectLunsCommand<T extends SyncDirectLunsParameters> extends A
     }
 
     private List<VM> getPluggedVms(Guid diskId) {
-        List<VM> result = vmDao.getForDisk(diskId, false).get(Boolean.TRUE);
-        // Return an empty list if no plugged VMs found
-        if (result == null) {
-             result = new ArrayList<>();
-        }
-        return result;
+        return vmDao.getForDisk(diskId, false).computeIfAbsent(Boolean.TRUE, b -> Collections.emptyList());
     }
 
     private Stream<Guid> getIdsOfDirectLunsToSync() {


### PR DESCRIPTION
## Changes introduced with this PR

This patch fixes an NPE when running an unplugged disk's refreshlun command.

In case of refreshing an unplugged disk, the engine throws a NullPointerException. Example: [npe.txt](https://github.com/oVirt/ovirt-engine/files/11516191/npe.txt)


## Are you the owner of the code you are sending in, or do you have permission of the owner?

y