### PR TITLE
webadmin: remove ie10 from all-user-agents list

### DIFF
--- a/frontend/webadmin/modules/pom.xml
+++ b/frontend/webadmin/modules/pom.xml
@@ -138,7 +138,7 @@
       <id>all-user-agents</id>
       <properties>
         <!-- See [gwt-user.jar:com/google/gwt/useragent/UserAgent.gwt.xml] for a complete list -->
-        <gwt.userAgent>ie10,gecko1_8,safari</gwt.userAgent>
+        <gwt.userAgent>gecko1_8,safari</gwt.userAgent>
       </properties>
     </profile>
     <profile>


### PR DESCRIPTION
## Changes introduced with this PR

If BUILD_ALL_USER_AGENTS is set to 1 it builds with the all-user-agents list.
 After the gwt version bump in https://github.com/oVirt/ovirt-engine/commit/db75424f2bcc the used gwt version went from 2.9.0 to 2.12.1. 
In this newer version support was dropped to build for ie10, to ensure builds are still possible it needed to be removed from the list.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]