### PR TITLE
Fix ovn validations when upgrading host

### DIFF
--- a/packaging/ansible-runner-service-project/project/ovirt-host-reconfigure-ovn.yml
+++ b/packaging/ansible-runner-service-project/project/ovirt-host-reconfigure-ovn.yml
@@ -37,4 +37,4 @@
     - el_ver|int == 8
     - ovirt_openvswitch_pre.version is version('2.11', '==')
     - ovirt_openvswitch_post.version is version('2.15', '>=')
-    - ovn_central is defined
+    - ovn_central is defined and ovn_central != None and ovn_central | length != 0


### PR DESCRIPTION
## Issue
KVM host upgrade marked as failed because ansible task "[Reconfigure OVN for oVirt]" fails
## Changes introduced with this PR

*Fix ovn_central validation for None/Empty. Fix the openvswitch version.

## Are you the owner of the code you are sending in, or do you have permission of the owner?
Yes