### PR TITLE
packaging: fix setting PayloadSize

### DIFF
--- a/packaging/etc/engine-config/engine-config.properties
+++ b/packaging/etc/engine-config/engine-config.properties
@@ -424,6 +424,8 @@ CockpitSSOPort.type=String
 CockpitSSOPort.description="Host TCP port the ovirt-cockpit-sso service listens on (9986 by default)."
 AlwaysFilterResultsForWebUi.type=Boolean
 AlwaysFilterResultsForWebUi.description="Administrator users can only see entities they have explicit permission on in VM Portal (false by default)."
+PayloadSize.type=Integer
+PayloadSize.description="The maximum size of the payload in bytes that can be sent to the engine to attach to the VM (8192 by default)."
 # PM Health Check
 PMHealthCheckEnabled.type=Boolean
 PMHealthCheckEnabled.description="Enable/Disable Power Management Health Check feature."


### PR DESCRIPTION
PayloadSize was not added to the engine-config.properties file. Because of this you could not set the PayloadSize value via engine-config.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]