### PR TITLE
packaging: enable engine when it was enabled in answer file

### DIFF
--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/core/misc.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/core/misc.py
@@ -64,8 +64,7 @@ class Plugin(plugin.PluginBase):
     )
     def _customization(self):
         if self.environment[oenginecons.CoreEnv.ENABLE] is None:
-            self.environment[oenginecons.CoreEnv.ENABLE] = (
-                dialog.queryBoolean(
+            enabled = dialog.queryBoolean(
                     dialog=self.dialog,
                     name='OVESETUP_ENGINE_ENABLE',
                     note=_(
@@ -73,15 +72,28 @@ class Plugin(plugin.PluginBase):
                         '(@VALUES@) [@DEFAULT@]: '
                     ),
                     prompt=True,
-                    default=True,
-                ) if self.environment[oenginecons.EngineDBEnv.NEW_DATABASE]
-                else (
-                    self._engine_fqdn is not None and
-                    self.environment[
-                        osetupcons.ConfigEnv.FQDN
-                    ] == self._engine_fqdn
-                )
             )
+            if enabled is None:
+                self.environment[oenginecons.CoreEnv.ENABLE] = (
+                    dialog.queryBoolean(
+                        dialog=self.dialog,
+                        name='OVESETUP_ENGINE_ENABLE',
+                        note=_(
+                            'Configure Engine on this host '
+                            '(@VALUES@) [@DEFAULT@]: '
+                        ),
+                        prompt=True,
+                        default=True,
+                    ) if self.environment[oenginecons.EngineDBEnv.NEW_DATABASE]
+                    else (
+                        self._engine_fqdn is not None and
+                        self.environment[
+                            osetupcons.ConfigEnv.FQDN
+                        ] == self._engine_fqdn
+                    )
+                )
+            else:
+                self.environment[oenginecons.CoreEnv.ENABLE] = enabled
         if self.environment[oenginecons.CoreEnv.ENABLE]:
             self.environment[oengcommcons.ApacheEnv.ENABLE] = True
             self.environment[


### PR DESCRIPTION
When using an answer file that contains:
QUESTION/1/OVESETUP_ENGINE_ENABLE=str:yes
The CoreEnv.ENABLE was not set to True if fqdn's didn't match and it was not a new database.

But as we explicitly want to enable the engine according to the answer file, we must enable it.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]