### PR TITLE
packaging: fix yaml call in extract_ova.py

### DIFF
--- a/packaging/ansible-runner-service-project/project/roles/ovirt-ova-extract/files/extract_ova.py
+++ b/packaging/ansible-runner-service-project/project/roles/ovirt-ova-extract/files/extract_ova.py
@@ -135,4 +135,5 @@ if len(sys.argv) < 4:
     print("Usage: extract_ova.py ova_path disks_paths image_mappings")
     sys.exit(2)
 
-extract_disks(sys.argv[1], json.loads(sys.argv[2]), yaml.load(sys.argv[3]))
+extract_disks(sys.argv[1], json.loads(sys.argv[2]),
+              yaml.load(sys.argv[3], Loader=yaml.SafeLoader))


### PR DESCRIPTION
PyYaml removed the yaml.load(arg1) call, and requires to explicitly add a Loader type. [1]

1: https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]