### PR TITLE
pom: align dependencies when using different maven versions

### DIFF
--- a/build-tools-root/ovirt-findbugs-filters/pom.xml
+++ b/build-tools-root/ovirt-findbugs-filters/pom.xml
@@ -12,6 +12,12 @@ SPDX-License-Identifier: Apache-2.0
 
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+    <groupId>org.ovirt.engine</groupId>
+    <artifactId>build-tools-root</artifactId>
+    <version>4.5.7-SNAPSHOT</version>
+  </parent>
+
   <groupId>org.ovirt.engine</groupId>
   <artifactId>ovirt-findbugs-filters</artifactId>
   <version>4.5.7-SNAPSHOT</version>

--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,7 @@
     <maven-ear-plugin.version>3.2.0</maven-ear-plugin.version>
     <maven-ejb-plugin.version>3.2.1</maven-ejb-plugin.version>
     <maven-enforcer-plugin.version>3.1.0</maven-enforcer-plugin.version>
+    <maven-install-plugin.version>3.1.1</maven-install-plugin.version>
     <maven-jar-plugin.version>3.2.2</maven-jar-plugin.version>
     <maven-processor-plugin.version>4.5</maven-processor-plugin.version>
     <maven-resources-plugin.version>3.3.0</maven-resources-plugin.version>
@@ -1045,6 +1046,12 @@
         </plugin>
 
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>${maven-install-plugin.version}</version>
+        </plugin>
+
+        <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>properties-maven-plugin</artifactId>
           <version>${properties-maven-plugin.version}</version>
@@ -1058,14 +1065,14 @@
             <xmlOutput>true</xmlOutput>
             <xmlOutputDirectory>target/site</xmlOutputDirectory>
             <excludeFilterFile>exclude-filters-general.xml, ${project.basedir}/exclude-filters.xml</excludeFilterFile>
+            <plugins>
+              <plugin>
+                <groupId>org.ovirt.engine</groupId>
+                <artifactId>ovirt-findbugs-filters</artifactId>
+                <version>4.5.7-SNAPSHOT</version>
+              </plugin>
+            </plugins>
           </configuration>
-          <dependencies>
-            <dependency>
-              <groupId>org.ovirt.engine</groupId>
-              <artifactId>ovirt-findbugs-filters</artifactId>
-              <version>4.5.7-SNAPSHOT</version>
-            </dependency>
-          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
Set a parent in ovirt-findbugs-filters to make sure we pull same dependencies there as in the root project.

Move ovirt-findbugs-filters to a plugin to avoid a cyclic dependency when building.

Pin a version for maven-install-plugin.

This all to make sure we build using the same dependencies on all OS'es. We need this for example on COPR to have correct dependencies included in ovirt-engine-build-dependencies, as the srpm is build there on FC41 which has different plugin versions in its Super POM.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]