### PR TITLE
restapi: Add watchdog support to update VM API

### DIFF
--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendVmResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendVmResource.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.ovirt.engine.api.common.util.DetailHelper;
 import org.ovirt.engine.api.model.Action;
 import org.ovirt.engine.api.model.Fault;
@@ -21,6 +22,7 @@ import org.ovirt.engine.api.model.Statistic;
 import org.ovirt.engine.api.model.Statistics;
 import org.ovirt.engine.api.model.Template;
 import org.ovirt.engine.api.model.Vm;
+import org.ovirt.engine.api.model.Watchdog;
 import org.ovirt.engine.api.resource.ActionResource;
 import org.ovirt.engine.api.resource.AssignedAffinityLabelsResource;
 import org.ovirt.engine.api.resource.AssignedPermissionsResource;
@@ -49,10 +51,12 @@ import org.ovirt.engine.api.restapi.resource.externalhostproviders.BackendVmKate
 import org.ovirt.engine.api.restapi.types.InitializationMapper;
 import org.ovirt.engine.api.restapi.types.RngDeviceMapper;
 import org.ovirt.engine.api.restapi.types.VmMapper;
+import org.ovirt.engine.api.restapi.types.WatchdogMapper;
 import org.ovirt.engine.api.restapi.util.DisplayHelper;
 import org.ovirt.engine.api.restapi.util.IconHelper;
 import org.ovirt.engine.api.restapi.util.LinkHelper;
 import org.ovirt.engine.api.restapi.util.ParametersHelper;
+import org.ovirt.engine.api.restapi.util.WatchdogHelper;
 import org.ovirt.engine.core.common.VdcObjectType;
 import org.ovirt.engine.core.common.action.ActionParametersBase;
 import org.ovirt.engine.core.common.action.ActionType;
@@ -711,6 +715,18 @@ public class BackendVmResource
             }
             if (incoming.isSetTpmEnabled()) {
                 params.setTpmEnabled(incoming.isTpmEnabled());
+            }
+            if (incoming.isSetWatchdogs()) {
+
+                List<Watchdog> incomingWatchdogs = incoming.getWatchdogs().getWatchdogs();
+                if (!CollectionUtils.isEmpty(incomingWatchdogs)) {
+                    params.setUpdateWatchdog(true);
+
+                    Watchdog icomingWatchdog = incomingWatchdogs.get(0);
+                    if (!WatchdogHelper.isWatchdogEmpty(icomingWatchdog)) {
+                        params.setWatchdog(WatchdogMapper.map(icomingWatchdog, null));
+                    }
+                }
             }
 
             DisplayHelper.setGraphicsToParams(incoming.getDisplay(), params);

--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/util/WatchdogHelper.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/util/WatchdogHelper.java
@@ -1,0 +1,19 @@
+package org.ovirt.engine.api.restapi.util;
+
+import org.ovirt.engine.api.model.Watchdog;
+
+public class WatchdogHelper {
+
+    private WatchdogHelper() {}
+
+    /**
+     * Check if the watchdog is null or has no fields set.
+     *
+     * @param watchdog the {@link Watchdog} object to check
+     * @return {@code true} if the watchdog is {@code null} or all of the fields
+     *         (action, model, id) are unset; {@code false} otherwise
+     */
+    public static boolean isWatchdogEmpty(Watchdog watchdog) {
+        return watchdog == null || !watchdog.isSetAction() && !watchdog.isSetModel() && !watchdog.isSetId();
+    }
+}


### PR DESCRIPTION
Updating the watchdog via the VM Watchdog API bypass validation checks, such as verifying the presence of a next-run configuration for running VMs. This can lead to inconsistent or incorrect watchdog settings.

## Changes introduced with this PR

* Add watchdog support to the update VM API which already performs the necessary validations. This ensures that watchdog updates are applied safely and consistently, especially for running VMs with pending configurations.

## Are you the owner of the code you are sending in, or do you have permission of the owner?
Yes