### PR TITLE
pom: fix jaxb2-maven-plugin version

### DIFF
--- a/backend/manager/modules/restapi/interface/definition/pom.xml
+++ b/backend/manager/modules/restapi/interface/definition/pom.xml
@@ -230,7 +230,6 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>jaxb2-maven-plugin</artifactId>
-        <version>2.5.0</version>
 
         <executions>
           <!-- Generate the Java code from the XML schema of version 4 of the API: -->

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
     <!-- Extenal plugins versions -->
     <build-helper-maven-plugin.version>3.3.0</build-helper-maven-plugin.version>
     <exec-maven-plugin.version>3.1.0</exec-maven-plugin.version>
-    <jaxb2-maven-plugin.version>3.1.0</jaxb2-maven-plugin.version>
+    <jaxb2-maven-plugin.version>2.5.0</jaxb2-maven-plugin.version>
     <libsass-maven-plugin.version>0.2.8-libsass_3.4.4</libsass-maven-plugin.version>
     <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
     <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
@@ -1077,7 +1077,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>jaxb2-maven-plugin</artifactId>
-          <version>jaxb2-maven-plugin.version</version>
+          <version>${jaxb2-maven-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
The version of jaxb2-maven-plugin was incorrectly referenced in the main pom.xml and another version was used in the interface definition pom. Align this to use same version and fix version reference.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]