### PR TITLE
bll/storage: don't check source domain space on lsm

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/MoveOrCopyDiskCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/MoveOrCopyDiskCommand.java
@@ -715,7 +715,7 @@ public class MoveOrCopyDiskCommand<T extends MoveOrCopyImageGroupParameters> ext
                 diskVmElementDao.getAllDiskVmElementsByDiskId(getParameters().getImageGroupID()));
     }
 
-    protected MultipleStorageDomainsValidator createMultipleStorageDomainsValidator() {
+    public MultipleStorageDomainsValidator createMultipleStorageDomainsValidator() {
         List<Guid> sdsToValidate = new ArrayList<>();
         sdsToValidate.add(getStorageDomainId());
 

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/lsm/LiveMigrateDiskCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/lsm/LiveMigrateDiskCommand.java
@@ -1,6 +1,5 @@
 package org.ovirt.engine.core.bll.storage.lsm;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -26,7 +25,6 @@ import org.ovirt.engine.core.bll.storage.utils.VdsCommandsHelper;
 import org.ovirt.engine.core.bll.tasks.CommandHelper;
 import org.ovirt.engine.core.bll.tasks.interfaces.CommandCallback;
 import org.ovirt.engine.core.bll.utils.PermissionSubject;
-import org.ovirt.engine.core.bll.validator.storage.MultipleStorageDomainsValidator;
 import org.ovirt.engine.core.bll.validator.storage.StorageDomainValidator;
 import org.ovirt.engine.core.common.AuditLogType;
 import org.ovirt.engine.core.common.FeatureSupported;
@@ -682,16 +680,6 @@ public class LiveMigrateDiskCommand<T extends LiveMigrateDiskParameters> extends
         }
 
         return true;
-    }
-
-    @Override
-    protected MultipleStorageDomainsValidator createMultipleStorageDomainsValidator() {
-        List<Guid> sdsToValidate = new ArrayList<>();
-
-        sdsToValidate.add(getParameters().getSourceDomainId());
-        sdsToValidate.add(getParameters().getDestDomainId());
-
-        return new MultipleStorageDomainsValidator(getStoragePoolId(), sdsToValidate);
     }
 
     private DiskImage getDiskImageByImageId(Guid imageId) {


### PR DESCRIPTION
When doing a LiveStorageMigration, the code checked if the disk/image would fit not only on the destination, but also on the source. This because theoretically the snapshot image can grow until the disksize.

But this means that we needed to live migrate a 1TB disk, also at least 1TB of free space on the source domain.
This is quite useless, and causes problemns to move disks from for example an already overloaded source domain.

As this check is neither being done when creating a simple snapshot, just drop the check on the source domain.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]