### PR TITLE
core: added disk id as optional column on subtab disks for VM's

### DIFF
--- a/frontend/webadmin/modules/gwt-common/src/main/java/org/ovirt/engine/ui/common/widget/uicommon/vm/BaseVmDiskListModelTable.java
+++ b/frontend/webadmin/modules/gwt-common/src/main/java/org/ovirt/engine/ui/common/widget/uicommon/vm/BaseVmDiskListModelTable.java
@@ -29,6 +29,7 @@ public class BaseVmDiskListModelTable<E, T extends VmDiskListModelBase<?>> exten
     private DisksViewRadioGroup disksViewRadioGroup;
 
     private static AbstractTextColumn<Disk> aliasColumn;
+    private static AbstractTextColumn<Disk> idColumn;
     private static AbstractDiskSizeColumn<Disk> sizeColumn;
     private static AbstractDiskSizeColumn<Disk> actualSizeColumn;
     private static AbstractTextColumn<Disk> allocationColumn;
@@ -89,6 +90,11 @@ public class BaseVmDiskListModelTable<E, T extends VmDiskListModelBase<?>> exten
 
         getTable().ensureColumnVisible(
                 aliasColumn, constants.aliasDisk(), all || images || luns || managedBlock, "120px"); //$NON-NLS-1$
+
+        getTable().ensureColumnVisible(
+                idColumn, constants.idVmDiskTable(), all, "120px"); //$NON-NLS-1$
+
+        getTable().hideColumnByDefault(idColumn);
 
         getTable().ensureColumnVisible(
                 DisksViewColumns.bootableDiskColumn,
@@ -162,6 +168,7 @@ public class BaseVmDiskListModelTable<E, T extends VmDiskListModelBase<?>> exten
         getTable().enableColumnResizing();
 
         aliasColumn = DisksViewColumns.getAliasColumn(null);
+        idColumn = DisksViewColumns.getIdColumn(null);
         sizeColumn = DisksViewColumns.getSizeColumn(null);
         actualSizeColumn = DisksViewColumns.getActualSizeColumn(null);
         allocationColumn = DisksViewColumns.getAllocationColumn(null);


### PR DESCRIPTION
Fixes issue # (delete if not relevant)

## Changes introduced with this PR

* When looking up information about a vm, the disk id was not present in the table with information about it's disks, this patch add's it as an optional column.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]