### PR TITLE
Adding host to a new cluster failed

### DIFF
--- a/packaging/ansible-runner-service-project/project/roles/ovirt-provider-ovn-driver/tasks/configure.yml
+++ b/packaging/ansible-runner-service-project/project/roles/ovirt-provider-ovn-driver/tasks/configure.yml
@@ -45,4 +45,4 @@
           vdsm-tool ovn-config {{ ovn_central }} {{ ovn_tunneling_interface }} {{ ovn_host_fqdn }}
 
   when:
-    - ovn_central is defined
+    - ovn_central is defined and ovn_central != None and ovn_central | length != 0


### PR DESCRIPTION
Signed-off-by: ShubhaOracle <Shubha.kulkarni@oracle.com>

Fixes issue # Host addition to new cluster failed
- Changes introduced with this PR:
When adding a host to a new cluster, host addition failed due the check for ovn_central failed. Added the fix to check if variable ovn_central is defined and is not None and empty 

- Problem Description
Steps:
1. Create a new data center with default settings
2. Create a new cluster with default settings and the the new data center. CPU type is "Auto Detect"
3. Install RPM on a fresh installed server
4. Add the the server to the new cluster

Symptom: The host installation failed. The cluster CPU Type is blank. If activating the host a few times, the host is in non-operational status but the cluster CPU type will be changed to "Secure Intel Skylake Server Family". If change the cluster CPU type manually to "Intel Broadwell Family" and reinstall the host, the host can be activated.

- Are you the owner of the code you are sending in, or do you have permission of the owner?
Yes