### PR TITLE
restapi: add operating system description to host api object

### DIFF
--- a/backend/manager/modules/restapi/types/src/main/java/org/ovirt/engine/api/restapi/types/HostMapper.java
+++ b/backend/manager/modules/restapi/types/src/main/java/org/ovirt/engine/api/restapi/types/HostMapper.java
@@ -378,6 +378,7 @@ public class HostMapper {
             model.setVersion(version);
             model.setType(hostOs.getName());
         }
+        model.setDescription(Objects.toString(entity.getPrettyName(), ""));
         model.setCustomKernelCmdline(Objects.toString(entity.getCurrentKernelCmdline(), ""));
         model.setReportedKernelCmdline(entity.getKernelArgs());
         return model;


### PR DESCRIPTION
Fixes issue: https://github.com/oVirt/ovirt-engine-api-model/issues/105

## Changes introduced with this PR

* Added description attribute to a host object. This is only used for reading purposes to expose more in depth information about which OS is running on the host. If no os description can be found, return an empty string.

Needs https://github.com/oVirt/ovirt-engine-api-model/pull/118 approved to function.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]