### PR TITLE
webadmin: internationalize forgotten hard coded string

### DIFF
--- a/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/ApplicationConstants.java
+++ b/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/ApplicationConstants.java
@@ -2642,6 +2642,8 @@ public interface ApplicationConstants extends CommonApplicationConstants {
 
     String tenantName();
 
+    String authProtocol();
+
     String authHostName();
 
     String authPort();

--- a/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/section/main/view/popup/provider/ProviderPopupView.ui.xml
+++ b/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/section/main/view/popup/provider/ProviderPopupView.ui.xml
@@ -87,7 +87,7 @@
                                     <ge:StringEntityModelPasswordBoxEditor ui:field="passwordEditor" label="{constants.passwordProvider}" usePatternFly="true" labelColSize="SM_6" widgetColSize="SM_6" autocomplete="new-password" />
                                 </b:Row>
                                 <b:Row>
-                                    <e:ListModelListBoxEditor ui:field="authProtocolEditor" label="Protocol" usePatternFly="true" labelColSize="SM_6" widgetColSize="SM_6" />
+                                    <e:ListModelListBoxEditor ui:field="authProtocolEditor" label="{constants.authProtocol}" usePatternFly="true" labelColSize="SM_6" widgetColSize="SM_6" />
                                 </b:Row>
                                 <b:Row>
                                     <ge:StringEntityModelTextBoxEditor ui:field="authHostnameEditor" label="{constants.authHostName}"  usePatternFly="true" labelColSize="SM_6" widgetColSize="SM_6" />

--- a/frontend/webadmin/modules/webadmin/src/main/resources/org/ovirt/engine/ui/webadmin/ApplicationConstants.properties
+++ b/frontend/webadmin/modules/webadmin/src/main/resources/org/ovirt/engine/ui/webadmin/ApplicationConstants.properties
@@ -119,6 +119,7 @@ attachedNetwork=Attached
 attachedNetworkCluster=Attached Network
 attachedToVms=Attached to VMs
 authorizationProvider=Authorization provider
+authProtocol=Protocol
 authHostName=Host Name
 authPort=API Port
 authApiVersion=API Version


### PR DESCRIPTION
Fixes issue https://github.com/oVirt/ovirt-engine/issues/446

## Changes introduced with this PR

* Adapted the protocol label to use a constant instead of a hard coded string.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]