### PR TITLE
core: fix map to long overflow issue

### DIFF
--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/utils/HugePageUtils.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/utils/HugePageUtils.java
@@ -86,7 +86,7 @@ public class HugePageUtils {
 
     public static int totalHugePageMemMb(Map<Integer, Integer> hugepages) {
         long hugePageMemKb = hugepages.entrySet().stream()
-                .mapToLong(entry -> entry.getKey() * entry.getValue())
+                .mapToLong(entry -> (long) entry.getKey() * (long) entry.getValue())
                 .sum();
 
         return (int) ((hugePageMemKb + KIB_IN_MIB - 1) / KIB_IN_MIB);
@@ -98,7 +98,7 @@ public class HugePageUtils {
         }
 
         long hugePageMemKb = vds.getHugePages().stream()
-                .mapToLong(hugePage -> hugePage.getTotal() * hugePage.getSizeKB())
+                .mapToLong(hugePage -> (long) hugePage.getTotal() * (long) hugePage.getSizeKB())
                 .sum();
 
         return (int) ((hugePageMemKb + KIB_IN_MIB - 1) / KIB_IN_MIB);
@@ -110,7 +110,7 @@ public class HugePageUtils {
         }
 
         long hugePageMemKb = vds.getHugePages().stream()
-                .mapToLong(hugePage -> hugePage.getFree() * hugePage.getSizeKB())
+                .mapToLong(hugePage -> (long) hugePage.getFree() * (long) hugePage.getSizeKB())
                 .sum();
 
         return (int) ((hugePageMemKb + KIB_IN_MIB - 1) / KIB_IN_MIB);


### PR DESCRIPTION
## Changes introduced with this PR

* When calculating hugepage memory usage stats Integers were used. This caused negative numbers when exceeding 2TB, use explicit casts to long to combat this behaviour.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]