### PR TITLE
webadmin: show free space on target storage domain when moving multip…

### DIFF
--- a/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/section/main/view/popup/storage/DisksAllocationPopupView.java
+++ b/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/section/main/view/popup/storage/DisksAllocationPopupView.java
@@ -6,7 +6,7 @@ import org.ovirt.engine.ui.common.view.popup.AbstractModelBoundPopupView;
 import org.ovirt.engine.ui.common.widget.AlertWithIcon;
 import org.ovirt.engine.ui.common.widget.dialog.SimpleDialogPanel;
 import org.ovirt.engine.ui.common.widget.editor.ListModelListBoxEditor;
-import org.ovirt.engine.ui.common.widget.renderer.NameRenderer;
+import org.ovirt.engine.ui.common.widget.renderer.StorageDomainFreeSpaceRenderer;
 import org.ovirt.engine.ui.common.widget.uicommon.storage.DisksAllocationView;
 import org.ovirt.engine.ui.uicommonweb.models.EntityModel;
 import org.ovirt.engine.ui.uicommonweb.models.storage.DisksAllocationModel;
@@ -53,7 +53,7 @@ public class DisksAllocationPopupView extends AbstractModelBoundPopupView<DisksA
     public DisksAllocationPopupView(EventBus eventBus) {
         super(eventBus);
 
-        targetStorageListEditor = new ListModelListBoxEditor<>(new NameRenderer<>());
+        targetStorageListEditor = new ListModelListBoxEditor<>(new StorageDomainFreeSpaceRenderer<>());
         disksAllocationView = new DisksAllocationView();
         initWidget(ViewUiBinder.uiBinder.createAndBindUi(this));
         disksAllocationView.setUsePatternFly(true);


### PR DESCRIPTION
## Changes introduced with this PR

* When moving multiple disks, the dropdown with the storage domain for all disks only contained the name of the storage domain. Extended this so it also shows the free space of the target storage domain. (like it's the case with the individual dropdowns).

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]