### PR TITLE
Fix ansible-lint issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
     - name: Install required PyPI packages
-      run: ${{ matrix.pip-command }} install "ansible-lint>=6.0.0,<6.8.3"
+      run: ${{ matrix.pip-command }} install "ansible-lint>=6.0.0,<7.0.0"
 
     - name: Checkout sources
       uses: ovirt/checkout-action@main

--- a/build/ansible-check.sh
+++ b/build/ansible-check.sh
@@ -9,4 +9,4 @@ if ! command -v ansible-lint > /dev/null 2>&1; then
 fi
 
 # Run ansible-lint
-#ansible-lint -c ${ANSIBLE_LINT_CONF} packaging/ansible-runner-service-project/project/roles/*
+ansible-lint -c ${ANSIBLE_LINT_CONF} packaging/ansible-runner-service-project/project/roles/*


### PR DESCRIPTION
* Enable ansible-lint execution
* Use the latest ansible-lint 6.y version

Fixes: https://github.com/oVirt/ovirt-engine/issues/851
Signed-off-by: Martin Perina <mperina@redhat.com>
