### PR TITLE
core: added ability to alter video device through API

### DIFF
--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendVmResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendVmResource.java
@@ -46,6 +46,7 @@ import org.ovirt.engine.api.resource.VmWatchdogsResource;
 import org.ovirt.engine.api.resource.externalhostproviders.KatelloErrataResource;
 import org.ovirt.engine.api.restapi.logging.Messages;
 import org.ovirt.engine.api.restapi.resource.externalhostproviders.BackendVmKatelloErrataResource;
+import org.ovirt.engine.api.restapi.types.DisplayMapper;
 import org.ovirt.engine.api.restapi.types.InitializationMapper;
 import org.ovirt.engine.api.restapi.types.RngDeviceMapper;
 import org.ovirt.engine.api.restapi.types.VmMapper;
@@ -78,6 +79,7 @@ import org.ovirt.engine.core.common.action.VmManagementParametersBase;
 import org.ovirt.engine.core.common.action.VmOperationParameterBase;
 import org.ovirt.engine.core.common.businessentities.Cluster;
 import org.ovirt.engine.core.common.businessentities.CpuPinningPolicy;
+import org.ovirt.engine.core.common.businessentities.DisplayType;
 import org.ovirt.engine.core.common.businessentities.GraphicsType;
 import org.ovirt.engine.core.common.businessentities.HaMaintenanceMode;
 import org.ovirt.engine.core.common.businessentities.InitializationType;
@@ -683,6 +685,9 @@ public class BackendVmResource
 
             updated.setUsbPolicy(VmMapper.getUsbPolicyOnUpdate(incoming.getUsb(), entity.getUsbPolicy()));
 
+            if (incoming.getDisplay() != null && incoming.getDisplay().getVideoType() != null) {
+                updated.setDefaultDisplayType(DisplayMapper.map((org.ovirt.engine.api.model.VideoType) incoming.getDisplay().getVideoType(), (DisplayType) null));
+            }
             VmManagementParametersBase params = new VmManagementParametersBase(updated);
 
             params.setUpdateNuma(incoming.isSetNumaTuneMode());

--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/util/DisplayHelper.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/util/DisplayHelper.java
@@ -9,6 +9,7 @@ import org.ovirt.engine.api.model.Certificate;
 import org.ovirt.engine.api.model.Display;
 import org.ovirt.engine.api.model.DisplayType;
 import org.ovirt.engine.api.model.Template;
+import org.ovirt.engine.api.model.VideoType;
 import org.ovirt.engine.api.model.Vm;
 import org.ovirt.engine.api.restapi.resource.BackendResource;
 import org.ovirt.engine.api.restapi.types.DisplayMapper;
@@ -80,15 +81,17 @@ public class DisplayHelper {
      * @param params  - parameters to be updated with graphics data
      */
     public static void setGraphicsToParams(Display display, HasGraphicsDevices params) {
-        if (display != null && display.isSetType()) {
-            DisplayType newDisplayType = display.getType();
-
-            if (newDisplayType != null) {
+        if (display != null) {
+            GraphicsType newGraphicsType = null;
+            if (display.isSetVideoType()) {
+                newGraphicsType = DisplayMapper.map((VideoType) display.getVideoType(), (GraphicsType) null);
+            } else if (display.isSetType()) {
+                newGraphicsType = DisplayMapper.map((DisplayType) display.getType(), null);
+            }
+            if (newGraphicsType != null) {
                 for (GraphicsType graphicsType : GraphicsType.values()) {
                     params.getGraphicsDevices().put(graphicsType, null); // reset graphics devices
                 }
-
-                GraphicsType newGraphicsType = DisplayMapper.map(newDisplayType, null);
                 params.getGraphicsDevices().put(newGraphicsType,
                         new GraphicsDevice(newGraphicsType.getCorrespondingDeviceType()));
             }

--- a/backend/manager/modules/restapi/types/src/main/java/org/ovirt/engine/api/restapi/types/DisplayMapper.java
+++ b/backend/manager/modules/restapi/types/src/main/java/org/ovirt/engine/api/restapi/types/DisplayMapper.java
@@ -5,11 +5,11 @@ import java.util.Set;
 
 import org.ovirt.engine.api.model.Display;
 import org.ovirt.engine.api.model.DisplayType;
+import org.ovirt.engine.api.model.VideoType;
 import org.ovirt.engine.api.model.Vm;
 import org.ovirt.engine.core.common.action.RunVmOnceParams;
 import org.ovirt.engine.core.common.businessentities.GraphicsType;
-import org.ovirt.engine.core.common.businessentities.InstanceType;
-import org.ovirt.engine.core.common.businessentities.VmTemplate;
+import org.ovirt.engine.core.common.businessentities.VmBase;
 
 public class DisplayMapper {
 
@@ -20,7 +20,37 @@ public class DisplayMapper {
         } else if (graphicsType == GraphicsType.VNC) {
             return DisplayType.VNC;
         }
-        return null;
+        return displayType;
+    }
+
+    @Mapping(from = org.ovirt.engine.core.common.businessentities.DisplayType.class, to = VideoType.class)
+    public static VideoType map(org.ovirt.engine.core.common.businessentities.DisplayType displayType, VideoType videoType) {
+        switch (displayType) {
+            case vga:
+                return VideoType.VGA;
+            case bochs:
+                return VideoType.BOCHS;
+            case cirrus:
+                return VideoType.CIRRUS;
+            case qxl:
+                return VideoType.QXL;
+            default:
+                return videoType;
+        }
+    }
+
+    @Mapping(from = VideoType.class, to = GraphicsType.class)
+    public static GraphicsType map(VideoType videoType, GraphicsType graphicsType) {
+        switch (videoType) {
+            case VGA:
+            case CIRRUS:
+            case BOCHS:
+                return GraphicsType.VNC;
+            case QXL:
+                return GraphicsType.SPICE;
+            default:
+                return graphicsType;
+        }
     }
 
     @Mapping(from = DisplayType.class, to = GraphicsType.class)
@@ -31,35 +61,43 @@ public class DisplayMapper {
             case VNC:
                 return GraphicsType.VNC;
             default:
-                return null;
+                return graphicsType;
         }
     }
 
-    @Mapping(from = VmTemplate.class, to = Display.class)
-    public static Display map(VmTemplate vmTemplate, Display display) {
-        Display result = (display == null)
-                ? new Display()
-                : display;
-
-        result.setMonitors(vmTemplate.getNumOfMonitors());
-        result.setAllowOverride(vmTemplate.isAllowConsoleReconnect());
-        result.setSmartcardEnabled(vmTemplate.isSmartcardEnabled());
-        result.setKeyboardLayout(vmTemplate.getVncKeyboardLayout());
-        result.setFileTransferEnabled(vmTemplate.isSpiceFileTransferEnabled());
-        result.setCopyPasteEnabled(vmTemplate.isSpiceCopyPasteEnabled());
-
-        return result;
+    @Mapping(from = VideoType.class, to = org.ovirt.engine.core.common.businessentities.DisplayType.class)
+    public static org.ovirt.engine.core.common.businessentities.DisplayType map(VideoType videoType, org.ovirt.engine.core.common.businessentities.DisplayType displayType) {
+        switch (videoType) {
+            case VGA:
+                return org.ovirt.engine.core.common.businessentities.DisplayType.vga;
+            case BOCHS:
+                return org.ovirt.engine.core.common.businessentities.DisplayType.bochs;
+            case CIRRUS:
+                return org.ovirt.engine.core.common.businessentities.DisplayType.cirrus;
+            case QXL:
+                return org.ovirt.engine.core.common.businessentities.DisplayType.qxl;
+            default:
+                return displayType;
+        }
     }
 
-    @Mapping(from = InstanceType.class, to = Display.class)
-    public static Display map(InstanceType instanceType, Display display) {
+    @Mapping(from = VmBase.class, to = Display.class)
+    public static Display map(VmBase vmBase, Display display) {
         Display result = (display == null)
                 ? new Display()
                 : display;
 
-        result.setMonitors(instanceType.getNumOfMonitors());
-        result.setSmartcardEnabled(instanceType.isSmartcardEnabled());
-
+        result.setMonitors(vmBase.getNumOfMonitors());
+        result.setAllowOverride(vmBase.isAllowConsoleReconnect());
+        result.setSmartcardEnabled(vmBase.isSmartcardEnabled());
+        result.setKeyboardLayout(vmBase.getVncKeyboardLayout());
+        result.setFileTransferEnabled(vmBase.isSpiceFileTransferEnabled());
+        result.setCopyPasteEnabled(vmBase.isSpiceCopyPasteEnabled());
+        result.setDisconnectAction(VmBaseMapper.map(vmBase.getConsoleDisconnectAction(), null).toString());
+        result.setDisconnectActionDelay(vmBase.getConsoleDisconnectActionDelay());
+        if (vmBase.getDefaultDisplayType() != null) {
+            result.setVideoType(DisplayMapper.map(vmBase.getDefaultDisplayType(), null));
+        }
         return result;
     }
 
@@ -101,7 +139,7 @@ public class DisplayMapper {
             case SPICE:
                 return org.ovirt.engine.core.common.businessentities.DisplayType.qxl;
             default:
-                return null;
+                return incoming;
         }
     }
 }

--- a/backend/manager/modules/restapi/types/src/main/java/org/ovirt/engine/api/restapi/types/InstanceTypeMapper.java
+++ b/backend/manager/modules/restapi/types/src/main/java/org/ovirt/engine/api/restapi/types/InstanceTypeMapper.java
@@ -30,7 +30,6 @@ public class InstanceTypeMapper extends VmBaseMapper {
     public static InstanceType map(org.ovirt.engine.core.common.businessentities.InstanceType entity, InstanceType incoming) {
         InstanceType model = incoming != null ? incoming : new InstanceType();
         mapCommonEntityToModel(model, (VmTemplate) entity);
-        model.setDisplay(DisplayMapper.map(entity, null));
 
         if (entity.getDefaultBootSequence() != null) {
             OperatingSystem os = model.getOs();

--- a/backend/manager/modules/restapi/types/src/main/java/org/ovirt/engine/api/restapi/types/TemplateMapper.java
+++ b/backend/manager/modules/restapi/types/src/main/java/org/ovirt/engine/api/restapi/types/TemplateMapper.java
@@ -101,9 +101,6 @@ public class TemplateMapper extends VmBaseMapper {
         if (entity.getClusterArch() != null) {
             model.getCpu().setArchitecture(CPUMapper.map(entity.getClusterArch(), null));
         }
-        model.setDisplay(DisplayMapper.map(entity, null));
-        model.getDisplay().setDisconnectAction(map(entity.getConsoleDisconnectAction(), null).toString());
-        model.getDisplay().setDisconnectActionDelay(entity.getConsoleDisconnectActionDelay());
 
         TemplateVersion version = new TemplateVersion();
         version.setVersionName(entity.getTemplateVersionName());

--- a/backend/manager/modules/restapi/types/src/main/java/org/ovirt/engine/api/restapi/types/VmBaseMapper.java
+++ b/backend/manager/modules/restapi/types/src/main/java/org/ovirt/engine/api/restapi/types/VmBaseMapper.java
@@ -400,6 +400,8 @@ public class VmBaseMapper {
             }
             model.getPlacementPolicy().setHosts(hostsList);
         }
+
+        model.setDisplay(DisplayMapper.map(entity, null));
     }
 
     /**

--- a/backend/manager/modules/restapi/types/src/main/java/org/ovirt/engine/api/restapi/types/VmMapper.java
+++ b/backend/manager/modules/restapi/types/src/main/java/org/ovirt/engine/api/restapi/types/VmMapper.java
@@ -21,7 +21,6 @@ import org.ovirt.engine.api.model.CpuPinningPolicy;
 import org.ovirt.engine.api.model.CpuTopology;
 import org.ovirt.engine.api.model.CustomProperties;
 import org.ovirt.engine.api.model.CustomProperty;
-import org.ovirt.engine.api.model.Display;
 import org.ovirt.engine.api.model.Domain;
 import org.ovirt.engine.api.model.DynamicCpu;
 import org.ovirt.engine.api.model.ExternalHostProvider;
@@ -295,8 +294,6 @@ public class VmMapper extends VmBaseMapper {
             model.setVmPool(pool);
         }
 
-        model.setDisplay(new Display());
-
         // some fields (like boot-order,display..) have static value (= the permanent config)
         // and dynamic value (current/last run value, that can be different in case of run-once or edit while running)
         if (showDynamicInfo && entity.getDynamicData() != null && entity.getStatus().isRunningOrPaused()) {
@@ -398,15 +395,7 @@ public class VmMapper extends VmBaseMapper {
         if (entity.getLastStopTime() != null) {
             model.setStopTime(DateMapper.map(entity.getLastStopTime(), null));
         }
-        model.getDisplay().setMonitors(entity.getNumOfMonitors());
-        model.getDisplay().setAllowOverride(entity.getAllowConsoleReconnect());
-        model.getDisplay().setSmartcardEnabled(entity.isSmartcardEnabled());
-        model.getDisplay().setKeyboardLayout(entity.getDefaultVncKeyboardLayout());
-        model.getDisplay().setFileTransferEnabled(entity.isSpiceFileTransferEnabled());
-        model.getDisplay().setCopyPasteEnabled(entity.isSpiceCopyPasteEnabled());
         model.getDisplay().setProxy(getEffectiveSpiceProxy(entity));
-        model.getDisplay().setDisconnectAction(map(entity.getConsoleDisconnectAction(), null).toString());
-        model.getDisplay().setDisconnectActionDelay(entity.getConsoleDisconnectActionDelay());
 
         model.setStateless(entity.isStateless());
         model.setDeleteProtected(entity.isDeleteProtected());

--- a/backend/manager/modules/restapi/types/src/test/java/org/ovirt/engine/api/restapi/types/VmMapperTest.java
+++ b/backend/manager/modules/restapi/types/src/test/java/org/ovirt/engine/api/restapi/types/VmMapperTest.java
@@ -76,6 +76,7 @@ public class VmMapperTest extends
         VmDynamic dynamic = new VmDynamic();
         dynamic.setStatus(VMStatus.Up);
         dynamic.setBootSequence(to.getDefaultBootSequence());
+        to.setDefaultDisplayType(org.ovirt.engine.core.common.businessentities.DisplayType.vga);
         dynamic.getGraphicsInfos().put(GraphicsType.SPICE, new GraphicsInfo());
         org.ovirt.engine.core.common.businessentities.VM ret =
                 new org.ovirt.engine.core.common.businessentities.VM(to,


### PR DESCRIPTION
## Changes introduced with this PR

* When pulling info for a vm, template or instance type through the API return a video_type in the console info together with the graphic console as the type. Ability to alter the video device attached to a vm through the PUT api call. Saves this update as a configuration for the next run of the VM if it is in the up state.

* Needs https://github.com/oVirt/ovirt-engine-api-model/pull/117 implemented in api model to properly function.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]