### PR TITLE
engine: add scope 'openid' for compatibility with new versions of the keycloak

### DIFF
--- a/backend/manager/modules/enginesso/src/main/java/org/ovirt/engine/core/sso/service/ExternalOIDCService.java
+++ b/backend/manager/modules/enginesso/src/main/java/org/ovirt/engine/core/sso/service/ExternalOIDCService.java
@@ -52,6 +52,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class ExternalOIDCService {
 
+    private static final String OPENID_SCOPE = "openid";
     private static Logger log = LoggerFactory.getLogger(ExternalOIDCService.class);
 
     // Reference to the HTTP client used to send the requests to the SSO server:
@@ -124,6 +125,12 @@ public class ExternalOIDCService {
         String externalOidcClientId = ssoContext.getSsoLocalConfig().getProperty("EXTERNAL_OIDC_CLIENT_ID");
         String externalOidcClientSecret = ssoContext.getSsoLocalConfig().getProperty("EXTERNAL_OIDC_CLIENT_SECRET");
         String scope = SsoService.getScopeRequestParameter(request, "");
+
+        // We should request this scope by RFC (https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest)
+        // to have possibility for working with other oidc endpoints.
+        if( ! scope.contains(OPENID_SCOPE)) {
+            scope = scope + " " + OPENID_SCOPE;
+        }
 
         HttpPost post = createPost(externalOidcTokenEndPoint);
         List<BasicNameValuePair> form = new ArrayList<>();


### PR DESCRIPTION
## Changes introduced with this PR

This is linked with this change for V19: https://www.keycloak.org/docs/latest/upgrading/index.html#userinfo-endpoint-changes

Now for request user-info endpoint we need request token with 'openid' scope (this is required scope by the standard)

## Are you the owner of the code you are sending in, or do you have permission of the owner?

y