### PR TITLE
core: fix extend image message when extending disks

### DIFF
--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/job/StepEnum.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/job/StepEnum.java
@@ -40,6 +40,7 @@ public enum StepEnum {
     REMOVE_DEVICE_FROM_DOMAIN,
     UPDATE_OVF,
     DEACTIVATE_STORAGE_DOMAIN,
+    EXTEND_DISK,
 
     /**
      * Maps VDSM tasks type to {@code StepEnum} so it can be resolvable as readable description

--- a/backend/manager/modules/dal/src/main/resources/bundles/ExecutionMessages.properties
+++ b/backend/manager/modules/dal/src/main/resources/bundles/ExecutionMessages.properties
@@ -189,6 +189,8 @@ step.CONVERTING_VM=Converting VM
 step.CONVERTING_OVA=Converting VM from OVA
 step.EXTRACTING_OVA=Extracting VM from OVA
 step.CREATING_OVA=Creating a Virtual Appliance
+step.EXTEND_IMAGE=Extending Size of Image
+step.EXTEND_DISK=Extending Disk ${disk}
 
 # Gluster step types
 step.SETTING_GLUSTER_OPTION=Setting option ${Key}=${Value} on volume ${GlusterVolume} of cluster ${Cluster}


### PR DESCRIPTION
- Implemented messages for step information when extending a disk.
- Added default part to switch statements in UpdateDiskCommand to solve warnings in code editor regarding certain disk storage types not being included in the switch statement.
- Removed amendImageGroupVolumesCommandParameters function due to being unused method.

## Are you the owner of the code you are sending in, or do you have permission of the owner?
[y]