### PR TITLE
Last backup api extension

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/EngineBackupAwarenessManager.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/EngineBackupAwarenessManager.java
@@ -15,6 +15,7 @@ import org.apache.commons.lang.exception.ExceptionUtils;
 import org.ovirt.engine.core.common.AuditLogType;
 import org.ovirt.engine.core.common.BackendService;
 import org.ovirt.engine.core.common.businessentities.EngineBackupLog;
+import org.ovirt.engine.core.common.businessentities.EngineBackupScope;
 import org.ovirt.engine.core.common.config.Config;
 import org.ovirt.engine.core.common.config.ConfigValues;
 import org.ovirt.engine.core.dal.dbbroker.auditloghandling.AuditLogDirector;
@@ -31,21 +32,6 @@ import org.slf4j.LoggerFactory;
  */
 @Singleton
 public class EngineBackupAwarenessManager implements BackendService {
-
-    private enum BackupScope {
-        DB("db"),
-        FILES("files");
-
-        String name;
-
-        BackupScope(String name) {
-            this.name = name;
-        }
-
-        public String getName() {
-            return name;
-        }
-    }
 
     private static final Logger log = LoggerFactory.getLogger(EngineBackupAwarenessManager.class);
     private Lock lock = new ReentrantLock();
@@ -96,8 +82,8 @@ public class EngineBackupAwarenessManager implements BackendService {
         AuditLogable alert = new AuditLogableImpl();
 
         //try to get last backup record
-        EngineBackupLog lastDbBackup = getLastBackupByScope(BackupScope.DB);
-        EngineBackupLog lastFilesBackup = getLastBackupByScope(BackupScope.FILES);
+        EngineBackupLog lastDbBackup = getLastBackupByScope(EngineBackupScope.DB);
+        EngineBackupLog lastFilesBackup = getLastBackupByScope(EngineBackupScope.FILES);
         if (lastDbBackup == null || lastFilesBackup == null) {
             auditLogDirector.log(alert, AuditLogType.ENGINE_NO_FULL_BACKUP);
         } else {
@@ -118,7 +104,7 @@ public class EngineBackupAwarenessManager implements BackendService {
 
     }
 
-    private EngineBackupLog getLastBackupByScope(BackupScope scope) {
+    private EngineBackupLog getLastBackupByScope(EngineBackupScope scope) {
         return engineBackupLogDao.getLastSuccessfulEngineBackup(scope.getName());
     }
 }

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/aaa/GetLastEngineBackupQuery.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/aaa/GetLastEngineBackupQuery.java
@@ -1,0 +1,25 @@
+package org.ovirt.engine.core.bll.aaa;
+
+import javax.inject.Inject;
+
+import org.ovirt.engine.core.bll.QueriesCommandBase;
+import org.ovirt.engine.core.bll.context.EngineContext;
+import org.ovirt.engine.core.common.businessentities.EngineBackupLog;
+import org.ovirt.engine.core.common.queries.GetLastEngineBackupParameters;
+import org.ovirt.engine.core.dao.EngineBackupLogDao;
+
+public class GetLastEngineBackupQuery<P extends GetLastEngineBackupParameters> extends QueriesCommandBase<P> {
+
+    @Inject
+    private EngineBackupLogDao engineBackupLogDao;
+
+    public GetLastEngineBackupQuery(P parameters, EngineContext engineContext) {
+        super(parameters, engineContext);
+    }
+
+    @Override
+    protected void executeQueryCommand() {
+        EngineBackupLog log = (EngineBackupLog) engineBackupLogDao.getLastSuccessfulEngineBackup(getParameters().getEngineBackupScope());
+        getQueryReturnValue().setReturnValue(log);
+    }
+}

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/EngineBackupScope.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/EngineBackupScope.java
@@ -1,0 +1,30 @@
+package org.ovirt.engine.core.common.businessentities;
+
+public enum EngineBackupScope {
+
+    DB("db"),
+    FILES("files"),
+    DWH("dwhdb"),
+    CINDER("cinderlib"),
+    KEYCLOAK("keycloak"),
+    GRAFANA("grafanadb");
+
+    String name;
+
+    EngineBackupScope(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public static EngineBackupScope fromString(String name) {
+        for (EngineBackupScope scope : EngineBackupScope.values()) {
+            if (scope.getName().equalsIgnoreCase(name)) {
+                return scope;
+            }
+        }
+        throw new IllegalArgumentException("No enum constant for name " + name);
+    }
+}

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/queries/GetLastEngineBackupParameters.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/queries/GetLastEngineBackupParameters.java
@@ -1,0 +1,23 @@
+package org.ovirt.engine.core.common.queries;
+
+import org.ovirt.engine.core.common.businessentities.EngineBackupScope;
+
+public class GetLastEngineBackupParameters extends QueryParametersBase {
+
+    private EngineBackupScope scope;
+
+    public GetLastEngineBackupParameters() {
+    }
+
+    public GetLastEngineBackupParameters(EngineBackupScope scope) {
+        this.scope = scope;
+    }
+
+    public void setEngineBackupScope(EngineBackupScope scope) {
+        this.scope = scope;
+    }
+
+    public String getEngineBackupScope() {
+        return scope.getName();
+    }
+}

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/queries/QueryType.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/queries/QueryType.java
@@ -539,7 +539,10 @@ public enum QueryType implements Serializable {
     GetSystemOption(QueryAuthType.User),
 
     // Default type instead of having to null check
-    Unknown(QueryAuthType.User);
+    Unknown(QueryAuthType.User),
+
+    // Last Engine Backup
+    GetLastEngineBackup;
 
     /**
      * What kind of authorization the query requires. Although this is essentially a <code>boolean</code>, it's

--- a/frontend/webadmin/modules/gwt-common/src/main/resources/org/ovirt/engine/core/Common.gwt.xml
+++ b/frontend/webadmin/modules/gwt-common/src/main/resources/org/ovirt/engine/core/Common.gwt.xml
@@ -544,6 +544,9 @@
         <!-- Cpu topology -->
         <include name="common/businessentities/VdsCpuUnit.java"/>
 
+        <!-- For GetLastEngineBackupParameters -->
+        <include name="common/businessentities/EngineBackupScope.java"/>
+
     </source>
 
     <super-source path="ui/uioverrides" />

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <!-- oVirt dependencies versions -->
     <kubevirt-client.version>0.5.0</kubevirt-client.version>
     <metamodel.version>1.3.10</metamodel.version>
-    <model.version>4.6.0</model.version>
+    <model.version>4.6.1-SNAPSHOT</model.version>
     <ovirt-engine-extensions-api.version>1.0.1</ovirt-engine-extensions-api.version>
     <vdsm-jsonrpc-java.version>1.7.2</vdsm-jsonrpc-java.version>
 


### PR DESCRIPTION
Fixes issue # (delete if not relevant)

## Changes introduced with this PR
* Exposes the dates of the last succesfull backups to the api, needs https://github.com/oVirt/ovirt-engine-api-model/pull/110 to function.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]