### PR TITLE
add RHEL10 to osinfo list

### DIFF
--- a/packaging/conf/osinfo-defaults.properties
+++ b/packaging/conf/osinfo-defaults.properties
@@ -193,6 +193,11 @@ os.rhel_9x64.id.value = 34
 os.rhel_9x64.name.value = Red Hat Enterprise Linux 9.x x64
 os.rhel_9x64.derivedFrom.value = rhel_8x64
 
+# rhel10x64(39, OsType.Linux)
+os.rhel_10x64.id.value = 39
+os.rhel_10x64.name.value = Red Hat Enterprise Linux 10.x x64
+os.rhel_10x64.derivedFrom.value = rhel_8x64
+
 # redhat coreos
 os.rhcos_x64.id.value = 35
 os.rhcos_x64.name.value = Red Hat Enterprise Linux CoreOS

--- a/packaging/conf/osinfo-defaults.properties
+++ b/packaging/conf/osinfo-defaults.properties
@@ -196,7 +196,7 @@ os.rhel_9x64.derivedFrom.value = rhel_8x64
 # rhel10x64(39, OsType.Linux)
 os.rhel_10x64.id.value = 39
 os.rhel_10x64.name.value = Red Hat Enterprise Linux 10.x x64
-os.rhel_10x64.derivedFrom.value = rhel_8x64
+os.rhel_10x64.derivedFrom.value = rhel_9x64
 
 # redhat coreos
 os.rhcos_x64.id.value = 35


### PR DESCRIPTION
## Changes introduced with this PR

* added RHEL10 to osinfo list. All config is inherited from rhel_8x64

