### PR TITLE
spec: add buildrequirement on maven-local-openjdk21

### DIFF
--- a/ovirt-engine.spec.in
+++ b/ovirt-engine.spec.in
@@ -194,7 +194,7 @@ ExcludeArch:	s390x ppc64le
 
 
 BuildRequires:  maven-openjdk21
-BuildRequires:	javapackages-tools
+BuildRequires:	maven-local-openjdk21
 BuildRequires:	make
 BuildRequires:	maven >= 3.6.0
 BuildRequires:	python3-devel


### PR DESCRIPTION
Add a BuildRequires to maven-local-openjdk21.
This can replace dependency on javapackages-tools as the maven-local-openjdk21 has it as requirement.
## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]