### PR TITLE
Fix creation of ova with encoded ovf

### DIFF
--- a/packaging/ansible-runner-service-project/project/roles/ovirt-ova-pack/files/pack_ova.py
+++ b/packaging/ansible-runner-service-project/project/roles/ovirt-ova-pack/files/pack_ova.py
@@ -43,11 +43,12 @@ def pad_to_block_size(file):
 
 def write_ovf(entity, ova_file, ovf):
     print("writing ovf: %s" % ovf)
-    tar_info = create_tar_info(entity + ".ovf", len(ovf))
+    encoded_ovf = ovf if python2 else ovf.encode()
+    tar_info = create_tar_info(entity + ".ovf", len(encoded_ovf))
     buf = (tar_info.tobuf() if python2 else
            tar_info.tobuf(format=tarfile.GNU_FORMAT))
     ova_file.write(buf)
-    ova_file.write(ovf if python2 else ovf.encode())
+    ova_file.write(encoded_ovf)
     pad_to_block_size(ova_file)
 
 


### PR DESCRIPTION
The size of the entry in the tar file for the OVF should match the length of the encoded ovf, otherwise the OVF parsing fails in case the encoded OVF is longer.