### PR TITLE
packaging: fix error when enabling KeyCloak

### DIFF
--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/network/ovirtproviderovn.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/network/ovirtproviderovn.py
@@ -1111,6 +1111,8 @@ class Plugin(plugin.PluginBase):
                 oengcommcons.KeycloakEnv.ENABLE
             )
             if keycloak_enabled:
+                if self.environment.get(OvnEnv.OVIRT_PROVIDER_OVN_SECRET) is None:
+                    self._generate_client_secret()
                 self._configure_ovirt_provider_ovn()
 
     @plugin.event(


### PR DESCRIPTION
This fixes engine-setup error:
[ ERROR ] Failed to execute stage 'Misc configuration': 'OVESETUP_OVN/ovirtProviderOvnSecret'

Since commit 978c90e we save the ovirtProviderOvnSecret value in the setup file.
But if this value is not there, but ovirtProviderOvn is True, the engine-setup fails.

So if we can't find the value in the config, a new password is generated.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]