### PR TITLE
Bypass VM login attempt if SSO is not configured

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/VmLogonCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/VmLogonCommand.java
@@ -49,15 +49,19 @@ public class VmLogonCommand<T extends VmOperationParameterBase> extends VmOperat
         final DbUser currentUser = getCurrentUser();
         final String password = SsoUtils.getPassword(
                 sessionDataContainer.getSsoAccessToken(getParameters().getSessionId()));
-        final String domainController = currentUser != null ? currentUser.getDomain() : "";
-        final boolean sentToVM = runVdsCommand(
-                VDSCommandType.VmLogon,
-                new VmLogonVDSCommandParameters(
-                        getVdsId(),
-                        getVm().getId(),
-                        domainController,
-                        getUserName(),
-                        password)).getSucceeded();
-        setSucceeded(sentToVM);
+        if (password == null) {
+            setSucceeded(true);
+        } else {
+            final String domainController = currentUser != null ? currentUser.getDomain() : "";
+            final boolean sentToVM = runVdsCommand(
+                    VDSCommandType.VmLogon,
+                    new VmLogonVDSCommandParameters(
+                            getVdsId(),
+                            getVm().getId(),
+                            domainController,
+                            getUserName(),
+                            password)).getSucceeded();
+            setSucceeded(sentToVM);
+        }
     }
 }


### PR DESCRIPTION
Signed-off-by: Denis Kvist <denvist@yandex.ru>

Bypass VM login attempt if SSO is not configured

Similar issues:
- https://access.redhat.com/solutions/6982921
- https://bugzilla.redhat.com/show_bug.cgi?id=1391146

## Changes introduced with this PR

* Login to VM Portal
* Select running VM
* Try to download vv-console file

### Expected behavior:
vv-console file succesful downloaded

### Current behavior:
Got error while getting vv-console

## Are you the owner of the code you are sending in, or do you have permission of the owner?

y