### PR TITLE
spec: drop ceph/collectd/cinderlib requirements on EL10

### DIFF
--- a/ovirt-engine.spec.in
+++ b/ovirt-engine.spec.in
@@ -243,6 +243,8 @@ Requires:	fapolicyd
 Requires:	scap-security-guide >= 0.1.60-4
 
 # Metrics stuff
+%if 0%{?rhel} < 10
+# collectd is not available anymore on EL10
 Requires:	collectd >= 5.12.0-7
 Requires:	collectd-postgresql >= 5.12.0-7
 Requires:	collectd-disk >= 5.12.0-7
@@ -250,6 +252,7 @@ Requires:	collectd-write_http >= 5.12.0-7
 %if 0%{?rhel}
 # collectd-write_syslog is available only on EL
 Requires:	collectd-write_syslog >= 5.12.0-7
+%endif
 %endif
 
 
@@ -287,9 +290,12 @@ Requires:	ovirt-dependencies >= 4.5.2
 
 # cinderlib integration
 # https://bugzilla.redhat.com/1955375
+# Not available (yet) on CentOS 10
+%if 0%{?rhel} < 10
 Requires:	ceph-common
 Requires:	python3-cinderlib
 Requires:	python3-urllib3
+%endif
 
 %{?extra_main_requires}
 


### PR DESCRIPTION
- Ceph: Currently not available (yet) for CentOS 10
- Cinderlib: Currently not available (yet) for CentOS 10
- collectd: Dropped in CentOS 10

Therefor we drop the hard requirement for them in the EL10 builds.

Fixes issue # (delete if not relevant)

## Changes introduced with this PR

*

*

*

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]