### PR TITLE
core: fix ova export of TPM and NVRAM data

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/CreateOvaCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/CreateOvaCommand.java
@@ -207,8 +207,8 @@ public class CreateOvaCommand<T extends CreateOvaParameters> extends CommandBase
         vars.put("ova_name", getParameters().getName());
         vars.put("ovirt_ova_pack_ovf", encodedOvf);
         vars.put("ovirt_ova_pack_disks", genDiskParameters(disks, diskIdToPath));
-        vars.put("ovirt_ova_pack_tpm", tpmData);
-        vars.put("ovirt_ova_pack_nvram", nvramData);
+        vars.put("ovirt_ova_pack_tpm", tpmData.getValue());
+        vars.put("ovirt_ova_pack_nvram", nvramData.getValue());
         vars.put("ovirt_ova_pack_padding", Boolean.toString(compatibilityVersion.greater(Version.v4_6)));
         params.setVariables(vars);
         return params;


### PR DESCRIPTION
Since commit 6c486456921699e43c85c2d7babcb5d89bddd57d, the TPM and NVRAM data are SecretValue's.

But we need to pass the 'unprotected' string value to the ansible runner to pack the OVA.
Otherwise the data gets packaged in to '{ value : "str" }' format, which is unreadable.

Fixes issue #973

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]