### PR TITLE
core: remove the rest build parts for java 8

### DIFF
--- a/backend/manager/modules/common/pom.xml
+++ b/backend/manager/modules/common/pom.xml
@@ -59,19 +59,6 @@
 
   <build>
     <plugins>
-
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <release>8</release>
-          <target>1.8</target>
-          <source>1.8</source>
-          <excludes>
-            <exclude>**/uioverrides/**/*</exclude>
-          </excludes>
-        </configuration>
-      </plugin>
-
       <plugin>
         <artifactId>maven-source-plugin</artifactId>
         <executions>

--- a/backend/manager/modules/compat/pom.xml
+++ b/backend/manager/modules/compat/pom.xml
@@ -14,15 +14,6 @@
 
   <build>
     <plugins>
-
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <release>8</release>
-          <target>1.8</target>
-          <source>1.8</source>
-        </configuration>
-      </plugin>
       <plugin>
         <artifactId>maven-source-plugin</artifactId>
         <executions>

--- a/frontend/webadmin/modules/gwt-common/pom.xml
+++ b/frontend/webadmin/modules/gwt-common/pom.xml
@@ -107,20 +107,6 @@
     <plugins>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>set-system-properties</goal>
-            </goals>
-            <configuration>
-              <properties><property><name>javaAAA.home</name><value>/lib/jvm/java-1.8</value></property></properties>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
         <artifactId>gwt-maven-plugin</artifactId>
         <executions>
           <execution>

--- a/frontend/webadmin/modules/gwt-extension/pom.xml
+++ b/frontend/webadmin/modules/gwt-extension/pom.xml
@@ -41,8 +41,6 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <release>8</release>
-          <target>1.8</target>
           <excludes>
             <exclude>**/uioverrides/**/*</exclude>
           </excludes>

--- a/frontend/webadmin/modules/pom.xml
+++ b/frontend/webadmin/modules/pom.xml
@@ -65,10 +65,6 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <configuration>
-            <source>1.8</source>
-            <target>1.8</target>
-            <release>8</release>
-
             <!-- We use maven-processor-plugin to invoke annotation processors -->
             <compilerArgument>-proc:none</compilerArgument>
             <excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,6 @@
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
     <maven-surefire-plugin.version>3.0.0-M7</maven-surefire-plugin.version>
     <maven-war-plugin.version>3.3.2</maven-war-plugin.version>
-    <properties-maven-plugin.version>1.1.0</properties-maven-plugin.version>
     <spotbugs-maven-plugin.version>4.7.2.0</spotbugs-maven-plugin.version>
     <taglist-maven-plugin.version>3.0.0</taglist-maven-plugin.version>
 
@@ -1060,12 +1059,6 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-install-plugin</artifactId>
           <version>${maven-install-plugin.version}</version>
-        </plugin>
-
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>properties-maven-plugin</artifactId>
-          <version>${properties-maven-plugin.version}</version>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
It was made for GWT that didn't support newer than java 8 versions. From some time it starts to support java 11 (current version already can compile on that)

Fixes issue # (delete if not relevant)

## Changes introduced with this PR

Removed some parts from maven settings that connected with java-8

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n] -> yes