### PR TITLE
packaging: fix java-home with env vars

### DIFF
--- a/packaging/bin/java-home
+++ b/packaging/bin/java-home
@@ -17,7 +17,7 @@ validjre() {
 
 	if [ -x "${java_bin}" ]; then
 		local java_version=$("${java_bin}" -version 2>&1)
-		local java_major_version=$(echo "$java_version" | head -n 1 | awk '{print $3}' | tr -d '"' | cut -d. -f1)
+		local java_major_version=$(echo "$java_version" | grep "openjdk version" | awk '{print $3}' | tr -d '"' | cut -d. -f1)
 		if [ "$java_major_version" -ge 11 ] && echo "$java_version" | grep -q "OpenJDK"; then
 			ret=0
 		fi


### PR DESCRIPTION
## Changes introduced with this PR

The `java -version` command also prints environment vars that it picks up e.g.:
Picked up JAVA_TOOL_OPTIONS: -Dcom.redhat.fips=false

This breaks the script.
To prevent this, don't read the first line but read the line that actually has the version.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

y