### PR TITLE
ui: optimized sorting on optional vCPUs column

### DIFF
--- a/backend/manager/modules/searchbackend/src/main/java/org/ovirt/engine/core/searchbackend/SearchObjectAutoCompleter.java
+++ b/backend/manager/modules/searchbackend/src/main/java/org/ovirt/engine/core/searchbackend/SearchObjectAutoCompleter.java
@@ -100,6 +100,7 @@ public class SearchObjectAutoCompleter extends SearchObjectsBaseAutoCompleter {
         requiresFullTable.put(SearchObjects.VM_OBJ_NAME + "-" + VmConditionFieldAutoCompleter.TAG, true);
         requiresFullTable.put(SearchObjects.VM_OBJ_NAME + "-" + VmConditionFieldAutoCompleter.TYPE, true);
         requiresFullTable.put(SearchObjects.VM_OBJ_NAME + "-" + VmConditionFieldAutoCompleter.UPTIME, true);
+        requiresFullTable.put(SearchObjects.VM_OBJ_NAME + "-" + VmConditionFieldAutoCompleter.VCPUS, true);
         // Hosts
         requiresFullTable.put(SearchObjects.VDS_OBJ_NAME + "-" + VdsConditionFieldAutoCompleter.ADDRESS, true);
         requiresFullTable.put(SearchObjects.VDS_OBJ_NAME + "-" + VdsConditionFieldAutoCompleter.ADDRESS, true);

--- a/backend/manager/modules/searchbackend/src/main/java/org/ovirt/engine/core/searchbackend/VmConditionFieldAutoCompleter.java
+++ b/backend/manager/modules/searchbackend/src/main/java/org/ovirt/engine/core/searchbackend/VmConditionFieldAutoCompleter.java
@@ -53,8 +53,9 @@ public class VmConditionFieldAutoCompleter extends BaseConditionFieldAutoComplet
     public static final String NEXT_RUN_CONFIG_EXISTS = "NEXT_RUN_CONFIG_EXISTS";
     public static final String HAS_ILLEGAL_IMAGES = "HAS_ILLEGAL_IMAGES";
     public static final String BIOS_TYPE = "BIOS_TYPE";
-    private static final int MILISECOND = 1000;
     public static final String NAMESPACE = "K8S_NAMESPACE";
+    public static final String VCPUS = "VCPUS";
+    private static final int MILISECOND = 1000;
 
     public VmConditionFieldAutoCompleter() {
         // Building the basic verbs Dict
@@ -94,6 +95,7 @@ public class VmConditionFieldAutoCompleter extends BaseConditionFieldAutoComplet
         verbs.add(HAS_ILLEGAL_IMAGES);
         verbs.add(BIOS_TYPE);
         verbs.add(NAMESPACE);
+        verbs.add(VCPUS);
         // Building the autoCompletion Dict
         buildCompletions();
 
@@ -134,6 +136,7 @@ public class VmConditionFieldAutoCompleter extends BaseConditionFieldAutoComplet
         getTypeDictionary().put(HAS_ILLEGAL_IMAGES, Boolean.class);
         getTypeDictionary().put(BIOS_TYPE, BiosType.class);
         getTypeDictionary().put(NAMESPACE, String.class);
+        getTypeDictionary().put(VCPUS, Integer.class);
 
         // building the ColumnName Dict
         columnNameDict.put(NAME, "vm_name");
@@ -172,6 +175,7 @@ public class VmConditionFieldAutoCompleter extends BaseConditionFieldAutoComplet
         columnNameDict.put(HAS_ILLEGAL_IMAGES, "has_illegal_images");
         columnNameDict.put(BIOS_TYPE, "bios_type");
         columnNameDict.put(NAMESPACE, "namespace");
+        columnNameDict.put(VCPUS, "num_of_cpus");
 
         // Override field names for purpose of sorting, if needed
         sortableFieldDict.put(IP, Collections.singletonList(
@@ -192,7 +196,8 @@ public class VmConditionFieldAutoCompleter extends BaseConditionFieldAutoComplet
         } else if (CPU_USAGE.equals(fieldName) || MEM_USAGE.equals(fieldName)
                 || MEMORY.equals(fieldName) || GUARANTEED_MEMORY.equals(fieldName)
                 || NETWORK_USAGE.equals(fieldName)
-                || MIGRATION_PROGRESS_PERCENT.equals(fieldName)) {
+                || MIGRATION_PROGRESS_PERCENT.equals(fieldName)
+                || VCPUS.equals(fieldName)) {
             return NumericConditionRelationAutoCompleter.INSTANCE;
         } else if (TAG.equals(fieldName)) {
             return StringConditionRelationAutoCompleter.INSTANCE;

--- a/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/section/main/view/MainVirtualMachineView.java
+++ b/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/section/main/view/MainVirtualMachineView.java
@@ -241,8 +241,7 @@ public class MainVirtualMachineView extends AbstractMainWithDetailsTableView<VM,
             }
         };
         getTable().addColumn(vCpusColumn, constants.vcpus(), "80px"); //$NON-NLS-1$
-        // client-side sorting since this is calculated value
-        vCpusColumn.makeSortable();
+        vCpusColumn.makeSortable(VmConditionFieldAutoCompleter.VCPUS);
         getTable().hideColumnByDefault(vCpusColumn);
 
         AbstractTextColumn<VM> definedMemoryColumn = new AbstractTextColumn<VM>() {


### PR DESCRIPTION
## Changes introduced with this PR

* Previously sorting on vCPUs on the vm tab was handled by the client side which caused it to only sort vm's present on the page (100 max). Updated functionality to utilize backend so all vm's get sorted instead.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]