### PR TITLE
packaging: fix OVESETUP_APACHE trigger

### DIFF
--- a/packaging/bin/engine-backup.sh.in
+++ b/packaging/bin/engine-backup.sh.in
@@ -2041,7 +2041,7 @@ __EOF__
 	# Make next engine-setup ask about apache
 	if [ -n "${exclude_apache}" ]; then
 		local ESC_APACHE_CONFIGURED_LINE=$(echo "${APACHE_CONFIGURED_LINE}" | sed 's;/;\\/;')
-		sed -i "${INSTALL_ROOT}/^${ESC_APACHE_CONFIGURED_LINE}\$/d" "${POSTINSTALL_RELATIVE}"
+		sed -i "/^${ESC_APACHE_CONFIGURED_LINE}\$/d" "${INSTALL_ROOT}/${POSTINSTALL_RELATIVE}"
 	fi
 
 	migrateLegacyCerts


### PR DESCRIPTION
## Changes introduced with this PR

Fix sed command that removes the OVESETUP_APACHE var from a setup config file.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

y