### PR TITLE
db: cleanup: Remove crumbs after materialized views deletion

### DIFF
--- a/packaging/dbscripts/dbfunc-common.sh
+++ b/packaging/dbscripts/dbfunc-common.sh
@@ -340,16 +340,6 @@ _dbfunc_common_run_post_upgrade() {
 	_dbfunc_common_schema_refresh_create
 	#Running post-upgrade scripts
 	_dbfunc_common_psql_statements_in_dir 'post_upgrade'
-	#run custom materialized views if exists
-	custom_materialized_views_file="${DBFUNC_COMMON_DBSCRIPTS_DIR}/upgrade/post_upgrade/custom/create_materialized_views.sql"
-	if [ -f "${custom_materialized_views_file}" ]; then
-		dbfunc_output "running custom materialized views from '${custom_materialized_views_file}'..."
-		if ! dbfunc_psql_v --file="${custom_materialized_views_file}"; then
-			#drop all custom views
-			dbfunc_psql_v --command="select DropAllCustomMaterializedViews();" > /dev/null
-			dbfunc_output "Illegal syntax in custom Materialized Views, Custom Materialized Views were dropped."
-		fi
-	fi
 }
 
 # Runs all the SQL scripts in directory upgrade/$1/

--- a/packaging/dbscripts/dbfunc-custom.sh
+++ b/packaging/dbscripts/dbfunc-custom.sh
@@ -38,8 +38,6 @@ dbfunc_common_hook_views_refresh() {
 	dbfunc_psql_die_v --file="${DBFUNC_COMMON_DBSCRIPTS_DIR}/create_dwh_views.sql" > /dev/null
 }
 
-# Materilized views functions, override with empty implementation on DBs that not supporting that
-
 dbfunc_common_hook_sequence_numbers_update() {
 	dbfunc_psql_die_v --file="${DBFUNC_COMMON_DBSCRIPTS_DIR}/update_sequence_numbers.sql" > /dev/null
 }


### PR DESCRIPTION
There were some remained parts after materialized views functionality deletion. Comments and if-blocks that don't mean anything now. Initial deletion commit hash: fa5ead39d36cb999460f853d4573a36dba8ec8b0

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n] y