### PR TITLE
fix: SerializationException: Type 'org.ovirt.engine.core.common.utils.SecretValue' was not included in the set of types... #900 

### DIFF
--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/utils/SecretValue.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/utils/SecretValue.java
@@ -1,8 +1,11 @@
 package org.ovirt.engine.core.common.utils;
 
+import java.io.Serializable;
 import java.util.Objects;
 
-public class SecretValue<T> {
+public class SecretValue<T> implements Serializable {
+    private static final long serialVersionUID = -7894728002078425194L;
+
     private T value;
 
     public T getValue() {

--- a/frontend/webadmin/modules/gwt-common/src/main/java/org/ovirt/engine/ui/common/widget/uicommon/vm/VmSnapshotInfoPanel.java
+++ b/frontend/webadmin/modules/gwt-common/src/main/java/org/ovirt/engine/ui/common/widget/uicommon/vm/VmSnapshotInfoPanel.java
@@ -1,10 +1,14 @@
 package org.ovirt.engine.ui.common.widget.uicommon.vm;
 
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
 import org.gwtbootstrap3.client.ui.Label;
+import org.ovirt.engine.core.common.businessentities.network.NetworkInterface;
+import org.ovirt.engine.core.common.businessentities.network.NetworkStatistics;
 import org.ovirt.engine.core.common.businessentities.network.VmInterfaceType;
 import org.ovirt.engine.core.common.businessentities.network.VmNetworkInterface;
 import org.ovirt.engine.core.common.businessentities.storage.Disk;
@@ -266,8 +270,10 @@ public class VmSnapshotInfoPanel extends FlowPanel {
         AbstractTextColumn<VmNetworkInterface> dropsColumn = new AbstractSumUpColumn<VmNetworkInterface>() {
             @Override
             protected Double[] getRawValue(VmNetworkInterface object) {
-                Double receiveDrops = object != null ? object.getStatistics().getReceiveDrops().doubleValue() : null;
-                Double transmitDrops = object != null ? object.getStatistics().getTransmitDrops().doubleValue() : null;
+                Double receiveDrops = Optional.ofNullable(object).map(NetworkInterface::getStatistics)
+                        .map(NetworkStatistics::getReceiveDrops).map(BigInteger::doubleValue).orElse(null);
+                Double transmitDrops = Optional.ofNullable(object).map(NetworkInterface::getStatistics)
+                        .map(NetworkStatistics::getTransmitDrops).map(BigInteger::doubleValue).orElse(null);
                 return new Double[] { receiveDrops, transmitDrops };
             }
         };


### PR DESCRIPTION
## Fixes issue
This PR fixes the https://github.com/oVirt/ovirt-engine/issues/900 issue.

## Changes introduced with this PR
Since the SecretValue structure is used in GWT, it should implement Serializable interface. Also couple null checks were added to avoid NPE in the scenario explained in the #900 issue.

## Are you the owner of the code you are sending in, or do you have permission of the owner?
Yes