### PR TITLE
conf: support RHEL 9.6 machinetypes on cluster 4.8

### DIFF
--- a/packaging/dbscripts/upgrade/pre_upgrade/0000_config.sql
+++ b/packaging/dbscripts/upgrade/pre_upgrade/0000_config.sql
@@ -87,7 +87,7 @@ select fn_db_add_config_value('ClusterEmulatedMachines','pc-q35-rhel8.1.0,pc-q35
 select fn_db_add_config_value('ClusterEmulatedMachines','pc-q35-rhel8.3.0,pc-q35-4.1,pc-i440fx-rhel7.6.0,pc-i440fx-2.12,pseries-rhel8.3.0,s390-ccw-virtio-2.12','4.5');
 select fn_db_add_config_value('ClusterEmulatedMachines','pc-q35-rhel8.4.0,pc-q35-4.1,pc-i440fx-rhel7.6.0,pc-i440fx-2.12,pseries-rhel8.4.0,s390-ccw-virtio-2.12','4.6');
 select fn_db_add_config_value('ClusterEmulatedMachines','pc-q35-rhel8.6.0,pc-q35-4.1,pc-i440fx-rhel7.6.0,pc-i440fx-2.12,pseries-rhel8.4.0,s390-ccw-virtio-2.12','4.7');
-select fn_db_add_config_value('ClusterEmulatedMachines','pc-q35-rhel9.4.0,pc-q35-4.1,pc-i440fx-rhel7.6.0,pc-i440fx-2.12,pseries-rhel8.4.0,s390-ccw-virtio-2.12','4.8');
+select fn_db_add_config_value('ClusterEmulatedMachines','pc-q35-rhel9.6.0,pc-i440fx-rhel7.6.0,pseries-rhel8.5.0,s390-ccw-virtio-rhel9.4.0','4.8');
 select fn_db_add_config_value('CpuOverCommitDurationMinutes','2','general');
 --Handling Data directory for ENGINE
 select fn_db_add_config_value('DataDir','/usr/share/engine','general');


### PR DESCRIPTION
## Changes introduced with this PR

Remove upstream machine types such as `pc-q35-4.1`, `pc-i440fx-2.12`, and `s390-ccw-virtio-2.12`.

In their place, the following RHEL-specific machine types have been added or retained:
* `pc-q35-rhel9.6.0`
* `pc-i440fx-rhel7.6.0`
* `pseries-rhel8.5.0`
* `s390-ccw-virtio-rhel9.4.0`

This change is necessary because RHEL's qemu-kvm disables upstream machine types and only supports RHEL-maintained versions, for example in patches like `0008-Remove-upstream-machine-type-versions-for-aarch64-s3.patch`. This ensures compatibility with RHEL 9.6 for cluster 4.8 deployments.

So, in short we only support the machine types that are supported by the RHEL qemu-kvm build.

Source: https://git.almalinux.org/rpms/qemu-kvm/src/branch/c9

vdsm PR that is linked to these changes: https://github.com/oVirt/vdsm/pull/432

## Are you the owner of the code you are sending in, or do you have permission of the owner?

y