### PR TITLE
engine: Fix duplicate VM backup entry error when creating incremental backup

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/backup/HybridBackupCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/backup/HybridBackupCommand.java
@@ -345,7 +345,7 @@ public class HybridBackupCommand<T extends VmBackupParameters> extends StartVmBa
         VmBackup vmBackup = getParameters().getVmBackup();
         vmBackup.setSnapshotId(snapshotId);
         getParameters().setVmBackup(vmBackup);
-        vmBackupDao.save(vmBackup);
+        vmBackupDao.update(vmBackup);
         persistCommandIfNeeded();
     }
 }


### PR DESCRIPTION
Fixes an issue that originates from https://github.com/oVirt/ovirt-engine/commit/ed023e5e0a000029b4d7e50b03fdbb3fd9a773bd

## Changes introduced with this PR

* Fixes the following error when creating an incremental backup:
`
 ERROR [org.ovirt.engine.core.bll.storage.backup.HybridBackupCommand] (default task-1) [full_cold_vm_backup] Command 'org.ovirt.engine.core.bll.storage.backup.HybridBackupCommand' failed: CallableStatementCallback; SQL [{call insertvmbackup(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)}]; ERROR: duplicate key value violates unique constraint "vm_backups_pkey"
   Detail: Key (backup_id)=(1733241d-4a0b-4205-9e52-5383eb7a82f2) already exists.
`

## Are you the owner of the code you are sending in, or do you have permission of the owner?

y