### PR TITLE
ui: convert dates to iso standard to restore filtering on date for events

### DIFF
--- a/backend/manager/modules/searchbackend/src/main/java/org/ovirt/engine/core/searchbackend/BaseConditionFieldAutoCompleter.java
+++ b/backend/manager/modules/searchbackend/src/main/java/org/ovirt/engine/core/searchbackend/BaseConditionFieldAutoCompleter.java
@@ -1,7 +1,6 @@
 package org.ovirt.engine.core.searchbackend;
 
 import java.math.BigDecimal;
-import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -272,12 +271,12 @@ public class BaseConditionFieldAutoCompleter extends BaseAutoCompleter implement
                 pair.setFirst("between");
                 DateTime nextDay = result.addDays(1);
                 pair.setSecond(StringFormat.format("'%1$s' and '%2$s'",
-                        result.toString(DateUtils.getFormat(DateFormat.DEFAULT, DateFormat.SHORT)),
-                        nextDay.toString(DateUtils.getFormat(DateFormat.DEFAULT, DateFormat.SHORT))));
+                        DateUtils.toIsoFormat(result),
+                        DateUtils.toIsoFormat(nextDay)));
             } else { // ">" or "<"
                      // value.argvalue = String.format("'%1$s'", result);
                 pair.setSecond(StringFormat.format("'%1$s'",
-                        result.toString(DateUtils.getFormat(DateFormat.DEFAULT, DateFormat.SHORT))));
+                        DateUtils.toIsoFormat(result)));
             }
 
         } else if ("TAG".equals(fieldName)) {

--- a/backend/manager/modules/searchbackend/src/main/java/org/ovirt/engine/core/searchbackend/DateUtils.java
+++ b/backend/manager/modules/searchbackend/src/main/java/org/ovirt/engine/core/searchbackend/DateUtils.java
@@ -34,12 +34,16 @@ class DateUtils {
         formats.add(getFormat(style, style));
     }
 
-    public static DateFormat getFormat(int dateStyle) {
+    private static DateFormat getFormat(int dateStyle) {
         return DateFormat.getDateInstance(dateStyle);
     }
 
-    public static DateFormat getFormat(int dateStyle, int timeStyle) {
+    private static DateFormat getFormat(int dateStyle, int timeStyle) {
         return DateFormat.getDateTimeInstance(dateStyle, timeStyle);
+    }
+
+    public static String toIsoFormat(DateTime date) {
+        return date.toInstant().toString();
     }
 
     public static String getDayOfWeek(int addDays) {

--- a/backend/manager/modules/searchbackend/src/test/java/org/ovirt/engine/core/searchbackend/AuditLogConditionFieldAutoCompleterTest.java
+++ b/backend/manager/modules/searchbackend/src/test/java/org/ovirt/engine/core/searchbackend/AuditLogConditionFieldAutoCompleterTest.java
@@ -6,9 +6,11 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
+import java.util.TimeZone;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -45,7 +47,8 @@ public class AuditLogConditionFieldAutoCompleterTest {
         String dateString = DateFormat.getDateInstance(DateFormat.SHORT).format(date);
         pair.setSecond(dateString);
         comp.formatValue("TIME", pair, false);
-        DateFormat fmt = DateFormat.getDateTimeInstance(DateFormat.DEFAULT, DateFormat.SHORT);
+        SimpleDateFormat fmt = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        fmt.setTimeZone(TimeZone.getDefault());
         assertEquals(quote(fmt.format(date)), pair.getSecond());
         pair.setSecond("1");
         comp.formatValue("TIME", pair, false);

--- a/frontend/webadmin/modules/gwt-extension/src/main/java/org/ovirt/engine/ui/uioverrides/org/ovirt/engine/core/searchbackend/DateUtils.java
+++ b/frontend/webadmin/modules/gwt-extension/src/main/java/org/ovirt/engine/ui/uioverrides/org/ovirt/engine/core/searchbackend/DateUtils.java
@@ -19,7 +19,7 @@ class DateUtils {
         return null;
     }
 
-    public static DateTimeFormat getFormat(int dateStyle) {
+    private static DateTimeFormat getFormat(int dateStyle) {
         switch (dateStyle) {
             case DateFormat.FULL:
                 return DateTimeFormat.getFormat(PredefinedFormat.DATE_FULL);
@@ -32,7 +32,7 @@ class DateUtils {
         }
     }
 
-    public static DateTimeFormat getFormat(int dateStyle, int timeStyle) {
+    private static DateTimeFormat getFormat(int dateStyle, int timeStyle) {
         switch (timeStyle) {
             case DateFormat.FULL:
                 return DateTimeFormat.getFormat(PredefinedFormat.DATE_TIME_FULL);
@@ -43,6 +43,11 @@ class DateUtils {
             default:
                 return DateTimeFormat.getFormat(PredefinedFormat.DATE_TIME_MEDIUM);
         }
+    }
+
+    //No need to transform to ISO format on frontend
+    public static String toIsoFormat(DateTime date) {
+        return null;
     }
 
     public static String getDayOfWeek(int addDays) {


### PR DESCRIPTION
Fixes issue https://github.com/oVirt/ovirt-engine/issues/1096

## Changes introduced with this PR

* Since JDK 20 the space between AM/PM and the rest of the timestamp has changed to a NARROW NO-BREAK SPACE (U+202F) talked about here: https://bugs.openjdk.org/browse/JDK-8324308 and here https://unicode-org.atlassian.net/browse/CLDR-15667, which caused parsing errors for PostgreSQL. To combat this issue, ensure that when comparing dates against each other ISO-8601 date time formats are used.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]