### PR TITLE
core: Fail when getVolumeInfo fails during OVF read

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/GetUnregisteredDiskQuery.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/GetUnregisteredDiskQuery.java
@@ -83,6 +83,13 @@ public class GetUnregisteredDiskQuery<P extends GetUnregisteredDiskQueryParamete
         // image. If there are multiple volumes, skip the image and move on to the next.
         if (volumesList.size() != 1) {
             getQueryReturnValue().setSucceeded(false);
+            log.info("Skipping a disk with snapshots: {}", diskId);
+
+            // Add context for why the query did not succeed. Not great, but it is what it is
+            DiskImage diskImage = new DiskImage();
+            diskImage.setDiskSnapshot(true);
+            diskImage.setDescription(String.format("snapshot-%s", diskId));
+            getQueryReturnValue().setReturnValue(diskImage);
             return;
         }
 

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/GetUnregisteredDisksQuery.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/GetUnregisteredDisksQuery.java
@@ -78,7 +78,14 @@ public class GetUnregisteredDisksQuery<P extends GetUnregisteredDisksQueryParame
             if (unregQueryReturn.getSucceeded()) {
                 unregisteredDisks.add(unregQueryReturn.getReturnValue());
             } else {
-                log.debug("Could not get populated disk: {}", unregQueryReturn.getExceptionString());
+                DiskImage returnValue = unregQueryReturn.getReturnValue();
+                if (returnValue.isDiskSnapshot() &&
+                        String.format("snapshot-%s", unregisteredDiskId).equals(returnValue.getDescription())) {
+                    continue;
+                }
+
+                log.error("Could not get populated disk: {}", unregQueryReturn.getExceptionString());
+                getQueryReturnValue().setSucceeded(false);
             }
         }
         getQueryReturnValue().setReturnValue(unregisteredDisks);


### PR DESCRIPTION
In a scenario where we managed to list the images on the storage, but failed to read get their information from vdsm, we will end up with engine assuming the OVF_STOREs are missing.

Instead this patch treats a failure to retrieve the infromation as a failure to force the user to retry.

Bug-Url: https://bugzilla.redhat.com/2244641