### PR TITLE
build: usage of new repository for maven central snapshots

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -836,9 +836,9 @@
       </releases>
     </repository>
     <repository>
-      <id>ossrh</id>
-      <name>OSSRH Snapshots</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <name>Central Portal Snapshots</name>
+      <id>central-portal-snapshots</id>
+      <url>https://central.sonatype.com/repository/maven-snapshots</url>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>


### PR DESCRIPTION
## Changes introduced with this PR

* When pulling from maven central use the new way described by https://central.sonatype.org/publish/publish-portal-snapshots/#publishing-via-other-methods

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]