### PR TITLE
Added iSCSI multipath status to the API

### DIFF
--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/storage/LUNs.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/storage/LUNs.java
@@ -269,6 +269,10 @@ public class LUNs implements BusinessEntity<String> {
         return getPathsDictionary() == null ? 0 : getPathsDictionary().size();
     }
 
+    public int getActivePathCount() {
+        return getPathsDictionary() == null ? 0 : (int) getPathsDictionary().values().stream().filter(o -> o).count();
+    }
+
     public Map<String, Boolean> getPathsDictionary() {
         return pathsDictionary;
     }

--- a/backend/manager/modules/restapi/types/src/main/java/org/ovirt/engine/api/restapi/types/StorageLogicalUnitMapper.java
+++ b/backend/manager/modules/restapi/types/src/main/java/org/ovirt/engine/api/restapi/types/StorageLogicalUnitMapper.java
@@ -58,6 +58,7 @@ public class StorageLogicalUnitMapper {
             model.setTarget(lunConnection.getIqn());
         }
 
+        model.setActivePaths(entity.getActivePathCount());
         model.setPaths(entity.getPathCount());
         return model;
     }


### PR DESCRIPTION
## Changes introduced with this PR

* A new field has been added <active_paths> to the /ovirt-engine/api/hosts/xxxx/storage endpoint that represents the multipaths that are NOT faulty as an integer value

* needs https://github.com/oVirt/ovirt-engine-api-model/pull/113 to function

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]