### PR TITLE
noVNC: don't use removed files

### DIFF
--- a/backend/manager/modules/services/src/main/webapp/novnc-main.jsp
+++ b/backend/manager/modules/services/src/main/webapp/novnc-main.jsp
@@ -58,23 +58,6 @@
 
     </style>
 
-    <!-- Promise polyfill for IE11 -->
-    <script src="files/novnc/vendor/promise.js"></script>
-
-    <!-- ES2015/ES6 modules polyfill -->
-    <script type="module">
-        window._noVNC_has_module_support = true;
-    </script>
-    <script>
-        window.addEventListener("load", function() {
-            if (window._noVNC_has_module_support) return;
-            const loader = document.createElement("script");
-            loader.src = "files/novnc/vendor/browser-es-module-loader/dist/" +
-                "browser-es-module-loader.js";
-            document.head.appendChild(loader);
-        });
-    </script>
-
     <!-- actual script modules -->
     <script type="module" crossorigin="anonymous">
         // RFB holds the API to connect and communicate with a VNC server


### PR DESCRIPTION
noVNC dropped support for IE in commit
https://github.com/novnc/noVNC/commit/890cff921d78835762fbdcfef862571c52cb3035 As a result, the promise.js file was removed, and should not be referenced anymore from our code.

EL8 and EL9 already ship without promise.js file.