### PR TITLE
webadmin: add possibility for UI plugins to set hidden search string for lists

### DIFF
--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/ApplyHiddenSearchStringEvent.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/ApplyHiddenSearchStringEvent.java
@@ -1,0 +1,80 @@
+package org.ovirt.engine.ui.uicommonweb.models;
+
+import java.util.Objects;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+import com.google.gwt.event.shared.HasHandlers;
+
+/**
+ * This class is mostly copy of the {@link ApplySearchStringEvent}
+ */
+public class ApplyHiddenSearchStringEvent extends GwtEvent<ApplyHiddenSearchStringEvent.ApplyHiddenSearchStringHandler> {
+
+    String hiddenSearchString;
+
+    protected ApplyHiddenSearchStringEvent() {
+        // Possibly for serialization.
+    }
+
+    public ApplyHiddenSearchStringEvent(String searchString) {
+        this.hiddenSearchString = searchString;
+    }
+
+    public static void fire(HasHandlers source, String searchString) {
+        ApplyHiddenSearchStringEvent eventInstance = new ApplyHiddenSearchStringEvent(searchString);
+        source.fireEvent(eventInstance);
+    }
+
+    public static void fire(HasHandlers source, ApplyHiddenSearchStringEvent eventInstance) {
+        source.fireEvent(eventInstance);
+    }
+
+    public interface ApplyHiddenSearchStringHandler extends EventHandler {
+        void onApplyHiddenSearchString(ApplyHiddenSearchStringEvent event);
+    }
+
+    private static final Type<ApplyHiddenSearchStringHandler> TYPE = new Type<>();
+
+    public static Type<ApplyHiddenSearchStringHandler> getType() {
+        return TYPE;
+    }
+
+    @Override
+    public Type<ApplyHiddenSearchStringHandler> getAssociatedType() {
+        return TYPE;
+    }
+
+    @Override
+    protected void dispatch(ApplyHiddenSearchStringHandler handler) {
+        handler.onApplyHiddenSearchString(this);
+    }
+
+    public String getHiddenSearchString() {
+        return hiddenSearchString;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof ApplyHiddenSearchStringEvent)) {
+            return false;
+        }
+        ApplyHiddenSearchStringEvent other = (ApplyHiddenSearchStringEvent) obj;
+        return Objects.equals(hiddenSearchString, other.hiddenSearchString);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(hiddenSearchString);
+    }
+
+    @Override
+    public String toString() {
+        return "ApplyHiddenSearchStringEvent[" //$NON-NLS-1$
+                + hiddenSearchString
+                + "]"; //$NON-NLS-1$
+    }
+}

--- a/frontend/webadmin/modules/uicommonweb/src/test/java/org/ovirt/engine/ui/uicommonweb/models/SearchableListModelTest.java
+++ b/frontend/webadmin/modules/uicommonweb/src/test/java/org/ovirt/engine/ui/uicommonweb/models/SearchableListModelTest.java
@@ -44,4 +44,77 @@ public class SearchableListModelTest {
         assertEquals(null, listModel.getSelectedItem());
         assertThat(listModel.getSelectedItems()).isEmpty();
     }
+
+    @Test
+    void whenNullHiddenSearchStringThenCorrectModifiedSearchString() {
+        SearchableListModel<Void, Integer> listModel =
+                mock(SearchableListModel.class,
+                        withSettings().useConstructor().defaultAnswer(Answers.CALLS_REAL_METHODS));
+        listModel.setDefaultSearchString("VM:"); //$NON-NLS-1$
+        listModel.setHiddenSearchString(null);
+        listModel.setSearchString(listModel.getDefaultSearchString());
+
+        assertEquals(listModel.getSearchString(), listModel.getModifiedSearchString());
+    }
+
+    @Test
+    void whenEmptyHiddenSearchStringThenCorrectModifiedSearchString() {
+        SearchableListModel<Void, Integer> listModel =
+                mock(SearchableListModel.class,
+                        withSettings().useConstructor().defaultAnswer(Answers.CALLS_REAL_METHODS));
+        listModel.setDefaultSearchString("VM:"); //$NON-NLS-1$
+        listModel.setHiddenSearchString(""); //$NON-NLS-1$
+        listModel.setSearchString(listModel.getDefaultSearchString());
+
+        assertEquals(listModel.getSearchString(), listModel.getModifiedSearchString());
+    }
+
+    @Test
+    void whenNotEmptyHiddenSearchStringThenCorrectModifiedSearchString() {
+        SearchableListModel<Void, Integer> listModel =
+                mock(SearchableListModel.class,
+                        withSettings().useConstructor().defaultAnswer(Answers.CALLS_REAL_METHODS));
+        listModel.setDefaultSearchString("VM:"); //$NON-NLS-1$
+        listModel.setHiddenSearchString("name=vm-1"); //$NON-NLS-1$
+        listModel.setSearchString(listModel.getDefaultSearchString());
+
+        assertEquals("VM:name=vm-1", listModel.getModifiedSearchString()); //$NON-NLS-1$
+    }
+
+    @Test
+    void whenNotEmptyHiddenSearchStringAndUserSearchStringThenCorrectModifiedSearchString() {
+        SearchableListModel<Void, Integer> listModel =
+                mock(SearchableListModel.class,
+                        withSettings().useConstructor().defaultAnswer(Answers.CALLS_REAL_METHODS));
+        listModel.setDefaultSearchString("VM:"); //$NON-NLS-1$
+        listModel.setHiddenSearchString("name=vm-1"); //$NON-NLS-1$
+        listModel.setSearchString("VM:name=vm-2"); //$NON-NLS-1$
+
+        assertEquals("VM:name=vm-2 AND name=vm-1", listModel.getModifiedSearchString()); //$NON-NLS-1$
+    }
+
+    @Test
+    void whenNotEmptyHiddenSearchStringAndUserSearchStringWithTagsThenCorrectModifiedSearchString() {
+        SearchableListModel<Void, Integer> listModel =
+                mock(SearchableListModel.class,
+                        withSettings().useConstructor().defaultAnswer(Answers.CALLS_REAL_METHODS));
+        listModel.setDefaultSearchString("VM:"); //$NON-NLS-1$
+        listModel.setHiddenSearchString("name=vm-1"); //$NON-NLS-1$
+        listModel.setSearchString("VM:name=vm-2 or cluster=Default"); //$NON-NLS-1$
+        listModel.setTagStrings(Arrays.asList("tag-1", "tag-2")); //$NON-NLS-1$ //$NON-NLS-2$
+
+        assertEquals("VM:name=vm-2 AND name=vm-1 OR cluster=Default AND name=vm-1 OR tag=tag-1 AND name=vm-1 OR tag=tag-2 AND name=vm-1", listModel.getModifiedSearchString()); //$NON-NLS-1$
+    }
+
+    @Test
+    void whenNotEmptyHiddenSearchStringAndUserSearchStringWithDifferentOrExpressionsThenCorrectModifiedSearchString() {
+        SearchableListModel<Void, Integer> listModel =
+                mock(SearchableListModel.class,
+                        withSettings().useConstructor().defaultAnswer(Answers.CALLS_REAL_METHODS));
+        listModel.setDefaultSearchString("VM:"); //$NON-NLS-1$
+        listModel.setHiddenSearchString("name=vm-1"); //$NON-NLS-1$
+        listModel.setSearchString("VM:name=vm-2 OR cluster=Default oR name=vm-3 Or name=vm-4"); //$NON-NLS-1$
+
+        assertEquals("VM:name=vm-2 AND name=vm-1 OR cluster=Default AND name=vm-1 OR name=vm-3 AND name=vm-1 OR name=vm-4 AND name=vm-1", listModel.getModifiedSearchString()); //$NON-NLS-1$
+    }
 }

--- a/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/gin/UtilsModule.java
+++ b/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/gin/UtilsModule.java
@@ -1,6 +1,7 @@
 package org.ovirt.engine.ui.webadmin.gin;
 
 import org.ovirt.engine.ui.common.gin.BaseUtilsModule;
+import org.ovirt.engine.ui.webadmin.section.main.presenter.HiddenSearchStringCollector;
 import org.ovirt.engine.ui.webadmin.section.main.presenter.SearchStringCollector;
 import org.ovirt.engine.ui.webadmin.section.main.presenter.TagEventCollector;
 
@@ -10,6 +11,7 @@ public class UtilsModule extends BaseUtilsModule {
     protected void configure() {
         super.configure();
         bind(SearchStringCollector.class).asEagerSingleton();
+        bind(HiddenSearchStringCollector.class).asEagerSingleton();
         bind(TagEventCollector.class).asEagerSingleton();
     }
 }

--- a/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/plugin/PluginManager.java
+++ b/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/plugin/PluginManager.java
@@ -603,6 +603,11 @@ public class PluginManager implements HasHandlers {
                     uiFunctions.@org.ovirt.engine.ui.webadmin.plugin.api.PluginUiFunctions::setSearchString(Ljava/lang/String;)(searchString);
                 }
             },
+            setHiddenSearchString: function(hiddenSearchString) {
+                if (validatePluginAction(this.pluginName)) {
+                    uiFunctions.@org.ovirt.engine.ui.webadmin.plugin.api.PluginUiFunctions::setHiddenSearchString(Ljava/lang/String;)(hiddenSearchString);
+                }
+            },
             loginUserName: function() {
                 if (validateSafePluginAction(this.pluginName)) {
                     return user.@org.ovirt.engine.ui.common.auth.CurrentUser::getFullUserName()();

--- a/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/plugin/api/PluginUiFunctions.java
+++ b/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/plugin/api/PluginUiFunctions.java
@@ -10,6 +10,7 @@ import org.ovirt.engine.ui.common.widget.action.AbstractButtonDefinition;
 import org.ovirt.engine.ui.common.widget.action.ActionButtonDefinition;
 import org.ovirt.engine.ui.common.widget.panel.AlertPanel;
 import org.ovirt.engine.ui.common.widget.uicommon.tasks.ToastNotification.NotificationStatus;
+import org.ovirt.engine.ui.uicommonweb.models.ApplyHiddenSearchStringEvent;
 import org.ovirt.engine.ui.uicommonweb.models.ApplySearchStringEvent;
 import org.ovirt.engine.ui.webadmin.place.WebAdminPlaceManager;
 import org.ovirt.engine.ui.webadmin.plugin.entity.EntityObject;
@@ -312,6 +313,13 @@ public class PluginUiFunctions implements HasHandlers {
      */
     public void setSearchString(final String searchString) {
         Scheduler.get().scheduleDeferred(() -> ApplySearchStringEvent.fire(PluginUiFunctions.this, searchString));
+    }
+
+    /**
+     * Applies the given search string as hidden filter part, which triggers transition to the corresponding application place.
+     */
+    public void setHiddenSearchString(final String hiddenSearchString) {
+        Scheduler.get().scheduleDeferred(() -> ApplyHiddenSearchStringEvent.fire(PluginUiFunctions.this, hiddenSearchString));
     }
 
     /**

--- a/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/section/main/presenter/HiddenSearchStringCollector.java
+++ b/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/section/main/presenter/HiddenSearchStringCollector.java
@@ -1,0 +1,41 @@
+package org.ovirt.engine.ui.webadmin.section.main.presenter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.ovirt.engine.ui.uicommonweb.models.ApplyHiddenSearchStringEvent;
+
+import com.google.inject.Inject;
+import com.google.web.bindery.event.shared.EventBus;
+
+/**
+ * Singleton object that listens for search string changes and stores them to be collected later in case interested
+ * objects haven't been instantiated yet.
+ * This class is mostly copy of the {@link SearchStringCollector}
+ */
+public class HiddenSearchStringCollector {
+    /**
+     * Maps default search strings to actual search strings (map models to search strings essentially).
+     */
+    Map<String, String> hiddenSearchStringMap = new HashMap<>();
+
+    @Inject
+    public HiddenSearchStringCollector(EventBus eventBus) {
+        eventBus.addHandler(ApplyHiddenSearchStringEvent.getType(), event -> {
+            String hiddenSearchString = event.getHiddenSearchString();
+            int colonIndex = hiddenSearchString.indexOf(':');
+            if (colonIndex >= 0) {
+                hiddenSearchStringMap.put(hiddenSearchString.substring(0, colonIndex + 1), hiddenSearchString);
+            }
+        });
+    }
+
+    public String getHiddenSearchStringPrefix(String prefix) {
+        String result = null;
+        if (prefix != null) {
+            result = hiddenSearchStringMap.get(prefix);
+            hiddenSearchStringMap.remove(prefix);
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
It is useful for plugins that control displayed list models with search string. Configured string will be applied as hidden filter for each search request to the backend. And user can't change it by mistake if he need secondary filtration. It is important that hidden filter should be simple. If it has some `or` expressions then result filter(with user defined search string and tags) can return not expected results (because search string don't have any operation priority)

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n] -> yes