### PR TITLE
restapi: Optimization of the GET /vms?detail=main REST API request

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/GetVdsCertificateSubjectsByVmIdsQuery.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/GetVdsCertificateSubjectsByVmIdsQuery.java
@@ -1,0 +1,71 @@
+package org.ovirt.engine.core.bll;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.ovirt.engine.core.bll.context.EngineContext;
+import org.ovirt.engine.core.common.businessentities.VdsStatic;
+import org.ovirt.engine.core.common.businessentities.VmDynamic;
+import org.ovirt.engine.core.common.queries.IdsQueryParameters;
+import org.ovirt.engine.core.common.queries.QueryReturnValue;
+import org.ovirt.engine.core.compat.Guid;
+import org.ovirt.engine.core.dao.VdsStaticDao;
+import org.ovirt.engine.core.dao.VmDynamicDao;
+import org.ovirt.engine.core.utils.CertificateSubjectHelper;
+
+
+public class GetVdsCertificateSubjectsByVmIdsQuery<P extends IdsQueryParameters> extends QueriesCommandBase<P> {
+    @Inject
+    private VmDynamicDao vmDynamicDao;
+
+    @Inject
+    private VdsStaticDao vdsStaticDao;
+
+    public GetVdsCertificateSubjectsByVmIdsQuery(P parameters, EngineContext engineContext) {
+        super(parameters, engineContext);
+    }
+
+    @Override
+    protected void executeQueryCommand() {
+        // Initially we set the command as failed:
+        QueryReturnValue queryReturnValue = getQueryReturnValue();
+        queryReturnValue.setSucceeded(false);
+
+        // Check if the virtual machines are running on hosts, and if so then retrieve the hosts and copy the subject
+        // of the certificate to the value returned by the query:
+        List<VmDynamic> vms = vmDynamicDao.getByIds(getParameters().getIds());
+        List<Guid> vdsIds = vms.stream()
+                .map(VmDynamic::getRunOnVds)
+                .filter(Objects::nonNull)
+                .distinct()
+                .collect(Collectors.toList());
+        if (!vdsIds.isEmpty()) {
+            List<VdsStatic> vdss = vdsStaticDao.getByIds(vdsIds);
+            // Collect certificate subjects for all hosts running the VMs
+            Map<Guid, String> certificateSubjects = vdss.stream()
+                    .collect(Collectors.toMap(
+                            VdsStatic::getId,
+                            vds -> CertificateSubjectHelper.getCertificateSubject(vds.getHostName())));
+            // Populate the certificate subjects for corresponding VMs
+            Map<Guid, String> certificateForVms = new HashMap<>();
+            for (VmDynamic vm : vms) {
+                Guid vdsId = vm.getRunOnVds();
+                if (vdsId != null) {
+                    String subject = certificateSubjects.get(vdsId);
+                    if (subject != null) {
+                        certificateForVms.put(vm.getId(), subject);
+                    }
+                }
+            }
+            if (!certificateForVms.isEmpty()) {
+                queryReturnValue.setSucceeded(true);
+                queryReturnValue.setReturnValue(certificateForVms);
+            }
+        }
+    }
+}

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/queries/QueryType.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/queries/QueryType.java
@@ -168,6 +168,7 @@ public enum QueryType implements Serializable {
 
     // Cluster
     GetVdsCertificateSubjectByVmId(QueryAuthType.User),
+    GetVdsCertificateSubjectsByVmIds(QueryAuthType.User),
     GetAllClusters(QueryAuthType.User),
     GetClusterById(QueryAuthType.User),
     GetClusterByName(QueryAuthType.User),

--- a/backend/manager/modules/dal/src/main/java/org/ovirt/engine/core/dao/VmDynamicDao.java
+++ b/backend/manager/modules/dal/src/main/java/org/ovirt/engine/core/dao/VmDynamicDao.java
@@ -41,6 +41,14 @@ public interface VmDynamicDao extends GenericDao<VmDynamic, Guid>, StatusAwareDa
     VmDynamic get(Guid id);
 
     /**
+     * Get all VmDynamic with the given ids
+     * @param vmIds
+     *            the list of VM ids
+     * @return list of corresponding dynamics
+     */
+    List<VmDynamic> getByIds(List<Guid> vmIds);
+
+    /**
      * Updates the specified dynamic vm.
      *
      * @param vm

--- a/backend/manager/modules/dal/src/main/java/org/ovirt/engine/core/dao/VmDynamicDaoImpl.java
+++ b/backend/manager/modules/dal/src/main/java/org/ovirt/engine/core/dao/VmDynamicDaoImpl.java
@@ -164,6 +164,14 @@ public class VmDynamicDaoImpl extends MassOperationsGenericDao<VmDynamic, Guid>
     }
 
     @Override
+    public List<VmDynamic> getByIds(List<Guid> vmIds) {
+        return getCallsHandler().executeReadList("GetVmDynamicByVmGuids",
+                createEntityRowMapper(),
+                getCustomMapSqlParameterSource()
+                        .addValue("vm_guids", createArrayOfUUIDs(vmIds)));
+    }
+
+    @Override
     protected MapSqlParameterSource createIdParameterMapper(Guid id) {
         return getCustomMapSqlParameterSource().addValue("vm_guid", id);
     }

--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendVmsResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendVmsResource.java
@@ -26,6 +26,7 @@ import org.apache.commons.lang.StringUtils;
 import org.ovirt.engine.api.common.util.DetailHelper;
 import org.ovirt.engine.api.model.ActionableResource;
 import org.ovirt.engine.api.model.AutoPinningPolicy;
+import org.ovirt.engine.api.model.Certificate;
 import org.ovirt.engine.api.model.Configuration;
 import org.ovirt.engine.api.model.ConfigurationType;
 import org.ovirt.engine.api.model.Disk;
@@ -731,6 +732,9 @@ public class BackendVmsResource extends
             // optimization of DB access: retrieve GraphicsDevices for all VMs at once
             Map<Guid, List<GraphicsDevice>> vmsGraphicsDevices =
                     DisplayHelper.getGraphicsDevicesForMultipleEntities(this, vmIds);
+            // optimization of DB access: retrieve Certificates for all VMs at once
+            Map<Guid, Certificate> vmsCertificate =
+                    DisplayHelper.getDisplayCertificatesForMultipleEntities(this, vmIds);
 
             for (org.ovirt.engine.core.common.businessentities.VM entity : entities) {
                 Vm vm = map(entity);
@@ -742,7 +746,7 @@ public class BackendVmsResource extends
                     vm.setGraphicsConsoles(consoles);
                 }
                 DisplayHelper.adjustDisplayData(this, vm, vmsGraphicsDevices, false);
-                DisplayHelper.addDisplayCertificate(this, vm);
+                DisplayHelper.addDisplayCertificate(vm, vmsCertificate.get(entity.getId()));
                 removeRestrictedInfo(vm);
                 collection.getVms().add(addLinks(populate(vm, entity)));
             }

--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/util/DisplayHelper.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/util/DisplayHelper.java
@@ -1,6 +1,8 @@
 package org.ovirt.engine.api.restapi.util;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -155,6 +157,45 @@ public class DisplayHelper {
                 vm.getDisplay().getCertificate().setContent(caCertificateReturnValue.getReturnValue());
             }
         }
+    }
+
+    public static void addDisplayCertificate(Vm vm, Certificate certificate) {
+        if (certificate != null) {
+            if (!vm.isSetDisplay()) {
+                vm.setDisplay(new Display());
+            }
+            vm.getDisplay().setCertificate(certificate);
+        }
+    }
+
+    public static Map<Guid, Certificate> getDisplayCertificatesForMultipleEntities(BackendResource res, List<Guid> vmIds) {
+        QueryReturnValue result =
+                res.runQuery(QueryType.GetVdsCertificateSubjectsByVmIds,
+                        new IdsQueryParameters(vmIds));
+
+        if (result != null && result.getSucceeded() && result.getReturnValue() != null) {
+            Map<Guid, String> certificateForVms = result.getReturnValue();
+
+            String certificateContent = null;
+            final QueryReturnValue caCertificateReturnValue =
+                    res.runQuery(QueryType.GetCACertificate, new QueryParametersBase());
+            if (caCertificateReturnValue.getSucceeded()) {
+                certificateContent = caCertificateReturnValue.getReturnValue();
+            }
+            String organizationName = CertificateSubjectHelper.getOrganizationName();
+
+            Map<Guid, Certificate> certificates = new HashMap<>();
+            for (Map.Entry<Guid, String> e : certificateForVms.entrySet()) {
+                Certificate cert = new Certificate();
+                cert.setSubject(e.getValue());
+                cert.setOrganization(organizationName);
+                cert.setContent(certificateContent);
+
+                certificates.put(e.getKey(), cert);
+            }
+            return certificates;
+        }
+        return Collections.emptyMap();
     }
 
     private static Display extractDisplayFromResource(BaseResource res) {

--- a/backend/manager/modules/restapi/jaxrs/src/test/java/org/ovirt/engine/api/restapi/util/DisplayHelperTest.java
+++ b/backend/manager/modules/restapi/jaxrs/src/test/java/org/ovirt/engine/api/restapi/util/DisplayHelperTest.java
@@ -1,0 +1,93 @@
+package org.ovirt.engine.api.restapi.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.ovirt.engine.api.model.Certificate;
+import org.ovirt.engine.api.model.Vm;
+import org.ovirt.engine.api.restapi.resource.BackendResource;
+import org.ovirt.engine.core.common.config.ConfigValues;
+import org.ovirt.engine.core.common.queries.QueryReturnValue;
+import org.ovirt.engine.core.common.queries.QueryType;
+import org.ovirt.engine.core.compat.Guid;
+import org.ovirt.engine.core.utils.MockConfigDescriptor;
+import org.ovirt.engine.core.utils.MockConfigExtension;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockConfigExtension.class)
+public class DisplayHelperTest {
+    private static final String CERTIFICATE = "O=Redhat,CN=X.Y.Z.Q";
+    private static final String CA_CERT = "dummy-cert";
+    private static final String ORG = "ORG";
+    private static final List<Guid> GUIDS = Arrays.asList(
+            new Guid("11111111-1111-1111-1111-111111111111"),
+            new Guid("22222222-2222-2222-2222-222222222222"));
+
+    public static Stream<MockConfigDescriptor<?>> mockConfiguration() {
+        return Stream.of(MockConfigDescriptor.of(ConfigValues.OrganizationName, ORG));
+    }
+
+    @Test
+    public void testAddDisplayCertificate() {
+        Vm vm = new Vm();
+        Certificate certificate = new Certificate();
+        DisplayHelper.addDisplayCertificate(vm, certificate);
+
+        assertSame(certificate, vm.getDisplay().getCertificate());
+    }
+
+    @Test
+    public void testGetDisplayCertificatesForMultipleEntitiesNoResult() {
+        BackendResource res = mock(BackendResource.class);
+        QueryReturnValue result = new QueryReturnValue();
+        result.setSucceeded(false);
+        when(res.runQuery(eq(QueryType.GetVdsCertificateSubjectsByVmIds), any())).thenReturn(result);
+
+        Map<Guid, Certificate> certificates = DisplayHelper.getDisplayCertificatesForMultipleEntities(res, GUIDS);
+        assertTrue(certificates.isEmpty());
+    }
+
+    @Test
+    public void testGetDisplayCertificatesForMultipleEntities() {
+        BackendResource res = mock(BackendResource.class);
+
+        QueryReturnValue result = new QueryReturnValue();
+        result.setSucceeded(true);
+        Map<Guid, String> subjects = GUIDS.stream().collect(Collectors.toMap(Function.identity(), id -> CERTIFICATE));
+        result.setReturnValue(subjects);
+        when(res.runQuery(eq(QueryType.GetVdsCertificateSubjectsByVmIds), any())).thenReturn(result);
+
+        result = new QueryReturnValue();
+        result.setSucceeded(true);
+        result.setReturnValue(CA_CERT);
+        when(res.runQuery(eq(QueryType.GetCACertificate), any())).thenReturn(result);
+
+
+        Map<Guid, Certificate> certificates = DisplayHelper.getDisplayCertificatesForMultipleEntities(res, GUIDS);
+        assertEquals(GUIDS.size(), certificates.size());
+        for (Guid guid : GUIDS) {
+            Certificate cert = certificates.get(guid);
+            assertNotNull(cert);
+            assertEquals(CERTIFICATE, cert.getSubject());
+            assertEquals(CA_CERT, cert.getContent());
+            assertEquals(ORG, cert.getOrganization());
+        }
+    }
+}

--- a/packaging/dbscripts/vms_sp.sql
+++ b/packaging/dbscripts/vms_sp.sql
@@ -638,6 +638,19 @@ BEGIN
 END;$FUNCTION$
 LANGUAGE plpgsql;
 
+CREATE OR REPLACE FUNCTION GetVmDynamicByVmGuids (v_vm_guids UUID[])
+RETURNS SETOF vm_dynamic STABLE AS $FUNCTION$
+BEGIN
+    RETURN QUERY
+
+    SELECT vm_dynamic.*
+    FROM vm_dynamic
+    WHERE vm_guid = ANY(v_vm_guids);
+
+    RETURN;
+END;$FUNCTION$
+LANGUAGE plpgsql;
+
 DROP TYPE IF EXISTS GetAllHashesFromVmDynamic_rs CASCADE;
 CREATE TYPE GetAllHashesFromVmDynamic_rs AS (vm_guid UUID, hash VARCHAR);
 CREATE OR REPLACE FUNCTION GetAllHashesFromVmDynamic ()


### PR DESCRIPTION
Reduce the number of database requests when retrieving certificate details for the requested VMs

## Changes introduced with this PR
This fix optimizes GET /vms?detail=main REST API request. In case when there is a parameter detail=main in the request: 
Old behavior - for each particular VM invoke DisplayHelper.addDisplayCertificate(BackendResource res, Vm vm) which:
* Runs GetVdsCertificateSubjectByVmId query, which internally runs vmDynamicDao.get(vmId) and then vdsStaticDao.get(vdsId)
* Runs GetCACertificate query, which reads and returns content of the EngineLocalConfig.getInstance().getPKICACert() file

Optimized behavior - for all VMs invoke DisplayHelper.getDisplayCertificatesForMultipleEntities(BackendResource res, List<Guid> vmIds) which:
* Runs GetVdsCertificateSubjectsByVmIds query, which internally runs vmDynamicDao.getByIds, collects unique host ids. For all the host ids it runs vdsStaticDao.getByIds
* Runs only once GetCACertificate query to retrieve the certificate content from the file.

So, the optimization significantly reduced the number of queries. Significantly reduced the number of calls to vmDynamicDao and  vdsStaticDao (because in general the number of unique hosts is much less than the number of VMs), and reduced the number of reads of the certificate content.

## Are you the owner of the code you are sending in, or do you have permission of the owner?
Y