### PR TITLE
core: set Unknown status for network error during vm create

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/RunVmCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/RunVmCommand.java
@@ -312,7 +312,12 @@ public class RunVmCommand<T extends RunVmParams> extends RunVmCommandBase<T>
                         cleanupPassthroughVnics();
                         reportCompleted();
                         throw e;
-                    case VDS_NETWORK_ERROR: // probably wrong xml format sent.
+                    case VDS_NETWORK_ERROR:
+                        resourceManager.setVmUnknown(getVm());
+                        getVm().setRunOnVds(getVdsId());
+                        cleanupPassthroughVnics();
+                        reportCompleted();
+                        throw e;
                     case PROVIDER_FAILURE:
                     case HOST_DEVICES_TAKEN_BY_OTHER_VM:
                     case INVALID_HA_VM_LEASE:

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/startup/recovery/RecoveryStartupBean.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/startup/recovery/RecoveryStartupBean.java
@@ -105,6 +105,7 @@ final class RecoveryStartupBean {
         for (VM vm : vms) {
             if (!vm.isNotRunning()) {
                 if (vm.getRunOnVds() != null && hostIds.contains(vm.getRunOnVds())) {
+                    resourceManager.removeAsyncRunningVm(vm.getId());
                     resourceManager.setVmUnknown(vm);
                 }
             }

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/ResourceManager.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/ResourceManager.java
@@ -240,7 +240,6 @@ public class ResourceManager implements BackendService {
      * Set vm status to Unknown and save to DB.
      */
     public void setVmUnknown(VM vm) {
-        removeAsyncRunningVm(vm.getId());
         internalSetVmStatus(vm.getDynamicData(), VMStatus.Unknown);
         // log VM transition to unknown status
         AuditLogable logable = new AuditLogableImpl();

--- a/backend/manager/modules/vdsbroker/src/test/java/org/ovirt/engine/core/vdsbroker/monitoring/VmTestPairs.java
+++ b/backend/manager/modules/vdsbroker/src/test/java/org/ovirt/engine/core/vdsbroker/monitoring/VmTestPairs.java
@@ -102,6 +102,44 @@ public enum VmTestPairs {
         Pair<VM, VdsmVm> build() {
             return pairOf(null, createVmInternalData(VMStatus.Paused));
         }
+    },
+    VM_UNKNOWN_ACTUALLY_RUNNING("E") {
+        @Override
+        Pair<VM, VdsmVm> build() {
+            Pair<VM, VdsmVm> pair = createPair();
+            setPairStatuses(pair, VMStatus.Unknown, VMStatus.Up);
+            return pair;
+        }
+    },
+    VM_UNKNOWN_NOT_FOUND_ON_HOST("F") {
+        @Override
+        Pair<VM, VdsmVm> build() {
+            VM dbVm = createDbVm();
+            dbVm.setStatus(VMStatus.Unknown);
+            dbVm.setRunOnVds(SRC_HOST_ID);
+            return pairOf(dbVm, null);
+        }
+    },
+    VM_UNKNOWN_CRASHED("10") {
+        @Override
+        Pair<VM, VdsmVm> build() {
+            Pair<VM, VdsmVm> pair = createPair();
+            pair.getFirst().setStatus(VMStatus.Unknown);
+            pair.getFirst().setRunOnVds(SRC_HOST_ID);
+            pair.getSecond().getVmDynamic().setStatus(VMStatus.Down);
+            pair.getSecond().getVmDynamic().setExitStatus(VmExitStatus.Error);
+            return pair;
+        }
+    },
+    VM_UNKNOWN_WAITING_FOR_LAUNCH("11") {
+        @Override
+        Pair<VM, VdsmVm> build() {
+            Pair<VM, VdsmVm> pair = createPair();
+            pair.getFirst().setStatus(VMStatus.Unknown);
+            pair.getFirst().setRunOnVds(SRC_HOST_ID);
+            pair.getSecond().getVmDynamic().setStatus(VMStatus.WaitForLaunch);
+            return pair;
+        }
     };
     public static final Guid DST_HOST_ID = Guid.newGuid();
     public static final Guid SRC_HOST_ID = Guid.newGuid();
@@ -111,7 +149,8 @@ public enum VmTestPairs {
     private Pair<VM, VdsmVm> pair;
 
     VmTestPairs(String id) {
-        this.id = Guid.createGuidFromString(id + "0000000-0000-0000-0000-000000000000");
+        String paddedId = String.format("%8s", id).replace(' ', '0');
+        this.id = Guid.createGuidFromString(paddedId + "-0000-0000-0000-000000000000");
         pair = build();
     }
 
@@ -212,7 +251,7 @@ public enum VmTestPairs {
         return vm;
     }
 
-    private void setPairStatuses(Pair<VM, VdsmVm> pair, VMStatus dbStatus, VMStatus vdsmStatus) {
+    private static void setPairStatuses(Pair<VM, VdsmVm> pair, VMStatus dbStatus, VMStatus vdsmStatus) {
         pair.getFirst().setStatus(dbStatus);
         pair.getSecond().getVmDynamic().setStatus(vdsmStatus);
     }


### PR DESCRIPTION
## Changes introduced with this PR

When a VDS network error occurs during VM start, set the VM status to "Unknown" instead of letting it fall through to "Down". This prevents duplicate VM deployments during network disturbances.

The VM stays in the async running list so that VmAnalyzer can trigger a rerun when the host becomes reachable again and the VM is confirmed down.

Changes:
- RunVmCommand: On VDS_NETWORK_ERROR, set VM to Unknown with runOnVds
- ResourceManager.setVmUnknown(): Remove the removeAsyncRunningVm() call to keep VM in async list for rerun capability
- RecoveryStartupBean: Explicitly remove from async list on engine startup (engine restart should not trigger rerun for Unknown VMs). This is not a change but the 'removal' was moved here from ResourceManager.setVmUnknown(). This to be able to re-use said ResourceManager method in the RunVmCommand.

Before: run vm on host1 > network error > vm down > run vm on host2
  (while VM was actually booting on host1)
After: run vm on host1 > network error > vm unknown > wait for host1
  to report actual VM state


## Are you the owner of the code you are sending in, or do you have permission of the owner?

y