### PR TITLE
core: only try to unlock vm if vm present

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/AddDiskCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/AddDiskCommand.java
@@ -824,6 +824,16 @@ public class AddDiskCommand<T extends AddDiskParameters> extends AbstractDiskVmC
         super.endSuccessfully();
     }
 
+    @Override
+    protected void endVmCommand() {
+        if (isFloatingDisk()) {
+            endActionOnDisks();
+            setSucceeded(true);
+        } else {
+            super.endVmCommand();
+        }
+    }
+
     private void plugDiskToVmIfNeeded() {
         if (Boolean.TRUE.equals(getParameters().getPlugDiskToVm()) && getVm() != null) {
             if (!getVm().getStatus().isUpOrPaused()) {


### PR DESCRIPTION
## Changes introduced with this PR

* When a standalone disk is made, don't try to release locks on VM, because there are none

* Before this change the creation of a standalone disk always generated a warning because of this.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]