### PR TITLE
core: update GWT to the newer version

### DIFF
--- a/frontend/webadmin/modules/frontend/pom.xml
+++ b/frontend/webadmin/modules/frontend/pom.xml
@@ -15,7 +15,7 @@
       <artifactId>activation</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-servlet</artifactId>
     </dependency>
     <dependency>
@@ -27,7 +27,7 @@
       <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
     </dependency>
     <!-- Guice and GIN -->
@@ -47,7 +47,7 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-dev</artifactId>
     </dependency>
     <dependency>

--- a/frontend/webadmin/modules/gwt-aop/pom.xml
+++ b/frontend/webadmin/modules/gwt-aop/pom.xml
@@ -11,11 +11,11 @@
   <name>AOP tweaks for GWT compiler</name>
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-dev</artifactId>
     </dependency>
     <dependency>

--- a/frontend/webadmin/modules/gwt-common/pom.xml
+++ b/frontend/webadmin/modules/gwt-common/pom.xml
@@ -12,11 +12,11 @@
   <dependencies>
     <!-- Google Web Toolkit dependencies -->
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-dev</artifactId>
     </dependency>
     <!-- GWT wrapper for Bootstrap framework -->

--- a/frontend/webadmin/modules/gwt-extension/pom.xml
+++ b/frontend/webadmin/modules/gwt-extension/pom.xml
@@ -14,7 +14,7 @@
   </properties>
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
     </dependency>
     <dependency>

--- a/frontend/webadmin/modules/pom.xml
+++ b/frontend/webadmin/modules/pom.xml
@@ -187,7 +187,7 @@
               <artifactId>gwt-maven-plugin</artifactId>
               <dependencies>
                 <dependency>
-                  <groupId>com.google.gwt</groupId>
+                  <groupId>org.gwtproject</groupId>
                   <artifactId>gwt-codeserver</artifactId>
                   <version>${gwt.version}</version>
                 </dependency>

--- a/frontend/webadmin/modules/uicommonweb/pom.xml
+++ b/frontend/webadmin/modules/uicommonweb/pom.xml
@@ -32,7 +32,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.gwt</groupId>
+            <groupId>org.gwtproject</groupId>
             <artifactId>gwt-user</artifactId>
         </dependency>
         <dependency>

--- a/frontend/webadmin/modules/uicompat/pom.xml
+++ b/frontend/webadmin/modules/uicompat/pom.xml
@@ -34,7 +34,7 @@
       <version>${engine.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
     </dependency>
   </dependencies>

--- a/frontend/webadmin/modules/webadmin/pom.xml
+++ b/frontend/webadmin/modules/webadmin/pom.xml
@@ -16,15 +16,15 @@
   <dependencies>
     <!-- Google Web Toolkit dependencies -->
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-dev</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-servlet</artifactId>
     </dependency>
     <!-- GWT wrapper for Bootstrap framework -->

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,8 @@
     <eddsa.version>0.3.0</eddsa.version>
     <gin.version>3.0.0</gin.version>
     <guice.version>4.2.3</guice.version>
-    <gwt.version>2.9.0</gwt.version>
+    <gwt.version>2.12.1</gwt.version>
+    <gwt-maven-plugin.version>2.10.0</gwt-maven-plugin.version>
     <gwtbootstrap3.version>0.9.4</gwtbootstrap3.version>
     <gwtp.version>1.6</gwtp.version>
     <hamcrest.version>1.3</hamcrest.version>
@@ -539,26 +540,26 @@
         <scope>provided</scope>
       </dependency>
       <dependency>
-        <groupId>com.google.gwt</groupId>
+        <groupId>org.gwtproject</groupId>
         <artifactId>gwt</artifactId>
         <version>${gwt.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
-        <groupId>com.google.gwt</groupId>
+        <groupId>org.gwtproject</groupId>
         <artifactId>gwt-user</artifactId>
         <version>${gwt.version}</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
-        <groupId>com.google.gwt</groupId>
+        <groupId>org.gwtproject</groupId>
         <artifactId>gwt-dev</artifactId>
         <version>${gwt.version}</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
-        <groupId>com.google.gwt</groupId>
+        <groupId>org.gwtproject</groupId>
         <artifactId>gwt-servlet</artifactId>
         <version>${gwt.version}</version>
         <scope>runtime</scope>
@@ -585,6 +586,12 @@
         <artifactId>gwtp-processors</artifactId>
         <version>${gwtp.version}</version>
         <scope>provided</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>com.google.gwt</groupId>
+            <artifactId>gwt-user</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <!-- GWT wrapper for Bootstrap framework -->
       <dependency>
@@ -605,6 +612,16 @@
         <artifactId>gwtp-mvp-client</artifactId>
         <version>${gwtp.version}</version>
         <scope>provided</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>com.google.gwt</groupId>
+            <artifactId>gwt-user</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.google.gwt</groupId>
+            <artifactId>gwt-dev</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <!-- Exclude Guice dependencies from GIN -->
       <dependency>
@@ -963,20 +980,20 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>gwt-maven-plugin</artifactId>
-          <version>${gwt.version}</version>
+          <version>${gwt-maven-plugin.version}</version>
           <dependencies>
             <dependency>
-              <groupId>com.google.gwt</groupId>
+              <groupId>org.gwtproject</groupId>
               <artifactId>gwt-user</artifactId>
               <version>${gwt.version}</version>
             </dependency>
             <dependency>
-              <groupId>com.google.gwt</groupId>
+              <groupId>org.gwtproject</groupId>
               <artifactId>gwt-dev</artifactId>
               <version>${gwt.version}</version>
             </dependency>
             <dependency>
-              <groupId>com.google.gwt</groupId>
+              <groupId>org.gwtproject</groupId>
               <artifactId>gwt-servlet</artifactId>
               <version>${gwt.version}</version>
             </dependency>


### PR DESCRIPTION
In new releases there are small fixes and possibility to build it with newer versions of java (up to 21).

With GWT update I aligned maven configuration to build all modules with java-11. 

It builded successfully on my machine.
I prepared small setup for testing (one host and one nfs storage domain).
And looked by hands on two browsers (firefox and chrome).
All things looks good for me.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n] y