### PR TITLE
backport: During VM import from SD, exclude shared disk when iterating over dis…

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ImportVmCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ImportVmCommand.java
@@ -1071,8 +1071,10 @@ public class ImportVmCommand<T extends ImportVmParameters> extends ImportVmComma
                 disk.setActive(false);
                 setDiskStorageDomainInfo(disk);
                 saveImage(disk);
-                snapshotId = disk.getVmSnapshotId();
-                saveSnapshotIfNotExists(snapshotId, disk);
+                if (!disk.isShareable()) {
+                    snapshotId = disk.getVmSnapshotId();
+                    saveSnapshotIfNotExists(snapshotId, disk);
+                }
                 saveDiskImageDynamic(disk);
             }
 


### PR DESCRIPTION
backport:

Author: ShubhaOracle <Shubha.kulkarni@oracle.com>
Date:   Wed Dec 13 17:44:12 2023 -0500

    During VM import from SD, exclude shared disk when iterating over disk snapshots. Signed-off-by: Shubha Kulkarni shubha.kulkarni@oracle.com

    Signed-off-by: ShubhaOracle <Shubha.kulkarni@oracle.com>
