### PR TITLE
core:enable topoext by default on AMD EPYC cpu

### DIFF
--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/builder/vminfo/LibvirtVmXmlBuilder.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/builder/vminfo/LibvirtVmXmlBuilder.java
@@ -432,6 +432,12 @@ public class LibvirtVmXmlBuilder {
             cpuType += "," + cpuFlagsProperty;
         }
 
+        // Add topoext on AMD EPYC, if it is not already set
+        if (cpuModelSupplier.get() != null && cpuModelSupplier.get().contains("AMD EPYC") &&
+                !cpuType.contains("topoext")) {
+            cpuType += ",+topoext";
+        }
+
         String[] typeAndFlags = cpuType.split(",");
 
         switch (vm.getClusterArch().getFamily()) {


### PR DESCRIPTION
## Issues
VMs created on AMD EPYC hosts have their Threads per Core stuck at 1 regardless what users specified.

## Changes introduced with this PR

* Enable the cpu feature flag TOPOEXT by default on AMD EPYC. It is required for AMD EPYC to support hyperthreading on kvm guests. If TOPOEXT is not desired by the VMs on AMD EPYC, add -topoext extra_cpu_flags explicitly to disable.

## Manual Tests Performed
1. Create VM on AMD EPYC host without **Pass-Through Host CPU**, the domain generated has `<feature policy='require' name='topoext'/>` and VM reports correct Threads per Core
2. Create VM on AMD EPYC host with **Pass-Through Host CPU**, the domain generated has `<feature policy='require' name='topoext'/>` and VM reports correct correct Threads per Core
3. Create VM on AMD EPYC host without **Pass-Through Host CPU** and with `extra_cpu_flags: -topoext`, the domain generated has `<feature policy='disable' name='topoext'/>` and VM reports wrong Threads per Core
4. Create VM on AMD EPYC host with **Pass-Through Host CPU** and with `extra_cpu_flags: -topoext`, the domain generated has `<feature policy='disable' name='topoext'/>` and VM reports wrong Threads per Core

## Are you the owner of the code you are sending in, or do you have permission of the owner?

Yes