### PR TITLE
Force LC_ALL=C before running df -l command on pki-enroll-request

### DIFF
--- a/packaging/bin/pki-enroll-request.sh
+++ b/packaging/bin/pki-enroll-request.sh
@@ -129,7 +129,7 @@ done
 common_set_conf_vars
 
 LOCK="${PKIDIR}/${CA_FILE}".pem
-df -l "${LOCK}" 2> /dev/null | grep -q "File" || die "${LOCK} is not on a local filesystem"
+LC_ALL=C df -l "${LOCK}" 2> /dev/null | grep -q "File" || die "${LOCK} is not on a local filesystem"
 
 # Wait for lock on fd 9
 (


### PR DESCRIPTION
## Changes introduced with this PR

* pki-enroll-request.sh checks if the CA file is stored on a local filesystem. However, the 'df' command output depends on the local system language, thus output may vary. With this patch LANG=C is forced just before the 'df' command is run.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

Yes.