### PR TITLE
replace deprecated Ansible include with import_tasks

### DIFF
--- a/packaging/ansible-runner-service-project/project/ovirt-host-upgrade.yml
+++ b/packaging/ansible-runner-service-project/project/ovirt-host-upgrade.yml
@@ -10,7 +10,7 @@
   pre_tasks:
     - include_vars: ovirt_host_upgrade_vars.yml
 
-    - include: ovirt-host-yum-conf.yml
+    - import_tasks: ovirt-host-yum-conf.yml
 
     - block:
       # Check if certificates need re-enrollment:
@@ -74,5 +74,5 @@
     - name: ovirt-host-deploy-vnc-certificates
 
   post_tasks:
-    - include: ovirt-host-remove-yum-conf.yml
-    - include: ovirt-host-reconfigure-ovn.yml
+    - import_tasks: ovirt-host-remove-yum-conf.yml
+    - import_tasks: ovirt-host-reconfigure-ovn.yml


### PR DESCRIPTION
Fixes issue of not being able to upgrade packages on nodes via ovirt

## Changes introduced with this PR

* fix ovirt Ansible playbook to work with newer ansible-core releases after 2023-05-16
* taken from [Marco Fais](https://lists.ovirt.org/archives/users/110553723741550915061952827377007637131/) https://lists.ovirt.org/archives/list/users@ovirt.org/message/3HABK6CMJOGRLKLZSMXEZPSNPM473LVS/

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]