### PR TITLE
core: improve isLiveDelete check

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/backup/DeleteVmCheckpointCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/backup/DeleteVmCheckpointCommand.java
@@ -29,7 +29,6 @@ import org.ovirt.engine.core.common.action.VmCheckpointParameters;
 import org.ovirt.engine.core.common.action.VolumeBitmapCommandParameters;
 import org.ovirt.engine.core.common.businessentities.ActionGroup;
 import org.ovirt.engine.core.common.businessentities.VDS;
-import org.ovirt.engine.core.common.businessentities.VMStatus;
 import org.ovirt.engine.core.common.businessentities.VdsmImageLocationInfo;
 import org.ovirt.engine.core.common.businessentities.VmBackup;
 import org.ovirt.engine.core.common.businessentities.VmCheckpoint;
@@ -240,7 +239,7 @@ public class DeleteVmCheckpointCommand<T extends VmCheckpointParameters> extends
     }
 
     private boolean isLiveDeleteCheckpoint() {
-        return getVm().getStatus() == VMStatus.Up;
+        return getVm().getStatus().isRunningOrPaused();
     }
 
     @Override


### PR DESCRIPTION
## Changes introduced with this PR

Just checking if VMStatus is Up is not enough.

There are some cases where the VM is actually active, but the status is not Up.
For example when there is a lot of I/O and using thin provisioned disks on block
storage, the VM sometimes goes into paused state.
If you then remove a checkpoint, the code does a coldDeleteVmCheckpoint.
But this should never happen, as a cold delete uses qemu-img to delete the
checkpoint and if the qcow2 image is still in use by a qemu process this will
corrupt the qcow2 image.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

y