### PR TITLE
pom: build compress and deps on oldest runtime version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,13 +56,13 @@
     <checkstyle.version>10.20.0</checkstyle.version>
     <commons-beanutils.version>1.9.4</commons-beanutils.version>
     <commons-cli.version>1.3.1</commons-cli.version>
-    <commons-codec.version>1.17.1</commons-codec.version>
+    <commons-codec.version>1.15</commons-codec.version>
     <commons-collections.version>3.2.2</commons-collections.version>
-    <commons-compress.version>1.27.1</commons-compress.version>
+    <commons-compress.version>1.21</commons-compress.version>
     <commons-configuration.version>1.6</commons-configuration.version>
-    <commons-io.version>2.16.1</commons-io.version>
+    <commons-io.version>2.8.0</commons-io.version>
     <commons-lang.version>2.6</commons-lang.version>
-    <commons-lang3.version>3.14.0</commons-lang3.version>
+    <commons-lang3.version>3.12.0</commons-lang3.version>
     <cors-filter.version>1.0.1</cors-filter.version>
     <cxf.version>2.2.7</cxf.version>
     <dbunit.version>2.7.3</dbunit.version>


### PR DESCRIPTION
We need to build against the oldest runtime versions that we support. So we need to use the versions used in RHEL9/CentOS9.

This because otherwise code can be incompatible with the library version installed by the OS.


## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]