### PR TITLE
Handle situation when empty groups not come from the keycloak

### DIFF
--- a/backend/manager/modules/enginesso/src/main/java/org/ovirt/engine/core/sso/service/ExternalOIDCService.java
+++ b/backend/manager/modules/enginesso/src/main/java/org/ovirt/engine/core/sso/service/ExternalOIDCService.java
@@ -10,6 +10,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -200,8 +201,14 @@ public class ExternalOIDCService {
     }
 
     private static Collection<ExtMap> buildPrincipalRecordGroups(Map<String, Object> response) {
+        List<String> groupNames;
+        if (response.containsKey("groups")) {
+            groupNames = (List<String>) response.get("groups");
+        } else {
+            return Collections.emptyList();
+        }
+
         LinkedList<ExtMap> groups = new LinkedList<>();
-        List<String> groupNames = (List<String>) response.get("groups");
         for (String groupName : groupNames) {
             groupName = groupName.replaceFirst("^/", "");
             ExtMap group = new ExtMap();


### PR DESCRIPTION
Before the keycloak v22 it sends empty array as group claim when user not a member of any group. After v22 it not put this claim at all.
Look discussion: https://github.com/keycloak/keycloak/issues/22340

## Are you the owner of the code you are sending in, or do you have permission of the owner?

y