### PR TITLE
packaging: fix restore on postgresql 16+

### DIFF
--- a/packaging/bin/engine-backup.sh.in
+++ b/packaging/bin/engine-backup.sh.in
@@ -1663,6 +1663,13 @@ must be owner of extension uuid-ossp
 schema "public" already exists
 must be owner of schema public
 must be member of role "postgres"
+# The following command:
+# ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public GRANT SELECT ON TABLES  TO ovirt_engine_history_grafana;
+# gives the next error
+# We add those privileges via dwh install, so safe to ignore here.
+# This is changed since PostgreSQL 16:
+# https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=48a257d444a787941ba3da24d65e6cbe31461d0a
+permission denied to change default privileges
 #
 # engine uses uuid-ossp PG extension, which requires special privs,
 permission denied for language c

--- a/packaging/setup/ovirt_engine_setup/engine_common/database.py
+++ b/packaging/setup/ovirt_engine_setup/engine_common/database.py
@@ -821,6 +821,8 @@ class OvirtUtils(base.Base):
         # This happens because we do some GRANTs for grafana's user on dwh db,
         # but dwh db user has no right to do them itself:
         'must be member of role "postgres"',
+        # On PostgreSQL 16+ this gives the following error:
+        'permission denied to change default privileges',
     )
 
     _RE_IGNORED_ERRORS = re.compile(


### PR DESCRIPTION
When restoring default privileges on PostgreSQL 16+, the error message has changed from 'must be member of role "postgres"' to 'permission denied to change default privileges'. [1]

We need to add this to ignored errors, otherwise the restore of the dwh database fails. As default privileges are added there.

1: https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=48a257d444a787941ba3da24d65e6cbe31461d0a

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]