### PR TITLE
Fix hugepages memory usage stats

### DIFF
--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/utils/HugePageUtils.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/utils/HugePageUtils.java
@@ -84,6 +84,10 @@ public class HugePageUtils {
         return hugePageMap;
     }
 
+    private static long longMultiply(int a, int b) {
+            return Long.valueOf(a) * Long.valueOf(b);
+        }
+
     public static int totalHugePageMemMb(Map<Integer, Integer> hugepages) {
         long hugePageMemKb = hugepages.entrySet().stream()
                 .mapToLong(entry -> longMultiply(entry.getKey(), entry.getValue()))

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/utils/HugePageUtils.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/utils/HugePageUtils.java
@@ -86,7 +86,7 @@ public class HugePageUtils {
 
     public static int totalHugePageMemMb(Map<Integer, Integer> hugepages) {
         long hugePageMemKb = hugepages.entrySet().stream()
-                .mapToLong(entry -> entry.getKey() * entry.getValue())
+                .mapToLong(entry -> longMultiply(entry.getKey(), entry.getValue()))
                 .sum();
 
         return (int) ((hugePageMemKb + KIB_IN_MIB - 1) / KIB_IN_MIB);
@@ -98,7 +98,7 @@ public class HugePageUtils {
         }
 
         long hugePageMemKb = vds.getHugePages().stream()
-                .mapToLong(hugePage -> hugePage.getTotal() * hugePage.getSizeKB())
+                .mapToLong(hugePage -> longMultiply(hugePage.getTotal(), hugePage.getSizeKB()))
                 .sum();
 
         return (int) ((hugePageMemKb + KIB_IN_MIB - 1) / KIB_IN_MIB);
@@ -110,7 +110,7 @@ public class HugePageUtils {
         }
 
         long hugePageMemKb = vds.getHugePages().stream()
-                .mapToLong(hugePage -> hugePage.getFree() * hugePage.getSizeKB())
+                .mapToLong(hugePage -> longMultiply(hugePage.getFree(), hugePage.getSizeKB()))
                 .sum();
 
         return (int) ((hugePageMemKb + KIB_IN_MIB - 1) / KIB_IN_MIB);


### PR DESCRIPTION
## Issue
When calculating hugepages memory, Java Integer was was used. It becomes negative number when it exceeds 2TB, resulting wrong stats reported.
## Changes introduced with this PR

Use Java Long instead of Integer to calculate hugepages memory.

## Are you the owner of the code you are sending in, or do you have permission of the owner?
Yes

## Testing
```
Customer reported the following after applying the patched jar
"Memory 5.5 available of 5.9 TiB
Virtual resources - Committed: 5%, Allocated: 22%" ```