### PR TITLE
Restore grafana.db selinux context after engine-restore

### DIFF
--- a/packaging/bin/engine-backup.sh.in
+++ b/packaging/bin/engine-backup.sh.in
@@ -1703,7 +1703,8 @@ restoreSQLiteDB() {
 		chmod 0750 "${db_dir}" 2>> "${LOG}" || logdie "chmod failed"
 		chown "${dir_owner}" "${db_dir}" 2>> "${LOG}" || output "Warning: ${dir_owner} user or group missing"
 	fi
-	cp -a "${backupfile}" "${db_file}" 2>> "${LOG}" || "cp failed"
+	cp -a "${backupfile}" "${db_file}" 2>> "${LOG}" || logdie "cp failed"
+	restorecon "${db_file}" || log "Restoring selinux context failed"
 }
 
 verifyEngineDb() {


### PR DESCRIPTION
Restore proper selinux context for /var/lib/grafana/grafana.db when
restoring from backup created by engine-backup.

Signed-off-by: Martin Perina <mperina@redhat.com>
