### PR TITLE
Issue: Intermittent UI exception while opening the Import Virtual Machine(s) pop-up

### DIFF
--- a/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/section/main/view/popup/storage/RegisterEntityInfoPanel.java
+++ b/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/section/main/view/popup/storage/RegisterEntityInfoPanel.java
@@ -312,8 +312,13 @@ public abstract class RegisterEntityInfoPanel<T, D extends ImportEntityData<T>, 
         AbstractTextColumn<VmNetworkInterface> dropsColumn = new AbstractSumUpColumn<VmNetworkInterface>() {
             @Override
             protected Double[] getRawValue(VmNetworkInterface object) {
-                Double receiveDrops = object != null ? object.getStatistics().getReceiveDrops().doubleValue() : null;
-                Double transmitDrops = object != null ? object.getStatistics().getTransmitDrops().doubleValue() : null;
+                Double receiveDrops = (object != null && object.getStatistics() != null
+                    && object.getStatistics().getReceiveDrops() != null)
+                    ? object.getStatistics().getReceiveDrops().doubleValue() : 0.0;
+                Double transmitDrops = (object != null && object.getStatistics() != null
+                    && object.getStatistics().getTransmitDrops() != null)
+                    ? object.getStatistics().getTransmitDrops().doubleValue() : 0.0;
+
                 return new Double[] { receiveDrops, transmitDrops };
             }
         };


### PR DESCRIPTION
Signed-off-by: ShubhaOracle <Shubha.kulkarni@oracle.com>

## Fixes issue 
Intermittent UI exception while opening the Import Virtual Machine(s) pop-up

```
Stack Trace when error happens:

2023-07-17 11:11:12,436-06 ERROR [org.ovirt.engine.ui.frontend.server.gwt.OvirtRemoteLoggingService] (default task-43) [] Uncaught exception: com.google.gwt.core.client.JavaScriptException: (TypeError) : a is null
at java.math.Conversion.toDecimalScaledString(Conversion.java:175)
at org.ovirt.engine.ui.webadmin.section.main.view.popup.storage.RegisterEntityInfoPanel18.18.18.getRawValue(RegisterEntityInfoPanel.java:314)
at org.ovirt.engine.ui.webadmin.section.main.view.popup.storage.RegisterEntityInfoPanel$18.getRawValue(RegisterEntityInfoPanel.java:314)
```

## Changes introduced with this PR

* Add checks for null values

