### PR TITLE
[engine] Fix problem with follow parameter when api prefix with version removed wrongly

### DIFF
--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/ResourceLocator.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/ResourceLocator.java
@@ -2,6 +2,8 @@ package org.ovirt.engine.api.restapi.resource;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.ovirt.engine.api.rsdl.ServiceTreeCrawler;
 import org.ovirt.engine.api.rsdl.ServiceTreeNode;
@@ -12,6 +14,8 @@ import org.ovirt.engine.api.rsdl.ServiceTreeNode;
  * the API ServiceTree according to the provided hrefs.
  */
 public class ResourceLocator {
+
+    private static final Pattern ULR_VERSION_PART_PATTERN = Pattern.compile("/api/(v\\d+/)?");
 
     private static ResourceLocator instance;
 
@@ -58,12 +62,15 @@ public class ResourceLocator {
      *   http://localhost:8080/ovirt-engine/api/
      * Remain with:
      *   datacenters/1034e9ba-c1a4-442c-8bc9-f7c1c997652b
+     *
+     * Api definition with version also can be truncated (e.g. /api/v3/ or /api/v4/)
      */
-    private String removePrefix(String href) {
-        int index = href.indexOf("/api/");
-        if (index>0) {
-            href = href.substring(index+5);
+    static String removePrefix(String href) {
+        Matcher matcher = ULR_VERSION_PART_PATTERN.matcher(href);
+        if (matcher.find()) {
+            href = href.substring(matcher.end());
         }
+
         return href;
     }
 }

--- a/backend/manager/modules/restapi/jaxrs/src/test/java/org/ovirt/engine/api/restapi/resource/ResourceLocatorTest.java
+++ b/backend/manager/modules/restapi/jaxrs/src/test/java/org/ovirt/engine/api/restapi/resource/ResourceLocatorTest.java
@@ -1,0 +1,42 @@
+package org.ovirt.engine.api.restapi.resource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ResourceLocatorTest {
+
+    @ParameterizedTest
+    @MethodSource("providerUrlsToCheckSuffixExtraction")
+    void testResourceLocatorGetPrefix(String source, String expectedResult) {
+        assertEquals(expectedResult, ResourceLocator.removePrefix(source));
+    }
+
+    private static Stream<Arguments> providerUrlsToCheckSuffixExtraction() {
+        var basePart = "http://localhost:8080/ovirt-engine";
+        var suffix = "datacenters/1034e9ba-c1a4-442c-8bc9-f7c1c997652b";
+
+        return Stream.of(
+                Arguments.of(
+                        basePart + "/api/v12/" + suffix,
+                        suffix
+                ),
+                Arguments.of(
+                        basePart + "/api/" + suffix,
+                        suffix
+                ),
+                Arguments.of(
+                        basePart + "/api/v4/" + suffix,
+                        suffix
+                ),
+                Arguments.of( // Without pattern, method should return the same string.
+                        basePart + "/" + suffix,
+                        basePart + "/" + suffix
+                )
+        );
+    }
+}


### PR DESCRIPTION
## Changes introduced with this PR

When api requests used with version (e.g. /api/v4) then "follow" parameter brokes processing. All requests have 500 error code in result.
Otherwise without version "follow" parameter works correctly and returns nested entities.

It brokes SDK's when api requests have hard coded api prefix.

I found the reason. When request url processed then api version not considered.
Here is the fix and some tests. 
Now request without version and with any api version will work correctly.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

yes