### PR TITLE
Skip chmod of ENGINE_EXTERNAL_PROVIDERS_TRUST_STORE in DEVELOPER_MODE

### DIFF
--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/network/ovirtproviderovn.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/network/ovirtproviderovn.py
@@ -877,11 +877,12 @@ class Plugin(plugin.PluginBase):
                 'pass': truststore_password,
             },
         )
-        self._set_file_permissions(
-            truststore,
-            True,
-            stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH,
-        )
+        if not self.environment[osetupcons.CoreEnv.DEVELOPER_MODE]:
+            self._set_file_permissions(
+                truststore,
+                True,
+                stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH,
+            )
 
     def _is_provider_installed(self):
         # TODO: we currently only check against installations done by


### PR DESCRIPTION
The keytool command before this _set_file_permissions is not executed in DEVELOPER_MODE.
If we execute the chmod, it fails with:
Failed to execute stage 'Misc configuration': [Errno 2] No such file or directory: '/home/xxx/xxx/var/lib/ovirt-engine/external_truststore' as the file was not created.
