### PR TITLE
storage: allow discard with VirtIO

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/validator/storage/DiskVmElementValidator.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/validator/storage/DiskVmElementValidator.java
@@ -108,6 +108,7 @@ public class DiskVmElementValidator {
 
         DiskInterface diskInterface = diskVmElement.getDiskInterface();
         if (diskInterface != DiskInterface.VirtIO_SCSI
+                && diskInterface != DiskInterface.VirtIO
                 && diskInterface != DiskInterface.IDE
                 && diskInterface != DiskInterface.SATA) {
             return new ValidationResult(

--- a/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/validator/storage/DiskVmElementDiscardSupportValidatorTest.java
+++ b/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/validator/storage/DiskVmElementDiscardSupportValidatorTest.java
@@ -59,8 +59,6 @@ public class DiskVmElementDiscardSupportValidatorTest {
                         null, null, ValidationResult.VALID),
 
                 // Unsupported interface
-                Arguments.of(new DiskImage(), true, DiskInterface.VirtIO, null, null,
-                        null, null, passDiscardNotSupportedByDiskInterface),
                 Arguments.of(new DiskImage(), true, DiskInterface.SPAPR_VSCSI, null, null,
                         null, null, passDiscardNotSupportedByDiskInterface),
 
@@ -82,6 +80,8 @@ public class DiskVmElementDiscardSupportValidatorTest {
                 - different interfaces
                 - different file storage types
                  */
+                Arguments.of(new DiskImage(), true, DiskInterface.VirtIO, null, StorageType.NFS,
+                        true, null, ValidationResult.VALID),
                 Arguments.of(new DiskImage(), true, DiskInterface.VirtIO_SCSI, null, StorageType.NFS,
                         true, null, ValidationResult.VALID),
                 Arguments.of(new DiskImage(), true, DiskInterface.IDE, null, StorageType.POSIXFS,
@@ -94,6 +94,8 @@ public class DiskVmElementDiscardSupportValidatorTest {
                 - different interfaces
                 - different block storage types
                  */
+                Arguments.of(new DiskImage(), true, DiskInterface.VirtIO, null, StorageType.ISCSI,
+                        false, null, passDiscardNotSupportedForDiskImageByUnderlyingStorage),
                 Arguments.of(new DiskImage(), true, DiskInterface.VirtIO_SCSI, null, StorageType.ISCSI,
                         false, null, passDiscardNotSupportedForDiskImageByUnderlyingStorage),
                 Arguments.of(new DiskImage(), true, DiskInterface.IDE, null, StorageType.FCP,
@@ -104,6 +106,8 @@ public class DiskVmElementDiscardSupportValidatorTest {
                 - different interfaces
                 - different block storage types
                  */
+                Arguments.of(new DiskImage(), true, DiskInterface.VirtIO, null, StorageType.ISCSI,
+                        true, null, ValidationResult.VALID),
                 Arguments.of(new DiskImage(), true, DiskInterface.VirtIO_SCSI, null, StorageType.ISCSI,
                         true, null, ValidationResult.VALID),
                 Arguments.of(new DiskImage(), true, DiskInterface.IDE, null, StorageType.FCP,
@@ -114,6 +118,10 @@ public class DiskVmElementDiscardSupportValidatorTest {
                 - different interfaces
                 - different block storage types
                  */
+                Arguments.of(new DiskImage(), true, DiskInterface.VirtIO, null, StorageType.ISCSI,
+                        true, true, new ValidationResult(EngineMessage
+                        .ACTION_TYPE_FAILED_PASS_DISCARD_NOT_SUPPORTED_BY_UNDERLYING_STORAGE_WHEN_WAD_IS_ENABLED,
+                        getStorageDomainNameVarReplacement(), getDiskAliasVarReplacement())),
                 Arguments.of(new DiskImage(), true, DiskInterface.VirtIO_SCSI, null, StorageType.ISCSI,
                         true, true, new ValidationResult(EngineMessage
                         .ACTION_TYPE_FAILED_PASS_DISCARD_NOT_SUPPORTED_BY_UNDERLYING_STORAGE_WHEN_WAD_IS_ENABLED,
@@ -128,12 +136,16 @@ public class DiskVmElementDiscardSupportValidatorTest {
                 - different interfaces
                 - different non file or block storage types
                  */
+                Arguments.of(new DiskImage(), true, DiskInterface.VirtIO, null, StorageType.UNKNOWN,
+                        null, null, createPassDiscardNotSupportedByStorageTypeValResult(StorageType.UNKNOWN)),
                 Arguments.of(new DiskImage(), true, DiskInterface.VirtIO_SCSI, null, StorageType.UNKNOWN,
                         null, null, createPassDiscardNotSupportedByStorageTypeValResult(StorageType.UNKNOWN)),
                 Arguments.of(new DiskImage(), true, DiskInterface.IDE, null, StorageType.CINDER,
                         null, null, createPassDiscardNotSupportedByStorageTypeValResult(StorageType.CINDER)),
 
                 // Unsupported disk storage type (different interfaces)
+                Arguments.of(new CinderDisk(), true, DiskInterface.VirtIO, null, null,
+                        null, null, passDiscardNotSupportedByCinder),
                 Arguments.of(new CinderDisk(), true, DiskInterface.VirtIO_SCSI, null, null,
                         null, null, passDiscardNotSupportedByCinder),
                 Arguments.of(new CinderDisk(), true, DiskInterface.IDE, null, null,

--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/AbstractDiskModel.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/AbstractDiskModel.java
@@ -716,6 +716,7 @@ public abstract class AbstractDiskModel extends DiskModel {
             DiskInterface selectedInterface = getDiskInterface().getSelectedItem();
             DiskStorageType selectedDiskStorageType = getDiskStorageType().getEntity();
             boolean isApplicableInterface = selectedInterface == DiskInterface.VirtIO_SCSI ||
+                    selectedInterface == DiskInterface.VirtIO ||
                     selectedInterface == DiskInterface.IDE ||
                     selectedInterface == DiskInterface.SATA;
             boolean isApplicableDiskStorageType = selectedDiskStorageType == DiskStorageType.LUN ||


### PR DESCRIPTION
Discard is support for VirtIO in Qemu since qemu 4.0.0. [1]. So allow setting discard support when using VirtIO storage interface.

1: https://gitlab.com/qemu-project/qemu/-/commit/37b06f8d46fe602e630e4

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]