### PR TITLE
core: fix NPE when NvramData is empty

### DIFF
--- a/backend/manager/modules/dal/src/main/java/org/ovirt/engine/core/dao/VmDaoImpl.java
+++ b/backend/manager/modules/dal/src/main/java/org/ovirt/engine/core/dao/VmDaoImpl.java
@@ -413,7 +413,7 @@ public class VmDaoImpl extends BaseDao implements VmDao {
 
     private Pair<SecretValue<String>, String> getExternalData(Guid vmId, String functionName) {
         List<Pair<SecretValue<String>, String>> resultRows = getCallsHandler().executeReadList(functionName,
-                (rs, i) -> new Pair<>(new SecretValue<String>(new String(rs.getString("data"))), rs.getString("hash")),
+                (rs, i) -> new Pair<>(new SecretValue<String>(rs.getString("data")), rs.getString("hash")),
                 getCustomMapSqlParameterSource().addValue("vm_id", vmId));
         if (resultRows.isEmpty()) {
             return new Pair<SecretValue<String>, String>();


### PR DESCRIPTION
When the is a NvramData row in the db, but without data, the getExternalData() call fails with a NPE:
ERROR [org.ovirt.engine.core.bll.HasNvramDataQuery] (default task-179) [4e047baa-c81c-4673-9cd2-6984d0e7477f] Exception: java.lang.NullPointerException
	at java.base/java.lang.String.<init>(String.java:236)
	at org.ovirt.engine.core.dal//org.ovirt.engine.core.dao.VmDaoImpl.lambda$getExternalData$6(VmDaoImpl.java:416)

This because 'new String(null)' gives this NPE.
As we don't need to call 'new' here, just remove it to fix the issue.

Fixes issue # (delete if not relevant)

## Changes introduced with this PR

*

*

*

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]