### PR TITLE
Do not change qcow+preallocated volumes when moving disks

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/CloneVmNoCollapseCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/CloneVmNoCollapseCommand.java
@@ -234,8 +234,7 @@ public class CloneVmNoCollapseCommand<T extends CloneVmParameters> extends Clone
                         oldToNewDiskImageMap
                                 .keySet()
                                 .stream()
-                                .collect(Collectors.toMap(d -> d.getImageId(),
-                                        d -> oldToNewDiskImageMap.get(d))));
+                                .collect(Collectors.toMap(DiskImage::getImageId, oldToNewDiskImageMap::get)));
         List<DiskImage> newChain = new ArrayList(oldToNewDiskImageMap.values());
         ImagesHandler.sortImageList(newChain);
 

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/CloneImageGroupVolumesStructureCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/CloneImageGroupVolumesStructureCommand.java
@@ -188,6 +188,7 @@ public class CloneImageGroupVolumesStructureCommand<T extends CloneImageGroupVol
         parameters.setParentCommand(getActionType());
         parameters.setParentParameters(getParameters());
         parameters.setJobWeight(getParameters().getOperationsJobWeight().get(image.getImageId().toString()));
+        parameters.setBackup(image.getBackup());
         runInternalActionWithTasksContext(ActionType.CreateVolumeContainer, parameters);
     }
 


### PR DESCRIPTION
Base volumes can be of QCOW format and preallocated type when the disk is set with incremental-backup enabled. When moving disks, we now propagate the incremental-backup settings forward to CreateVolume so it will keep these volumes preallocated on the destination storage domain.

Bug-Url: https://bugzilla.redhat.com/2211608