### PR TITLE
"secure boot" not getting enabled for Chipset/Firmware Type "Q35 Chipset with UEFI SecureBoot"

### DIFF
--- a/packaging/dbscripts/vms_sp.sql
+++ b/packaging/dbscripts/vms_sp.sql
@@ -2507,6 +2507,10 @@ BEGIN
         DELETE FROM vm_nvram_data
         WHERE vm_id = OLD.vm_guid;
     END IF;
+    IF OLD.bios_type = 3 AND NEW.bios_type = 4 THEN
+	DELETE FROM vm_nvram_data
+	WHERE vm_id = OLD.vm_guid;
+    END IF;
     RETURN NEW;
 END;$$
 LANGUAGE plpgsql;


### PR DESCRIPTION
Issue:
When VM emulator is changed to Q35 Chipset with UEFI SecureBoot from Q35 Chipset with UEFI, the NVRAM file needs to be rewritten.

Fix:
On VM update remove the previous NVRAM file.

Signed-off-by: Saksham Srivastava saksham.sa.srivastava@oracle.com