### PR TITLE
restapi: add attach_wgt flag to vm start endpoint

### DIFF
--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendVmResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendVmResource.java
@@ -499,6 +499,7 @@ public class BackendVmResource
         boolean ignitionSet = action.isSetUseIgnition();
         boolean useIgnition = ignitionSet && action.isUseIgnition();
         boolean useInitialization = action.isSetUseInitialization() && action.isUseInitialization();
+        boolean attachWgt = action.isSetAttachWgt() && action.isAttachWgt();
         if (useSysPrep && useCloudInit || useSysPrep && useIgnition || useCloudInit && useIgnition) {
             Fault fault = new Fault();
             fault.setReason(localize(Messages.CANT_USE_MIXED_INIT_SIMULTANEOUSLY));
@@ -518,6 +519,7 @@ public class BackendVmResource
             params.setInitializationType(null); //Engine will decide based on VM properties
         }
         params.setInitialize(useInitialization);
+        params.setAttachWgt(attachWgt);
 
         return doAction(actionType, params, action);
     }


### PR DESCRIPTION
## Changes introduced with this PR

Add the optional `attach_wgt` flag to the vm start endpoint. This will auto attach the virtio-win iso (if it is available) to the vm at boot time. The actual logic needed to attach the iso was implemented earlier for usage in the GUI.

Needs: https://github.com/oVirt/ovirt-engine-api-model/pull/116

## Are you the owner of the code you are sending in, or do you have permission of the owner?

y