### PR TITLE
Add missing custom_id in audit_log_sp.sql

### DIFF
--- a/packaging/dbscripts/audit_log_sp.sql
+++ b/packaging/dbscripts/audit_log_sp.sql
@@ -35,6 +35,7 @@ CREATE OR REPLACE FUNCTION InsertAuditLog (
     v_brick_id UUID,
     v_brick_path TEXT,
     v_origin VARCHAR(25),
+    v_custom_id VARCHAR(255),
     v_custom_event_id INT,
     v_event_flood_in_sec INT,
     v_custom_data TEXT
@@ -76,6 +77,7 @@ BEGIN
             brick_id,
             brick_path,
             origin,
+            custom_id,
             custom_event_id,
             event_flood_in_sec,
             custom_data
@@ -110,6 +112,7 @@ BEGIN
             v_brick_id,
             v_brick_path,
             v_origin,
+            v_custom_id,
             v_custom_event_id,
             v_event_flood_in_sec,
             v_custom_data
@@ -157,6 +160,7 @@ BEGIN
             brick_id,
             brick_path,
             origin,
+            custom_id,
             custom_event_id,
             event_flood_in_sec,
             custom_data
@@ -191,6 +195,7 @@ BEGIN
             v_brick_id,
             v_brick_path,
             v_origin,
+            v_custom_id,
             v_custom_event_id,
             v_event_flood_in_sec,
             v_custom_data


### PR DESCRIPTION
The `customId` field in `org.ovirt.engine.core.common.businessentities.AuditLog` entity is not persisted when saving an audit log entry via `org.ovirt.engine.core.dao.AuditLogDao`. This is due to a missing `custom_id` parameter in the `InsertAuditLog` stored procedure.

## Changes introduced with this PR

* Add missing `custom_id` parameter in the `InsertAuditLog` stored procedure.

## Are you the owner of the code you are sending in, or do you have permission of the owner?
Yes