### PR TITLE
pom: add ossrh snapshots repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -819,6 +819,17 @@
         <enabled>true</enabled>
       </releases>
     </repository>
+    <repository>
+      <id>ossrh</id>
+      <name>OSSRH Snapshots</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+    </repository>
   </repositories>
   <pluginRepositories>
     <pluginRepository>


### PR DESCRIPTION
Add the OSS RH Snapshots repository.
This way we can build ovirt-engine against SNAPSHOT builds of org.ovirt.*

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]