### PR TITLE
webadmin: set the VNC graphics type to Bochs display type

### DIFF
--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/UnitVmModel.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/UnitVmModel.java
@@ -2869,6 +2869,11 @@ public class UnitVmModel extends Model implements HasValidatedTabs, ModelWithMig
             }
         }
 
+        // For Bochs, only VNC is ALWAYS supplied
+        if (getDisplayType().getSelectedItem() == DisplayType.bochs) {
+            graphicsTypes.retainAll(Collections.singleton(GraphicsTypes.VNC));
+        }
+
         if (graphicsTypes.contains(GraphicsTypes.SPICE) && graphicsTypes.contains(GraphicsTypes.VNC)) {
             graphicsTypes.add(GraphicsTypes.SPICE_AND_VNC);
         }
@@ -2889,6 +2894,32 @@ public class UnitVmModel extends Model implements HasValidatedTabs, ModelWithMig
         GraphicsTypes graphics = getGraphicsType().getSelectedItem();
 
         if (display == null || graphics == null) {
+            return;
+        }
+
+        // For the Bochs display leave only VNC
+        if (display == DisplayType.bochs) {
+            Set<GraphicsTypes> allowedGraphics = new LinkedHashSet<>();
+            allowedGraphics.add(GraphicsTypes.VNC);
+
+            GraphicsTypes currentSelected = getGraphicsType().getSelectedItem();
+            if (allowedGraphics.contains(currentSelected)) {
+                getGraphicsType().setItems(allowedGraphics, currentSelected);
+            } else {
+                getGraphicsType().setItems(allowedGraphics);
+                getGraphicsType().setSelectedItem(GraphicsTypes.VNC);
+            }
+
+            // Disabling SPICE-specific settings
+            getIsUsbEnabled().setEntity(false);
+            getIsSmartcardEnabled().setEntity(false);
+            getIsUsbEnabled().setIsChangeable(false);
+            getIsSmartcardEnabled().setIsChangeable(false);
+
+            // Updating VNC layout availability
+            getVncKeyboardLayout().setIsAvailable(true);
+
+            updateNumOfMonitors();
             return;
         }
 


### PR DESCRIPTION
If you select a Q35 Chipset OS with UEFI as the default when creating a new virtual machine, the default display type will be Bochs and the wrong graphics type — SPICE + VNC. Bochs only works with VNC. The SPICE graphics type supports a different display type — QXL.

Example: let's select Windows 11 as the default OS with the Q35 Chipset with UEFI. Display type - bochs, graphics type - SPICE + VNC.
<img width="934" height="818" alt="image" src="https://github.com/user-attachments/assets/18eb0dfe-b357-43cf-b086-87528cef1431" />

When trying to create a virtual machine, we receive the error: "Selected display type is not supported by the operating system."
<img width="498" height="399" alt="image" src="https://github.com/user-attachments/assets/4921d490-8cdc-47db-8cde-aca638145d74" />

From this article(https://www.ovirt.org/develop/release-management/features/virt/bochs-display.html) it follows that Bochs is recommended and selected by default for virtual machines with UEFI, which is the Windows 11 example.
In the current implementation, for virtual machines with UEFI, Bochs is selected, but with the wrong graphics protocol (SPICE + VNC). The SPICE graphics type supports a different display type — QXL. Therefore, a decision was made to set the VNC graphics type to Bochs display type as the default value.

Outcome: display type - bochs, graphics type - VNC.
<img width="931" height="821" alt="image" src="https://github.com/user-attachments/assets/6620a936-c6a3-437e-b083-694f90f21cb9" />

Successfully created virtual machine:
<img width="772" height="34" alt="image" src="https://github.com/user-attachments/assets/c83dfe17-157f-4e0f-93c7-ad9370d43d3a" />

## Changes introduced with this PR

* set the VNC graphics type to Bochs display type as the default value
## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]