### PR TITLE
automation: drop el8 after centos stream 8 eol

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,9 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: centos-stream-8
-            container-name: el8stream
-            pip-command: pip3.9
           - name: centos-stream-9
             container-name: el9stream
             pip-command: pip3


### PR DESCRIPTION
## Changes introduced with this PR

* Dropping automation on el8 stream as centos stream 8 reached EOL.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

y