### PR TITLE
restapi: Remove sensitive response fields for non-admin users

### DIFF
--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/AbstractBackendNetworkResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/AbstractBackendNetworkResource.java
@@ -3,6 +3,7 @@ package org.ovirt.engine.api.restapi.resource;
 import javax.ws.rs.core.Response;
 
 import org.ovirt.engine.api.model.Network;
+import org.ovirt.engine.api.restapi.util.FieldCleaner;
 import org.ovirt.engine.core.common.action.ActionParametersBase;
 import org.ovirt.engine.core.common.action.ActionType;
 
@@ -29,6 +30,13 @@ public abstract class AbstractBackendNetworkResource
         return addLinks(map(entity));
     }
 
+    protected void removeRestrictedInfo(Network network) {
+        // Filtered users are not allowed to view restricted information
+        if (!isAdmin()) {
+            nullifyRestrictedFields(network);
+        }
+    }
+
     AbstractBackendNetworksResource getParent() {
         return parent;
     }
@@ -43,5 +51,10 @@ public abstract class AbstractBackendNetworkResource
             return null;
         }
         return performAction(removeAction, getRemoveParameters(entity));
+    }
+
+    public static void nullifyRestrictedFields(Network network) {
+        FieldCleaner.nullifyAllFieldsExcept(network, "id", "name", "dataCenter");
+        FieldCleaner.nullifyAllFieldsExcept(network.getDataCenter(), "id");
     }
 }

--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/AbstractBackendNetworksResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/AbstractBackendNetworksResource.java
@@ -1,5 +1,7 @@
 package org.ovirt.engine.api.restapi.resource;
 
+import static org.ovirt.engine.api.restapi.resource.AbstractBackendNetworkResource.nullifyRestrictedFields;
+
 import java.util.List;
 
 import org.ovirt.engine.api.model.BaseResource;
@@ -29,6 +31,15 @@ public abstract class AbstractBackendNetworksResource
 
     public Networks list() {
         return mapCollection(getBackendCollection(queryType, getQueryParameters()));
+    }
+
+    protected void removeRestrictedInfo(Networks networks) {
+        // Filtered users are not allowed to view restricted information
+        if (!isAdmin()) {
+            for (Network network : networks.getNetworks()) {
+                nullifyRestrictedFields(network);
+            }
+        }
     }
 
     protected Networks mapCollection(List<org.ovirt.engine.core.common.businessentities.network.Network> entities) {

--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendClusterNetworkResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendClusterNetworkResource.java
@@ -26,7 +26,12 @@ public class BackendClusterNetworkResource
         if (entity == null) {
             return notFound();
         }
-        return addLinks(map(entity), Cluster.class);
+
+        Network network = map(entity);
+        network = addLinks(network, Cluster.class);
+        removeRestrictedInfo(network);
+
+        return network;
     }
 
     @Override

--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendClusterNetworksResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendClusterNetworksResource.java
@@ -31,8 +31,10 @@ public class BackendClusterNetworksResource
 
     @Override
     public Networks list() {
-        return mapCollection(getBackendCollection(queryType, getQueryParameters()),
+        Networks networks = mapCollection(getBackendCollection(queryType, getQueryParameters()),
                 org.ovirt.engine.api.model.Cluster.class);
+        removeRestrictedInfo(networks);
+        return networks;
     }
 
     @Override

--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendDataCenterNetworkResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendDataCenterNetworkResource.java
@@ -27,7 +27,12 @@ public class BackendDataCenterNetworkResource
         if (entity == null) {
             return notFound();
         }
-        return addLinks(map(entity), LinkHelper.NO_PARENT);
+
+        Network network = map(entity);
+        network = addLinks(network, LinkHelper.NO_PARENT);
+        removeRestrictedInfo(network);
+
+        return network;
     }
 
     private org.ovirt.engine.core.common.businessentities.network.Network getNetwork() {

--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendDataCenterNetworksResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendDataCenterNetworksResource.java
@@ -50,6 +50,7 @@ public class BackendDataCenterNetworksResource
         for (Network network : networks.getNetworks()) {
             network.setDisplay(null);
         }
+        removeRestrictedInfo(networks);
         return networks;
     }
 

--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendIscsiBondNetworkResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendIscsiBondNetworkResource.java
@@ -33,7 +33,11 @@ public class BackendIscsiBondNetworkResource extends BackendNetworkResource {
             return notFound();
         }
 
-        return addLinks(map(entity), LinkHelper.NO_PARENT);
+        Network network = map(entity);
+        network = addLinks(network, LinkHelper.NO_PARENT);
+        removeRestrictedInfo(network);
+
+        return network;
     }
 
     private org.ovirt.engine.core.common.businessentities.network.Network getNetwork() {

--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendIscsiBondNetworksResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendIscsiBondNetworksResource.java
@@ -25,10 +25,12 @@ public class BackendIscsiBondNetworksResource extends BackendNetworksResource {
 
     @Override
     public Networks list() {
-        return mapCollection(
+        Networks networks = mapCollection(
                 getBackendCollection(QueryType.GetNetworksByIscsiBondId, new IdQueryParameters(iscsiBondId)),
                 LinkHelper.NO_PARENT
         );
+        removeRestrictedInfo(networks);
+        return networks;
     }
 
     @Override

--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendNetworkResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendNetworkResource.java
@@ -27,9 +27,13 @@ public class BackendNetworkResource extends AbstractBackendNetworkResource imple
         if (entity == null) {
             return notFound();
         }
+
         Network network = map(entity);
         network.setDisplay(null);
-        return addLinks(network, LinkHelper.NO_PARENT);
+        network = addLinks(network, LinkHelper.NO_PARENT);
+        removeRestrictedInfo(network);
+
+        return network;
     }
 
     @Override

--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendNetworksResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendNetworksResource.java
@@ -60,6 +60,8 @@ public class BackendNetworksResource
         for (Network network : networks.getNetworks()) {
             network.setDisplay(null);
         }
+        removeRestrictedInfo(networks);
+
         return networks;
     }
 

--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendStorageDomainsResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendStorageDomainsResource.java
@@ -1,6 +1,7 @@
 package org.ovirt.engine.api.restapi.resource;
 
 import static org.ovirt.engine.api.restapi.resource.BackendStorageDomainResource.getLinksToExclude;
+import static org.ovirt.engine.api.restapi.resource.BackendStorageDomainResource.nullifyRestrictedFields;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -69,11 +70,23 @@ public class BackendStorageDomainsResource
 
     @Override
     public StorageDomains list() {
+        StorageDomains storageDomains;
         if (isFiltered()) {
-            return mapCollection(getBackendCollection(QueryType.GetAllStorageDomains,
+            storageDomains = mapCollection(getBackendCollection(QueryType.GetAllStorageDomains,
                     new QueryParametersBase(), SearchType.StorageDomain));
         } else {
-            return mapCollection(getBackendCollection(SearchType.StorageDomain));
+            storageDomains = mapCollection(getBackendCollection(SearchType.StorageDomain));
+        }
+        removeRestrictedInfo(storageDomains);
+        return storageDomains;
+    }
+
+    private void removeRestrictedInfo(StorageDomains storageDomains) {
+        // Filtered users are not allowed to view restricted information
+        if (!isAdmin()) {
+            for (StorageDomain storageDomain : storageDomains.getStorageDomains()) {
+                nullifyRestrictedFields(storageDomain);
+            }
         }
     }
 

--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BaseBackendResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BaseBackendResource.java
@@ -414,6 +414,14 @@ public class BaseBackendResource {
     }
 
     /**
+     * @return true if current user has admin permission, otherwise false.
+     */
+    protected boolean isAdmin() {
+        DbUser user = getCurrent().getUser();
+        return user.isAdmin();
+    }
+
+    /**
      * Follows links in the entity according to value of "follow" URL query parameter.
      * A valid value of'follow' is a comma separated list of strings, which represent
      * internal links to be followed. Links may have several 'levels' denoted by periods.

--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/util/FieldCleaner.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/util/FieldCleaner.java
@@ -1,0 +1,52 @@
+package org.ovirt.engine.api.restapi.util;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.ovirt.engine.api.model.BaseResource;
+import org.ovirt.engine.api.model.Link;
+
+public class FieldCleaner {
+
+    private FieldCleaner() { }
+
+    public static void removeAllLinksExcept(BaseResource baseResource, String... allowedRel) {
+        List<Link> links = baseResource.getLinks();
+        if (CollectionUtils.isEmpty(links)) {
+            return;
+        }
+
+        Set<String> allowedRelSet = Set.of(allowedRel);
+        links.removeIf(link -> !allowedRelSet.contains(link.getRel()));
+    }
+
+    public static void nullifyAllFieldsExcept(Object obj, String... allowedFields) {
+        if (obj == null) {
+            return;
+        }
+
+        Set<String> allowedFieldSet = Set.of(allowedFields);
+        Class<?> currentClass = obj.getClass();
+        while (currentClass != null) {
+            for (Field field : currentClass.getDeclaredFields()) {
+                if (!allowedFieldSet.contains(field.getName())) {
+                    nullifyField(obj, field);
+                }
+            }
+            currentClass = currentClass.getSuperclass();
+        }
+    }
+
+    private static void nullifyField(Object obj, Field field) {
+        try {
+            field.setAccessible(true);
+            if (!field.getType().isPrimitive()) {
+                field.set(obj, null);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to nullify field: " + field.getName(), e);
+        }
+    }
+}

--- a/backend/manager/modules/restapi/jaxrs/src/test/java/org/ovirt/engine/api/restapi/resource/AbstractBackendBaseTest.java
+++ b/backend/manager/modules/restapi/jaxrs/src/test/java/org/ovirt/engine/api/restapi/resource/AbstractBackendBaseTest.java
@@ -142,6 +142,7 @@ public abstract class AbstractBackendBaseTest {
         currentUser.setLastName(USER);
         currentUser.setDomain(DOMAIN);
         currentUser.setNamespace(NAMESPACE);
+        currentUser.setAdmin(true);
         currentUser.setId(GUIDS[0]);
 
         Current current = new Current();

--- a/backend/manager/modules/restapi/jaxrs/src/test/java/org/ovirt/engine/api/restapi/util/FieldCleanerTest.java
+++ b/backend/manager/modules/restapi/jaxrs/src/test/java/org/ovirt/engine/api/restapi/util/FieldCleanerTest.java
@@ -1,0 +1,72 @@
+package org.ovirt.engine.api.restapi.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.ovirt.engine.api.model.Host;
+import org.ovirt.engine.api.model.Link;
+import org.ovirt.engine.api.model.Vm;
+import org.ovirt.engine.core.compat.Guid;
+
+public class FieldCleanerTest {
+
+    private static final String HOST_ID = Guid.newGuid().toString();
+    private static final String VM_ID = Guid.newGuid().toString();
+
+    @Test
+    void testRemoveAllLinksExcept() {
+        Link link1 = new Link();
+        link1.setRel("rel1");
+        link1.setHref("href1");
+
+        Link link2 = new Link();
+        link2.setRel("rel2");
+        link2.setHref("href2");
+
+        Vm vm = createVm();
+        vm.getLinks().addAll(List.of(link1, link2));
+
+        FieldCleaner.removeAllLinksExcept(vm, "rel2", "rel3");
+
+        List<Link> links = vm.getLinks();
+        assertEquals(1, links.size());
+
+        Link link = links.get(0);
+        assertEquals("rel2", link.getRel());
+        assertEquals("href2", link.getHref());
+    }
+
+    @Test
+    void testNullifyAllFieldsExcept() {
+        Vm vm = createVm();
+
+        FieldCleaner.nullifyAllFieldsExcept(vm, "id", "name", "host");
+        FieldCleaner.nullifyAllFieldsExcept(vm.getHost(), "id");
+
+        assertEquals(VM_ID, vm.getId());
+        assertNotNull(vm.getName());
+        assertNull(vm.getDescription());
+
+        assertNotNull(vm.getHost());
+        assertEquals(HOST_ID, vm.getHost().getId());
+        assertNull(vm.getHost().getName());
+    }
+
+    private Vm createVm() {
+        Host host = new Host();
+        host.setId(HOST_ID);
+        host.setName("host name");
+
+        Vm vm = new Vm();
+        vm.setId(VM_ID);
+        vm.setName("vm name");
+        vm.setDescription("vm description");
+        vm.setHost(host);
+
+        return vm;
+    }
+}


### PR DESCRIPTION
Non-admin users can access detailed information such as MTU, CPU information, library information and other internal configuration data through network, host and storage domain API.This commit adds logic to remove these fields from responses for non-admin users to prevent unintentional data exposure. Fields that are required by the VM Portal are retained to ensure existing functionality is not broken.

## Changes introduced with this PR

1. Remove all fields from Hosts API except "id", "name", "address", "cluster.id" for non-admin user

- Before fix
![hosts_before](https://github.com/user-attachments/assets/f1fff623-0857-4ca3-b145-1260e194518d)

- After fix
![hosts_after](https://github.com/user-attachments/assets/4415ebbb-697e-41fa-8907-db3d3f28a93d)


2. Remove all fields from Networks API except "id", "name", "data_center.id" for non-admin user

- Before fix
![networks_before](https://github.com/user-attachments/assets/66ba3835-94bc-4096-a3dd-094a3308f398)

- After fix
![networks_after](https://github.com/user-attachments/assets/0614f720-5ee4-4050-bc68-333281331675)


3. Remove all fields from Storage Domains API except "id", "name", "type", "permissions", "storage.type", "available", "used", "status", "data_center.id" for non-admin user

- Before fix
![storage_domain_before](https://github.com/user-attachments/assets/aec9647a-bb3f-4f77-a68e-d1fbe43583e2)

- After fix
![storage_domain_after](https://github.com/user-attachments/assets/5d7afd8e-b1a8-489b-9a0e-146c43fa55bc)


## Are you the owner of the code you are sending in, or do you have permission of the owner?
Yes