### PR TITLE
Replace deprecated commands

### DIFF
--- a/packaging/bin/engine-backup.sh.in
+++ b/packaging/bin/engine-backup.sh.in
@@ -1653,7 +1653,7 @@ restoreDB() {
 
 	[ -n "${failed_msg}" ] && logdie "${failed_msg}"
 
-	local IGNORED_ERRORS=$(cat << __EOF | egrep -v '^$|^#' | tr '\012' '|' | sed 's/|$//'
+	local IGNORED_ERRORS=$(cat << __EOF | grep -Ev '^$|^#' | tr '\012' '|' | sed 's/|$//'
 language "plpgsql" already exists
 must be owner of language plpgsql
 must be owner of extension plpgsql


### PR DESCRIPTION
## Changes introduced with this PR
- Remove the usage of the deprecated `linux_distribution` method.
- replace egrep with grep -E

## Are you the owner of the code you are sending in, or do you have permission of the owner?

y