### PR TITLE
fix user permission href missing from certain resources

### DIFF
--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendAssignedPermissionsResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendAssignedPermissionsResource.java
@@ -111,7 +111,7 @@ public class BackendAssignedPermissionsResource
         for (org.ovirt.engine.core.common.businessentities.Permission entity : entities) {
             castEveryonePermissionsToUser(entity);
             Permission permission = map(entity, getUserById(entity.getAdElementId()));
-            collection.getPermissions().add(addLinks(permission, permission.getUser() != null ? suggestedParentType : Group.class));
+            collection.getPermissions().add(addLinks(permission, permission.getUser() != null ? User.class : Group.class));
         }
         return collection;
     }


### PR DESCRIPTION
## Issue
 OLVM REST API responses for certain resource permissions including: cpuprofiles, vnicprofiles, and diskprofiles, were missing href(s) for a given resource id
## Changes introduced with this PR

A change to the REST API forces all calls, to the REST API, for resource permissions to follow the same format. Changing the `suggestedParentType` to `User.class` changes the response for all resources to follow the pattern `users/USER_ID/permissions/PERMISSION_ID`

## Are you the owner of the code you are sending in, or do you have permission of the owner?

Yes