### PR TITLE
core: set audio value to ich9 starting from rhel7

### DIFF
--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/VmDeviceGeneralType.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/VmDeviceGeneralType.java
@@ -167,6 +167,7 @@ public enum VmDeviceGeneralType {
             case SOUND:
             case AC97:
             case ICH6:
+            case ICH9:
                 type = SOUND;
                 break;
 

--- a/packaging/conf/osinfo-defaults.properties
+++ b/packaging/conf/osinfo-defaults.properties
@@ -175,13 +175,16 @@ os.rhel_6x64.devices.diskInterfaces.value = i440fx/IDE, VirtIO_SCSI, VirtIO, q35
 os.rhel_6x64.resources.minimum.ram.value = 1024
 os.rhel_6x64.resources.maximum.ram.value = 4194304
 
+# rhel7x64(24, OSType.Linux),
 os.rhel_7x64.id.value = 24
 os.rhel_7x64.name.value = Red Hat Enterprise Linux 7.x x64
 os.rhel_7x64.derivedFrom.value = rhel_6x64
+os.rhel_7x64.devices.audio.value.4.8 = ich6,q35/ich9
 os.rhel_7x64.devices.memoryHotplug.specialBlock.value = true
 os.rhel_7x64.devices.legacyVirtio.value = false
 os.rhel_7x64.devices.tpm.value = supported
 
+# rhel8x64(30, OsType.Linux),
 os.rhel_8x64.id.value = 30
 os.rhel_8x64.name.value = Red Hat Enterprise Linux 8.x x64
 os.rhel_8x64.derivedFrom.value = rhel_7x64
@@ -195,6 +198,7 @@ os.rhel_9x64.derivedFrom.value = rhel_8x64
 
 # rhel10x64(39, OsType.Linux)
 os.rhel_10x64.id.value = 39
+os.rhel_10x64.devices.audio.value = ich6,q35/ich9
 os.rhel_10x64.name.value = Red Hat Enterprise Linux 10.x x64
 os.rhel_10x64.derivedFrom.value = rhel_9x64
 


### PR DESCRIPTION
## Changes introduced with this PR

ich6 was set as audio device starting from rhel6.
ich9 is available starting from rhel7: https://bugzilla.redhat.com/show_bug.cgi?id=1140937.
 ICH6 is a PCI based device, while ICH9 is a PCIe based device. Therefor we prefer to use ICH9 on Q35, as otherwise there is an additional pcie-to-pci controller added.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]