### PR TITLE
remove usage of deprecated Looseversion 

### DIFF
--- a/ovirt-engine.spec.in
+++ b/ovirt-engine.spec.in
@@ -407,6 +407,7 @@ Requires:	logrotate
 Requires:	python3-otopi >= 1.10.3
 Requires:	python3-paramiko
 Requires:	python3-distro
+Requires:	python3-looseversion
 Requires(pre):	shadow-utils
 Conflicts:	%{name}-dwh < 4.4.0
 Conflicts:	%{name}-dwh-setup < 4.5.6

--- a/packaging/bin/engine-backup.sh.in
+++ b/packaging/bin/engine-backup.sh.in
@@ -1127,7 +1127,7 @@ getOSVersion() {
 
 looseVersion_le() {
 	# return 0 if first arg is <= second arg
-	python@PY_VERSION@ -c 'import sys; from distutils.version import LooseVersion; sys.exit(0 if LooseVersion(sys.argv[1]) <= LooseVersion(sys.argv[2]) else 1)' "$1" "$2"
+	python@PY_VERSION@ -c 'import sys; from looseversion import LooseVersion; sys.exit(0 if LooseVersion(sys.argv[1]) <= LooseVersion(sys.argv[2]) else 1)' "$1" "$2"
 }
 
 createtar() {

--- a/packaging/setup/ovirt_engine_setup/engine_common/database.py
+++ b/packaging/setup/ovirt_engine_setup/engine_common/database.py
@@ -9,13 +9,14 @@
 
 import atexit
 import datetime
-import distutils.version
 import gettext
 import os
 import re
 import tempfile
 
 import psycopg2
+
+from looseversion import LooseVersion
 
 from otopi import base
 from otopi import constants as otopicons
@@ -488,7 +489,7 @@ class OvirtUtils(base.Base):
         password=None,
         database=None,
     ):
-        server_v = distutils.version.LooseVersion(
+        server_v = LooseVersion(
             self.checkServerVersion(
                 host,
                 port,
@@ -498,7 +499,7 @@ class OvirtUtils(base.Base):
                 database,
             )
         ).version[:2]
-        client_v = distutils.version.LooseVersion(
+        client_v = LooseVersion(
             self.checkClientVersion()
         ).version[:2]
         return server_v < client_v

--- a/packaging/setup/plugins/ovirt-engine-remove/base/core/misc.py
+++ b/packaging/setup/plugins/ovirt-engine-remove/base/core/misc.py
@@ -10,9 +10,10 @@
 """Engine plugin."""
 
 
-import distutils.version
 import gettext
 import os
+
+from looseversion import LooseVersion
 
 from otopi import constants as otopicons
 from otopi import plugin
@@ -94,10 +95,10 @@ class Plugin(plugin.PluginBase):
                 _('Could not detect product setup')
             )
 
-        rpm_v = distutils.version.LooseVersion(
+        rpm_v = LooseVersion(
             osetupcons.Const.RPM_VERSION
         ).version[:3]
-        inst_v = distutils.version.LooseVersion(
+        inst_v = LooseVersion(
             self.environment[
                 osetupcons.CoreEnv.ORIGINAL_GENERATED_BY_VERSION
             ]


### PR DESCRIPTION
## Changes introduced with this PR

- Add python3-looseversion dependency. This is a drop-in replacement for the
  deprecated distutils.version.LooseVersion. We prefer looseversion above
  packaging.version.Version. The latter is meant to compare python package versions that
  adhere to PEP-440. We are not strictly comparing python packages, so if we use
  the strict "packaging" implementation we could encounter unexpected errors.
- Change the imports from distutils.version to loosversion where needed.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

y