### PR TITLE
Add pull-request write access to ost-trigger

### DIFF
--- a/.github/workflows/ost.yaml
+++ b/.github/workflows/ost.yaml
@@ -4,6 +4,9 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  pull-requests: write
+
 jobs:
   trigger-ost:
     uses: oVirt/ovirt-system-tests/.github/workflows/ost.yaml@master


### PR DESCRIPTION
This is now needed to run ost, otherwise you get the error:

Error calling workflow 'oVirt/ovirt-system-tests/.github/workflows/ost.yaml@master'.
The workflow is requesting 'pull-requests: write',
but is only allowed 'pull-requests: none'.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]