### PR TITLE
Bump SpringFramework to 5.3.27

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
     <resteasy.version>3.9.3.Final</resteasy.version>
     <slf4j.version>1.7.22</slf4j.version>
     <snakeyaml.version>1.33</snakeyaml.version>
-    <spring.version>5.3.19</spring.version>
+    <spring.version>5.3.27</spring.version>
     <sshd-core.version>2.9.2</sshd-core.version>
     <validation-api.version>2.0.1.Final</validation-api.version>
     <ws-commons-util.version>1.0.2</ws-commons-util.version>


### PR DESCRIPTION
Bumps the version to mitigate latest CVEs

Signed-off-by: Martin Perina <mperina@redhat.com>
