### PR TITLE
Change save/restore nvram data logic

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/SaveVmExternalDataCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/SaveVmExternalDataCommand.java
@@ -10,7 +10,6 @@ import org.ovirt.engine.core.common.FeatureSupported;
 import org.ovirt.engine.core.common.action.ExternalDataStatus;
 import org.ovirt.engine.core.common.action.SaveVmExternalDataParameters;
 import org.ovirt.engine.core.common.action.VmExternalDataKind;
-import org.ovirt.engine.core.common.businessentities.BiosType;
 import org.ovirt.engine.core.common.businessentities.VmDeviceGeneralType;
 import org.ovirt.engine.core.common.errors.EngineError;
 import org.ovirt.engine.core.common.errors.EngineException;
@@ -47,8 +46,8 @@ public class SaveVmExternalDataCommand<T extends SaveVmExternalDataParameters> e
         return !vmDeviceDao.getVmDeviceByVmIdAndType(getParameters().getVmId(), VmDeviceGeneralType.TPM).isEmpty();
     }
 
-    private boolean hasSecureBoot() {
-        return getVm().getBiosType() == BiosType.Q35_SECURE_BOOT
+    private boolean isUEFI() {
+        return getVm().getBiosType().isOvmf()
                 && FeatureSupported.isNvramPersistenceSupported(getVm().getCompatibilityVersion());
     }
 
@@ -80,7 +79,7 @@ public class SaveVmExternalDataCommand<T extends SaveVmExternalDataParameters> e
         if (hasTpmDevice()) {
             dataToRetrieve.add(VmExternalDataKind.TPM);
         }
-        if (hasSecureBoot()) {
+        if (isUEFI()) {
             dataToRetrieve.add(VmExternalDataKind.NVRAM);
         }
 

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/snapshots/SnapshotsManager.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/snapshots/SnapshotsManager.java
@@ -31,7 +31,6 @@ import org.ovirt.engine.core.bll.utils.IconUtils;
 import org.ovirt.engine.core.bll.utils.VmDeviceUtils;
 import org.ovirt.engine.core.common.AuditLogType;
 import org.ovirt.engine.core.common.action.VmExternalDataKind;
-import org.ovirt.engine.core.common.businessentities.BiosType;
 import org.ovirt.engine.core.common.businessentities.Cluster;
 import org.ovirt.engine.core.common.businessentities.Quota;
 import org.ovirt.engine.core.common.businessentities.Snapshot;
@@ -352,7 +351,7 @@ public class SnapshotsManager {
                 vmExternalData.put(VmExternalDataKind.TPM, tpmData);
             }
         }
-        if (vm.getBiosType() == BiosType.Q35_SECURE_BOOT) {
+        if (vm.getBiosType().isOvmf()) {
             SecretValue<String> nvramData = vmDao.getNvramData(vm.getId()).getFirst();
             if (!SecretValue.isNull(nvramData) && !nvramData.getValue().equals("")) {
                 vmExternalData.put(VmExternalDataKind.NVRAM, nvramData);

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/utils/VmDeviceUtils.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/utils/VmDeviceUtils.java
@@ -29,7 +29,6 @@ import org.ovirt.engine.core.common.FeatureSupported;
 import org.ovirt.engine.core.common.action.VmExternalDataKind;
 import org.ovirt.engine.core.common.action.VmManagementParametersBase;
 import org.ovirt.engine.core.common.businessentities.ArchitectureType;
-import org.ovirt.engine.core.common.businessentities.BiosType;
 import org.ovirt.engine.core.common.businessentities.ChipsetType;
 import org.ovirt.engine.core.common.businessentities.Cluster;
 import org.ovirt.engine.core.common.businessentities.ConsoleTargetType;
@@ -2287,7 +2286,7 @@ public class VmDeviceUtils {
         if (hasTpmDevice(targetVmId)) {
             vmDao.copyTpmData(sourceVmId, targetVmId);
         }
-        if (getVmBase(targetVmId).getBiosType() == BiosType.Q35_SECURE_BOOT) {
+        if (getVmBase(targetVmId).getBiosType().isOvmf()) {
             vmDao.copyNvramData(sourceVmId, targetVmId);
         }
     }

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/CreateBrokerVDSCommand.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/CreateBrokerVDSCommand.java
@@ -5,7 +5,6 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
-import org.ovirt.engine.core.common.businessentities.BiosType;
 import org.ovirt.engine.core.common.businessentities.VM;
 import org.ovirt.engine.core.common.businessentities.VmDevice;
 import org.ovirt.engine.core.common.businessentities.storage.DiskImage;
@@ -78,7 +77,7 @@ public class CreateBrokerVDSCommand<P extends CreateVDSCommandParameters> extend
         if (!SecretValue.isNull(tpmData)) {
             createInfo.put(VdsProperties.tpmData, tpmData.getValue());
         }
-        if (vm.getBiosType() == BiosType.Q35_SECURE_BOOT) {
+        if (vm.getBiosType().isOvmf()) {
             SecretValue<String> nvramData = vmInfoBuildUtils.nvramData(vm.getId());
             if (!SecretValue.isNull(nvramData)) {
                 createInfo.put(VdsProperties.nvramData, nvramData.getValue());


### PR DESCRIPTION
Save NVRAM data not only if BiosType is Q35_SECURE_BOOT Also save if Q35_OVMF because it also includes EFI boot variables With Q35_OVMF we unable to boot non-fallback bootloaders in place different from <esp>/EFI/BOOT/BOOT<arch>.EFI

To check this it needed to:
1) Run VM with installed Linux (it doesn't matter what distro) 2) Add a bootloader via efibbotmgr
   efibootmgr -c -d <boot device> -L "Some Linux" -l \\EFI\\<somevendor>\\grubx64.efi
3) Look at created efi boot variable
   efibootmgr -v
   It's present
4) Shutdown or Poweroff VM
5) Run it again
6) Check efi boot variables again
   efibootmgr -v
   It's absent
7) We got non bootable VM if fallback bootloader is broken or boot default esp/EFI/BOOT/BOOT<arch>.EFI
   otherwise
