### PR TITLE
conf: add Windows 2025

### DIFF
--- a/packaging/conf/osinfo-defaults.properties
+++ b/packaging/conf/osinfo-defaults.properties
@@ -387,7 +387,11 @@ os.windows_2022.id.value = 37
 os.windows_2022.name.value = Windows 2022
 os.windows_2022.derivedFrom.value = windows_2019x64
 os.windows_2022.sysprepPath.value = ${ENGINE_USR}/conf/sysprep/sysprep.2k22
-os.windows_2022.devices.tpm.value = required
+
+# Windows2025
+os.windows_2025.id.value = 38
+os.windows_2025.name.value = Windows 2025
+os.windows_2025.derivedFrom.value = windows_2022
 
 #Suse
 os.sles_11.id.value = 1193


### PR DESCRIPTION
## Changes introduced with this PR

Add Windows 2025. All config except for the name is inherited from Windows 2022 via the `derivedFrom` mechanism in `OsRepositoryImpl#getKeyNode()`

Also, tpm is not required for Windows 2022.

Fixes issue # (delete if not relevant)

## Are you the owner of the code you are sending in, or do you have permission of the owner?

y