### PR TITLE
core: fix boolean values in CloudInit

### DIFF
--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/CloudInitHandler.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/CloudInitHandler.java
@@ -191,7 +191,7 @@ public class CloudInitHandler {
     private void storeRegenerateKeys() {
         if (vmInit.getRegenerateKeys() != null) {
             // Create new system ssh keys
-            userData.put("ssh_deletekeys", String.valueOf(vmInit.getRegenerateKeys()));
+            userData.put("ssh_deletekeys", vmInit.getRegenerateKeys());
         }
     }
 
@@ -300,7 +300,7 @@ public class CloudInitHandler {
         metaData.put("launch_index", "0");
         metaData.put("availability_zone", "nova");
 
-        userData.put("disable_root", 0);
+        userData.put("disable_root", false);
 
         // Redirect log output from cloud-init execution from terminal
         Map<String, String> output = new HashMap<>();


### PR DESCRIPTION
disable_root and ssh_deletekeys should be booleans instead of 0/string. This gives a schema error in cloud-init otherwise.

Fixes: #889

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]