### PR TITLE
core: add stringprep/scram to dependency

### DIFF
--- a/backend/manager/dependencies/common/pom.xml
+++ b/backend/manager/dependencies/common/pom.xml
@@ -135,6 +135,26 @@
     </dependency>
 
     <dependency>
+      <groupId>com.ongres.stringprep</groupId>
+      <artifactId>saslprep</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.ongres.stringprep</groupId>
+      <artifactId>stringprep</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.ongres.scram</groupId>
+      <artifactId>common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.ongres.scram</groupId>
+      <artifactId>client</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.woorea</groupId>
       <artifactId>openstack-client</artifactId>
     </dependency>
@@ -335,6 +355,30 @@
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
                 <moduleName>org.postgresql</moduleName>
+              </module>
+
+              <module>
+                <groupId>com.ongres.stringprep</groupId>
+                <artifactId>saslprep</artifactId>
+                <moduleName>com.ongres.stringprep.saslprep</moduleName>
+              </module>
+
+              <module>
+                <groupId>com.ongres.stringprep</groupId>
+                <artifactId>stringprep</artifactId>
+                <moduleName>com.ongres.stringprep.stringprep</moduleName>
+              </module>
+
+              <module>
+                <groupId>com.ongres.scram</groupId>
+                <artifactId>common</artifactId>
+                <moduleName>com.ongres.scram.common</moduleName>
+              </module>
+
+              <module>
+                <groupId>com.ongres.scram</groupId>
+                <artifactId>client</artifactId>
+                <moduleName>com.ongres.scram.client</moduleName>
               </module>
 
               <module>

--- a/backend/manager/dependencies/common/src/main/modules/com/ongres/scram/client/main/module.xml
+++ b/backend/manager/dependencies/common/src/main/modules/com/ongres/scram/client/main/module.xml
@@ -3,7 +3,7 @@
 <module xmlns="urn:jboss:module:1.1" name="com.ongres.scram.client">
 
     <resources>
-        <resource-root path="ongres-scram-client.jar"/>
+        <resource-root path="client.jar"/>
     </resources>
 
     <dependencies>

--- a/backend/manager/dependencies/common/src/main/modules/com/ongres/scram/common/main/module.xml
+++ b/backend/manager/dependencies/common/src/main/modules/com/ongres/scram/common/main/module.xml
@@ -3,13 +3,13 @@
 <module xmlns="urn:jboss:module:1.1" name="com.ongres.scram.common">
 
     <resources>
-        <resource-root path="ongres-scram-common.jar"/>
+        <resource-root path="common.jar"/>
     </resources>
 
     <dependencies>
         <module name="javax.api"/>
         <module name="javax.transaction.api"/>
-        <module name="com.ongres.saslprep" export="true"/>
+        <module name="com.ongres.stringprep.saslprep" export="true"/>
     </dependencies>
 
 </module>

--- a/backend/manager/dependencies/common/src/main/modules/com/ongres/stringprep/saslprep/main/module.xml
+++ b/backend/manager/dependencies/common/src/main/modules/com/ongres/stringprep/saslprep/main/module.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<module xmlns="urn:jboss:module:1.1" name="com.ongres.saslprep">
+<module xmlns="urn:jboss:module:1.1" name="com.ongres.stringprep.saslprep">
 
     <resources>
-        <resource-root path="ongres-saslprep.jar"/>
+        <resource-root path="saslprep.jar"/>
     </resources>
 
     <dependencies>
         <module name="javax.api"/>
         <module name="javax.transaction.api"/>
-        <module name="com.ongres.stringprep" export="true"/>
+        <module name="com.ongres.stringprep.stringprep" export="true"/>
     </dependencies>
 
 </module>

--- a/backend/manager/dependencies/common/src/main/modules/com/ongres/stringprep/stringprep/main/module.xml
+++ b/backend/manager/dependencies/common/src/main/modules/com/ongres/stringprep/stringprep/main/module.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<module xmlns="urn:jboss:module:1.1" name="com.ongres.stringprep">
+<module xmlns="urn:jboss:module:1.1" name="com.ongres.stringprep.stringprep">
 
     <resources>
-        <resource-root path="ongres-stringprep.jar"/>
+        <resource-root path="stringprep.jar"/>
     </resources>
 
     <dependencies>

--- a/ovirt-engine.spec.in
+++ b/ovirt-engine.spec.in
@@ -748,10 +748,10 @@ while read dst src; do
 	rm -f "%{buildroot}${dst}"
 	ln -s "${src}" "%{buildroot}${dst}"
 done << __EOF__
-common/com/ongres/saslprep/main/ongres-saslprep.jar ongres-stringprep/saslprep.jar
-common/com/ongres/scram/client/main/ongres-scram-client.jar ongres-scram/client.jar
-common/com/ongres/scram/common/main/ongres-scram-common.jar ongres-scram/common.jar
-common/com/ongres/stringprep/main/ongres-stringprep.jar ongres-stringprep/stringprep.jar
+common/com/ongres/stringprep/saslprep/main/saslprep.jar ongres-stringprep/saslprep.jar
+common/com/ongres/stringprep/stringprep/main/stringprep.jar ongres-stringprep/stringprep.jar
+common/com/ongres/scram/client/main/client.jar ongres-scram/client.jar
+common/com/ongres/scram/common/main/common.jar ongres-scram/common.jar
 common/com/woorea/openstack/sdk/main/cinder-client.jar openstack-java-sdk/cinder-client.jar
 common/com/woorea/openstack/sdk/main/cinder-model.jar openstack-java-sdk/cinder-model.jar
 common/com/woorea/openstack/sdk/main/glance-client.jar openstack-java-sdk/glance-client.jar

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,8 @@
     <mockito.version>3.8.0</mockito.version>
     <openstack-client.version>3.2.9</openstack-client.version>
     <postgres.jdbc.version>42.7.5</postgres.jdbc.version>
+    <ongres.stringprep.version>1.1</ongres.stringprep.version>
+    <ongres.scram.version>2.1</ongres.scram.version>
     <reflections.version>0.9.9</reflections.version>
     <resteasy.version>3.9.3.Final</resteasy.version>
     <slf4j.version>1.7.22</slf4j.version>
@@ -441,6 +443,26 @@
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
         <version>${postgres.jdbc.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.ongres.stringprep</groupId>
+        <artifactId>saslprep</artifactId>
+        <version>${ongres.stringprep.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.ongres.stringprep</groupId>
+        <artifactId>stringprep</artifactId>
+        <version>${ongres.stringprep.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.ongres.scram</groupId>
+        <artifactId>common</artifactId>
+        <version>${ongres.scram.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.ongres.scram</groupId>
+        <artifactId>client</artifactId>
+        <version>${ongres.scram.version}</version>
       </dependency>
       <dependency>
         <groupId>org.snmp4j</groupId>


### PR DESCRIPTION
Adding stringprep/saslprep and scram(client/common) as dependencies in the pom.
This is needed to fix local builds. Otherwise the jars for those modules are missing.

Next to that also rename stringprep and saslprep with the stringprep prefix as this is more clear they are in the same groupId.


## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]