### PR TITLE
webadmin: add defined memory and cpu count to vm subtab under cluster

### DIFF
--- a/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/section/main/view/tab/cluster/SubTabClusterVmView.java
+++ b/frontend/webadmin/modules/webadmin/src/main/java/org/ovirt/engine/ui/webadmin/section/main/view/tab/cluster/SubTabClusterVmView.java
@@ -136,5 +136,25 @@ public class SubTabClusterVmView extends AbstractSubTabTableView<Cluster, VM, Cl
         };
         ipColumn.makeSortable(VmConditionFieldAutoCompleter.IP);
         getTable().addColumn(ipColumn, constants.ipVm(), "120px"); //$NON-NLS-1$
+
+        AbstractTextColumn<VM> vCpusColumn = new AbstractTextColumn<VM>() {
+            @Override
+            public String getValue(VM object) {
+                return Integer.toString(object.getNumOfCpus());
+            }
+        };
+        getTable().addColumn(vCpusColumn, constants.vcpus(), "80px"); //$NON-NLS-1$
+        vCpusColumn.makeSortable(VmConditionFieldAutoCompleter.VCPUS);
+        getTable().hideColumnByDefault(vCpusColumn);
+
+        AbstractTextColumn<VM> definedMemoryColumn = new AbstractTextColumn<VM>() {
+            @Override
+            public String getValue(VM object) {
+                return object.getMemSizeMb() + " MB"; //$NON-NLS-1$
+            }
+        };
+        getTable().addColumn(definedMemoryColumn, constants.memoryVmMB(), "100px"); //$NON-NLS-1$
+        definedMemoryColumn.makeSortable(VmConditionFieldAutoCompleter.MEMORY);
+        getTable().hideColumnByDefault(definedMemoryColumn);
     }
 }


### PR DESCRIPTION
Fixes issue https://github.com/oVirt/ovirt-engine/issues/643

## Changes introduced with this PR

* Add extra optional columns to the vm subtab to more closely resemble the main vm view.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]