### PR TITLE
For headless VMs, DisplayType does not need to be checked. Otherwise, we will have problems while creating clones.

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/VmHandler.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/VmHandler.java
@@ -801,6 +801,10 @@ public class VmHandler implements BackendService {
      */
     public ValidationResult isGraphicsAndDisplaySupported
         (int osId, Collection<GraphicsType> graphics, DisplayType displayType, BiosType biosType, Version clusterVersion) {
+        // When we have no any display for vm then we don't have to check compatibility of display-graphics for selected OS
+        if (displayType == DisplayType.none) {
+            return ValidationResult.VALID;
+        }
         if (!vmValidationUtils.isGraphicsAndDisplaySupported(osId, clusterVersion, graphics, displayType)) {
             return new ValidationResult(
                     EngineMessage.ACTION_TYPE_FAILED_ILLEGAL_VM_DISPLAY_TYPE_IS_NOT_SUPPORTED_BY_OS);


### PR DESCRIPTION
Signed-off-by: Denis Kvist <denvist@ya.ru>

## Changes introduced with this PR

This PR fixes the following issue: an error occurs while creating clone headless VM

### Steps to reproduce:

* Create VM without Display

* Create clone via Admin portal or API/SDK

### Expected behavior:

The operation was successful 

### Current behavior:

The operation was completed with an error:

```
2024-09-09 16:59:26,597: Clone into VM (vm1_e759_MB_20240909_165803) started ...
2024-09-09 16:59:27,090: !!! Got unexpected exception: Fault reason is "Operation Failed". Fault detail is "[Cannot add VM. Selected display type is not supported by the operating system.]". HTTP response code is 400.
```

## Are you the owner of the code you are sending in, or do you have permission of the owner?

y