### PR TITLE
packaging: update deprecated ssl functionality

### DIFF
--- a/packaging/libexec/ovirt-vmconsole-proxy-helper/ovirt-vmconsole-list.py.in
+++ b/packaging/libexec/ovirt-vmconsole-proxy-helper/ovirt-vmconsole-list.py.in
@@ -64,13 +64,12 @@ def urlopen(url, ca_certs=None, verify_host=True):
                 HTTPSConnection.__init__(self, host, **kwargs)
 
             def connect(self):
-                self.sock = ssl.wrap_socket(
-                    socket.create_connection((self.host, self.port)),
-                    cert_reqs=(
-                        ssl.CERT_REQUIRED if self._ca_certs
-                        else ssl.CERT_NONE
-                    ),
-                    ca_certs=self._ca_certs,
+                context = ssl.SSLContext()
+                if self._ca_certs:
+                    context.load_verify_locations(cafile=self._ca_certs)
+                    context.verify_mode = ssl.CERT_REQUIRED
+                self.sock = context.wrap_socket(
+                    socket.create_connection((self.host, self.port))
                 )
                 if verify_host:
                     cert = self.sock.getpeercert()

--- a/packaging/services/ovirt-websocket-proxy/ovirt-websocket-proxy.py.in
+++ b/packaging/services/ovirt-websocket-proxy/ovirt-websocket-proxy.py.in
@@ -208,7 +208,8 @@ class VenCryptSocket(object):
         # Do a regular TLS negotiation
         self.log.info(
             "VeNCrypt negotiation succeeded. Setting up TLS connection")
-        self.sock = ssl.wrap_socket(self.sock)
+        context = ssl.SSLContext()
+        self.sock = context.wrap_socket(self.sock)
         self.log.info("VeNCrypt negotiation done")
 
 


### PR DESCRIPTION
## Changes introduced with this PR

* Replace deprecated ssl.wrap_socket with ssl.SSLContext for Python 3.12

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]