### PR TITLE
packaging: add icons for new operating systems

### DIFF
--- a/packaging/icons/large/rhel_10x64.png
+++ b/packaging/icons/large/rhel_10x64.png
@@ -1,0 +1,1 @@
+originals/rhel.png

--- a/packaging/icons/large/windows_2025.png
+++ b/packaging/icons/large/windows_2025.png
@@ -1,0 +1,1 @@
+originals/windows.png

--- a/packaging/icons/small/rhel_10x64.png
+++ b/packaging/icons/small/rhel_10x64.png
@@ -1,0 +1,1 @@
+originals/rhel.png

--- a/packaging/icons/small/windows_2025.png
+++ b/packaging/icons/small/windows_2025.png
@@ -1,0 +1,1 @@
+originals/windows.png


### PR DESCRIPTION
## Changes introduced with this PR

* Since the last release rhel 10 and windows 2025 were added as OS for VM's. Reuse icons used for other OS's in the same family to reduce visual errors on the VM Portal.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]