### PR TITLE
core: added option for user to decide preference of vnc console invocation

### DIFF
--- a/frontend/webadmin/modules/gwt-common/src/main/java/org/ovirt/engine/ui/common/CommonApplicationConstants.java
+++ b/frontend/webadmin/modules/gwt-common/src/main/java/org/ovirt/engine/ui/common/CommonApplicationConstants.java
@@ -1964,4 +1964,8 @@ public interface CommonApplicationConstants extends Constants {
     String permissionFilter();
 
     String propertyId();
+
+    String preferredVncOption();
+
+    String defaultClient();
 }

--- a/frontend/webadmin/modules/gwt-common/src/main/java/org/ovirt/engine/ui/common/utils/ConsoleOptionsFrontendPersisterImpl.java
+++ b/frontend/webadmin/modules/gwt-common/src/main/java/org/ovirt/engine/ui/common/utils/ConsoleOptionsFrontendPersisterImpl.java
@@ -102,6 +102,11 @@ public class ConsoleOptionsFrontendPersisterImpl implements ConsoleOptionsFronte
     private void loadConsolesWithKeymaker(VmConsoles consoles, KeyMaker keyMaker) {
         String selectedProtocolString = clientStorage.getLocalItem(keyMaker.make(SELECTED_PROTOCOL));
         if (selectedProtocolString == null || "".equals(selectedProtocolString)) {
+            String vncType = loadGeneralVncType();
+            if (vncType != null && consoles.canSelectProtocol(ConsoleProtocol.VNC)) {
+                consoles.selectProtocol(ConsoleProtocol.VNC);
+                consoles.getConsoleModel(VncConsoleModel.class).setVncImplementation(VncConsoleModel.ClientConsoleMode.valueOf(vncType));
+            }
             setOptionsDefaults(consoles);
             return;
         }
@@ -246,6 +251,18 @@ public class ConsoleOptionsFrontendPersisterImpl implements ConsoleOptionsFronte
             return false;
         }
         return defaultValue;
+    }
+
+    public void storeGeneralVncType(String type) {
+        clientStorage.setLocalItem("general" + VNC_CLIENT_MODE, type); //$NON-NLS-1$
+    }
+
+    public String loadGeneralVncType() {
+        return clientStorage.getLocalItem("general" + VNC_CLIENT_MODE); //$NON-NLS-1$
+    }
+
+    public void removeGeneralVncType() {
+        clientStorage.removeLocalItem("general" + VNC_CLIENT_MODE); //$NON-NLS-1$
     }
 
     private void storeBool(String key, boolean value) {

--- a/frontend/webadmin/modules/gwt-common/src/main/java/org/ovirt/engine/ui/common/view/popup/OptionsPopupView.java
+++ b/frontend/webadmin/modules/gwt-common/src/main/java/org/ovirt/engine/ui/common/view/popup/OptionsPopupView.java
@@ -20,7 +20,9 @@ import org.ovirt.engine.ui.common.widget.dialog.tab.DialogTabPanel;
 import org.ovirt.engine.ui.common.widget.editor.generic.EntityModelCheckBoxEditor;
 import org.ovirt.engine.ui.common.widget.editor.generic.EntityModelRadioButtonEditor;
 import org.ovirt.engine.ui.common.widget.editor.generic.StringEntityModelTextArea;
+import org.ovirt.engine.ui.uicommonweb.ConsoleOptionsFrontendPersister;
 import org.ovirt.engine.ui.uicommonweb.models.options.EditOptionsModel;
+import org.ovirt.engine.ui.uicommonweb.models.vms.VncConsoleModel;
 import org.ovirt.engine.ui.uicompat.IEventListener;
 import org.ovirt.engine.ui.uicompat.PropertyChangedEventArgs;
 
@@ -108,6 +110,18 @@ public class OptionsPopupView extends AbstractModelBoundPopupView<EditOptionsMod
     @Path(value = "customHomePage.entity")
     StringEntityModelTextArea customHomePage;
 
+    @UiField (provided = true)
+    @Ignore
+    public EntityModelRadioButtonEditor consoleNativeRadioButton;
+
+    @UiField (provided = true)
+    @Ignore
+    public EntityModelRadioButtonEditor consoleNoVncRadioButton;
+
+    @UiField (provided = true)
+    @Ignore
+    public EntityModelRadioButtonEditor consoleDefaultRadioButton;
+
     @Inject
     public OptionsPopupView(EventBus eventBus, PlaceManager manager) {
         super(eventBus);
@@ -117,6 +131,12 @@ public class OptionsPopupView extends AbstractModelBoundPopupView<EditOptionsMod
         isHomePageCustom = new EntityModelRadioButtonEditor("homePage", Align.RIGHT); // $NON-NLS-1$
         isHomePageDefault = new EntityModelRadioButtonEditor("homePage", Align.RIGHT); // $NON-NLS-1$
 
+        consoleNativeRadioButton = new EntityModelRadioButtonEditor("Vnc", Align.RIGHT); // $NON-NLS-1$
+        consoleNativeRadioButton.setLabel(constants.nativeClient());
+        consoleNoVncRadioButton = new EntityModelRadioButtonEditor("Vnc", Align.RIGHT); // $NON-NLS-1$
+        consoleNoVncRadioButton.setLabel(constants.noVnc());
+        consoleDefaultRadioButton = new EntityModelRadioButtonEditor("Vnc", Align.RIGHT); // $NON-NLS-1$
+        consoleDefaultRadioButton.setLabel(constants.defaultClient());
         initWidget(ViewUiBinder.uiBinder.createAndBindUi(this));
         ViewIdHandler.idHandler.generateAndSetIds(this);
 
@@ -226,6 +246,51 @@ public class OptionsPopupView extends AbstractModelBoundPopupView<EditOptionsMod
     @Override
     public HasValueChangeHandlers<Boolean> getHomePageDefaultSwitch() {
         return isHomePageDefault.asRadioButton();
+    }
+
+    @Override
+    public HasValueChangeHandlers<Boolean> getConsoleVncNativeRadioButton() {
+        return consoleNativeRadioButton.asRadioButton();
+    }
+
+    @Override
+    public HasValueChangeHandlers<Boolean> getConsoleNoVncRadioButton() {
+        return consoleNoVncRadioButton.asRadioButton();
+    }
+
+    @Override
+    public HasValueChangeHandlers<Boolean> getConsoleDefaultRadioButton() {
+        return consoleDefaultRadioButton.asRadioButton();
+    }
+
+    @Override
+    public void setConsoleNoVncSelected(boolean selected, ConsoleOptionsFrontendPersister consoleOptionsPersister, EditOptionsModel model) {
+        consoleNoVncRadioButton.asRadioButton().setValue(selected);
+        if (selected) {
+            storeSelectedConsole(VncConsoleModel.ClientConsoleMode.NoVnc.toString(), consoleOptionsPersister, model);
+        }
+    }
+
+    @Override
+    public void setConsoleVncNativeSelected(boolean selected, ConsoleOptionsFrontendPersister consoleOptionsPersister, EditOptionsModel model) {
+        consoleNativeRadioButton.asRadioButton().setValue(selected);
+        if (selected) {
+            storeSelectedConsole(VncConsoleModel.ClientConsoleMode.Native.toString(), consoleOptionsPersister, model);
+        }
+    }
+
+    @Override
+    public void setConsoleDefaultSelected(boolean selected, ConsoleOptionsFrontendPersister consoleOptionsPersister, EditOptionsModel model) {
+        consoleDefaultRadioButton.asRadioButton().setValue(selected);
+        if (selected) {
+            consoleOptionsPersister.removeGeneralVncType();
+            model.getOkCommand().setIsExecutionAllowed(true);
+        }
+    }
+
+    private void storeSelectedConsole(String consoleType, ConsoleOptionsFrontendPersister persister, EditOptionsModel model) {
+        persister.storeGeneralVncType(consoleType);
+        model.getOkCommand().setIsExecutionAllowed(true);
     }
 
 }

--- a/frontend/webadmin/modules/gwt-common/src/main/java/org/ovirt/engine/ui/common/view/popup/OptionsPopupView.ui.xml
+++ b/frontend/webadmin/modules/gwt-common/src/main/java/org/ovirt/engine/ui/common/view/popup/OptionsPopupView.ui.xml
@@ -55,6 +55,16 @@
             font-weight: bold;
         }
 
+        .radioButton {
+            float: left;
+            display: inline;
+            padding-left: 20px;
+        }
+
+        .radioButton input {
+            margin-right: 5px;
+        }
+
     </ui:style>
     <d:SimpleDialogPanel width="800px" height="550px">
         <d:content>
@@ -139,6 +149,21 @@
                                                                       addStyleNames="{style.overrideClearBoth}"/>
                                         <d:InfoIcon ui:field="localStoragePersistedOnServerInfoIcon"
                                                     addStyleNames="{style.inlineBlock} {style.infoIcon}"/>
+                                    </b:Column>
+                                </b:Row>
+                                <b:Row>
+                                    <b:Column size="SM_12">
+                                        <g:Label text="{constants.preferredVncOption}" addStyleNames="{style.headerLabel}"/>
+                                    </b:Column>
+                                </b:Row>
+                                <b:Row>
+                                    <b:Column size="SM_12">
+                                        <ge:EntityModelRadioButtonEditor ui:field="consoleNativeRadioButton" 
+                                                        addStyleNames="{style.radioButton}"/>
+                                        <ge:EntityModelRadioButtonEditor ui:field="consoleNoVncRadioButton" 
+                                                        addStyleNames="{style.radioButton}"/>
+                                        <ge:EntityModelRadioButtonEditor ui:field="consoleDefaultRadioButton"
+                                                        addStyleNames="{style.radioButton}"/>
                                     </b:Column>
                                 </b:Row>
                             </b:Container>

--- a/frontend/webadmin/modules/gwt-common/src/main/resources/org/ovirt/engine/ui/common/CommonApplicationConstants.properties
+++ b/frontend/webadmin/modules/gwt-common/src/main/resources/org/ovirt/engine/ui/common/CommonApplicationConstants.properties
@@ -983,3 +983,5 @@ changeColumnsVisibilityOrder=Change columns visibility/order
 typeToSearchPlaceHolder=Type to search
 configChangesPending=Configuration changes may be pending. Unplug and replug to apply.
 permissionFilter=Permission Filters
+preferredVncOption=Preferred default VNC option
+defaultClient=Set to Default

--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/ConsoleOptionsFrontendPersister.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/ConsoleOptionsFrontendPersister.java
@@ -8,6 +8,12 @@ public interface ConsoleOptionsFrontendPersister {
 
     void loadFromLocalStorage(VmConsoles vmConsoles);
 
+    void storeGeneralVncType(String type);
+
+    String loadGeneralVncType();
+
+    void removeGeneralVncType();
+
     /**
      * The stored/loaded entities can not interfere from one app/view to other even it is all in one browser.
      */

--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/options/EditOptionsModel.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/options/EditOptionsModel.java
@@ -57,7 +57,7 @@ public class EditOptionsModel extends Model {
         this.okCommand = okCommand;
         this.resetCommand = resetCommand;
         // enable if values are edited
-        okCommand.setIsExecutionAllowed(false);
+        getOkCommand().setIsExecutionAllowed(false);
         getCommands().addAll(Arrays.asList(okCommand, cancelCommand, resetCommand));
 
     }
@@ -70,8 +70,8 @@ public class EditOptionsModel extends Model {
 
     void updateAvailability() {
         // Cancel is always enabled
-        okCommand.setIsExecutionAllowed(hasChangedValues());
-        resetCommand.setIsExecutionAllowed(!hasChangedValues() && hasCustomValues());
+        getOkCommand().setIsExecutionAllowed(hasChangedValues());
+        getResetCommand().setIsExecutionAllowed(!hasChangedValues() && hasCustomValues());
     }
 
     private boolean hasCustomValues() {
@@ -141,5 +141,13 @@ public class EditOptionsModel extends Model {
 
     public EntityModel<String> getCustomHomePage() {
         return customHomePage;
+    }
+
+    public UICommand getOkCommand() {
+        return okCommand;
+    }
+
+    public UICommand getResetCommand() {
+        return resetCommand;
     }
 }

--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/options/OptionsModel.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/options/OptionsModel.java
@@ -126,6 +126,7 @@ public class OptionsModel extends EntityModel<EditOptionsModel> {
                         (remote, target) -> REPORT_ERROR,
                         model,
                         true));
+        setWindow(null);
     }
 
     private void resetSettings() {


### PR DESCRIPTION
## Changes introduced with this PR

* Introduces option to change vnc console invocation protocol (Native or NoVnc) during runtime on a user basis for all vm's. 

* This setting is saved in the local storage, where individual selection of console type for a VM is also saved.

* When default is selected it falls back to the VNC type set in the config values. 

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]