### PR TITLE
db: update type of cpu_flags field

### DIFF
--- a/packaging/dbscripts/upgrade/04_05_0310_alter_type_cpu_flags.sql
+++ b/packaging/dbscripts/upgrade/04_05_0310_alter_type_cpu_flags.sql
@@ -1,0 +1,1 @@
+SELECT fn_db_change_column_type('vds_dynamic','cpu_flags','VARCHAR','TEXT');

--- a/packaging/dbscripts/vds_sp.sql
+++ b/packaging/dbscripts/vds_sp.sql
@@ -223,7 +223,7 @@ CREATE OR REPLACE FUNCTION InsertVdsDynamic (
     v_version_name VARCHAR(40),
     v_build_name VARCHAR(40),
     v_previous_status INT,
-    v_cpu_flags VARCHAR(4000),
+    v_cpu_flags TEXT,
     v_pending_vcpus_count INT,
     v_pending_vmem_size INT,
     v_cpu_sockets INT,
@@ -488,7 +488,7 @@ CREATE OR REPLACE FUNCTION UpdateVdsDynamic (
     v_version_name VARCHAR(40),
     v_build_name VARCHAR(40),
     v_previous_status INT,
-    v_cpu_flags VARCHAR(4000),
+    v_cpu_flags TEXT,
     v_pending_vcpus_count INT,
     v_pending_vmem_size INT,
     v_cpu_sockets INT,
@@ -1530,7 +1530,7 @@ LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION UpdateCpuFlags (
     v_vds_id UUID,
-    v_cpu_flags VARCHAR(4000)
+    v_cpu_flags TEXT
     )
 RETURNS VOID AS $FUNCTION$
 BEGIN


### PR DESCRIPTION
Fixes issue # https://github.com/oVirt/ovirt-engine/issues/1048

## Changes introduced with this PR

* Cluster has a column cpu_flags with type text while a host has the same column but with type varchar(4000). Making these two columns the same solves issues regarding cpu flags longer then 4000 characters.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]