### PR TITLE
dependencies: add deps for apache-commons-compress

### DIFF
--- a/backend/manager/dependencies/common/pom.xml
+++ b/backend/manager/dependencies/common/pom.xml
@@ -36,6 +36,21 @@
     </dependency>
 
     <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.sshd</groupId>
       <artifactId>sshd-common</artifactId>
     </dependency>
@@ -253,6 +268,24 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
                 <moduleName>org.apache.commons.compress</moduleName>
+              </module>
+
+              <module>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <moduleName>org.apache.commons.codec</moduleName>
+              </module>
+
+              <module>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <moduleName>org.apache.commons.io</moduleName>
+              </module>
+
+              <module>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <moduleName>org.apache.commons.lang3</moduleName>
               </module>
 
               <module>

--- a/backend/manager/dependencies/common/src/main/modules/org/apache/commons/codec/main/module.xml
+++ b/backend/manager/dependencies/common/src/main/modules/org/apache/commons/codec/main/module.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Not using the Wildfly build-in version as it's too old -->
+<module xmlns="urn:jboss:module:1.1" name="org.apache.commons.codec">
+  <resources>
+    <resource-root path="commons-codec.jar"/>
+  </resources>
+</module>

--- a/backend/manager/dependencies/common/src/main/modules/org/apache/commons/compress/main/module.xml
+++ b/backend/manager/dependencies/common/src/main/modules/org/apache/commons/compress/main/module.xml
@@ -4,4 +4,11 @@
   <resources>
     <resource-root path="commons-compress.jar"/>
   </resources>
+
+  <!-- Optional because these dependencies are not required on CentOS 9 -->
+  <dependencies>
+    <module name="org.apache.commons.codec" optional="true"/>
+    <module name="org.apache.commons.io" optional="true"/>
+    <module name="org.apache.commons.lang3" optional="true"/>
+  </dependencies>
 </module>

--- a/backend/manager/dependencies/common/src/main/modules/org/apache/commons/io/main/module.xml
+++ b/backend/manager/dependencies/common/src/main/modules/org/apache/commons/io/main/module.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Not using the Wildfly build-in version as it's too old -->
+<module xmlns="urn:jboss:module:1.1" name="org.apache.commons.io">
+  <resources>
+    <resource-root path="commons-io.jar"/>
+  </resources>
+</module>

--- a/backend/manager/dependencies/common/src/main/modules/org/apache/commons/lang3/main/module.xml
+++ b/backend/manager/dependencies/common/src/main/modules/org/apache/commons/lang3/main/module.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Not using the Wildfly build-in version as it's too old -->
+<module xmlns="urn:jboss:module:1.1" name="org.apache.commons.lang3">
+  <resources>
+    <resource-root path="commons-lang3.jar"/>
+  </resources>
+</module>

--- a/i18n/pom.xml
+++ b/i18n/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.5</version>
+      <version>${commons-lang3.version}</version>
     </dependency>
 
     <dependency>

--- a/ovirt-engine.spec.in
+++ b/ovirt-engine.spec.in
@@ -768,6 +768,9 @@ common/com/woorea/openstack/sdk/main/resteasy-connector.jar openstack-java-sdk/r
 common/net/i2p/crypto/eddsa/main/eddsa.jar
 common/org/aopalliance/main/aopalliance.jar
 common/org/apache/commons/compress/main/commons-compress.jar
+common/org/apache/commons/codec/main/commons-codec.jar
+common/org/apache/commons/io/main/commons-io.jar
+common/org/apache/commons/lang3/main/commons-lang3.jar
 common/org/apache/sshd/main/sshd-core.jar apache-sshd/sshd-core.jar
 common/org/apache/sshd/main/sshd-common.jar apache-sshd/sshd-common.jar
 common/org/apache/ws/commons/main/ws-commons-util.jar

--- a/pom.xml
+++ b/pom.xml
@@ -56,11 +56,13 @@
     <checkstyle.version>10.20.0</checkstyle.version>
     <commons-beanutils.version>1.9.4</commons-beanutils.version>
     <commons-cli.version>1.3.1</commons-cli.version>
-    <commons-codec.version>1.10</commons-codec.version>
+    <commons-codec.version>1.17.1</commons-codec.version>
     <commons-collections.version>3.2.2</commons-collections.version>
-    <commons-compress.version>1.21</commons-compress.version>
+    <commons-compress.version>1.27.1</commons-compress.version>
     <commons-configuration.version>1.6</commons-configuration.version>
+    <commons-io.version>2.16.1</commons-io.version>
     <commons-lang.version>2.6</commons-lang.version>
+    <commons-lang3.version>3.14.0</commons-lang3.version>
     <cors-filter.version>1.0.1</cors-filter.version>
     <cxf.version>2.2.7</cxf.version>
     <dbunit.version>2.7.3</dbunit.version>
@@ -276,6 +278,11 @@
         <version>${commons-codec.version}</version>
       </dependency>
       <dependency>
+        <groupId>commons-io</groupId>
+        <artifactId>commons-io</artifactId>
+        <version>${commons-io.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.dbunit</groupId>
         <artifactId>dbunit</artifactId>
         <version>${dbunit.version}</version>
@@ -473,6 +480,11 @@
         <groupId>commons-lang</groupId>
         <artifactId>commons-lang</artifactId>
         <version>${commons-lang.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>${commons-lang3.version}</version>
       </dependency>
       <dependency>
         <groupId>commons-cli</groupId>


### PR DESCRIPTION
Since apache-commons-compress 1.26.0, it depends on apache-commons-io / codec and lang3.
As the version in CentOS 10 is 1.27.1 and on CentOS 9 its 1.21, we add the dependencies as optional. This to make sure it just loads on CentOS 9 without the dependencies installed, while on CentOS 10 it will load them. As those are dependencies on the package itself.

All 3 dependencies are also available on the Wildfly base libs, but these are too old, which causes NoSuchClass exceptions when relying on those. Therefore we use the versions shipped via rpm.


## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]