### PR TITLE
db: Update maximum and minimum ram values for RHEL OS

### DIFF
--- a/packaging/conf/osinfo-defaults.properties
+++ b/packaging/conf/osinfo-defaults.properties
@@ -183,6 +183,7 @@ os.rhel_7x64.devices.audio.value.4.8 = ich6,q35/ich9
 os.rhel_7x64.devices.memoryHotplug.specialBlock.value = true
 os.rhel_7x64.devices.legacyVirtio.value = false
 os.rhel_7x64.devices.tpm.value = supported
+os.rhel_7x64.resources.maximum.ram.value = 6291456
 
 # rhel8x64(30, OsType.Linux),
 os.rhel_8x64.id.value = 30
@@ -190,6 +191,7 @@ os.rhel_8x64.name.value = Red Hat Enterprise Linux 8.x x64
 os.rhel_8x64.derivedFrom.value = rhel_7x64
 os.rhel_8x64.devices.memoryHotplug.specialBlock.value = false
 os.rhel_8x64.devices.ovirtGuestAgentChannel.value = false
+os.rhel_8x64.resources.maximum.ram.value = 16777216
 
 # rhel9x64(34, OsType.Linux)
 os.rhel_9x64.id.value = 34
@@ -200,6 +202,7 @@ os.rhel_9x64.derivedFrom.value = rhel_8x64
 os.rhel_10x64.id.value = 39
 os.rhel_10x64.devices.audio.value = ich6,q35/ich9
 os.rhel_10x64.name.value = Red Hat Enterprise Linux 10.x x64
+os.rhel_10x64.resources.maximum.ram.value = 67108864
 os.rhel_10x64.derivedFrom.value = rhel_9x64
 
 # redhat coreos

--- a/packaging/dbscripts/upgrade/pre_upgrade/0000_config.sql
+++ b/packaging/dbscripts/upgrade/pre_upgrade/0000_config.sql
@@ -699,7 +699,8 @@ select fn_db_add_config_value('VdsCertificateValidityInDays','1827','general');
 --Handling Virtual Machine Domain Name
 select fn_db_add_config_value_for_versions_up_to('VM32BitMaxMemorySizeInMB','20480','4.8');
 select fn_db_add_config_value_for_versions_up_to('VM64BitMaxMemorySizeInMB','6291456','4.5');
-select fn_db_add_config_value_for_versions_up_to('VM64BitMaxMemorySizeInMB','16777216','4.8');
+select fn_db_add_config_value_for_versions_up_to('VM64BitMaxMemorySizeInMB','16777216','4.7');
+select fn_db_add_config_value('VM64BitMaxMemorySizeInMB', '67108864', '4.8');
 select fn_db_add_config_value_for_versions_up_to('VMPpc64BitMaxMemorySizeInMB', '1048576', '4.3');
 select fn_db_add_config_value_for_versions_up_to('VMPpc64BitMaxMemorySizeInMB', '6291456', '4.8');
 select fn_db_add_config_value('VmGracefulShutdownMessage','System Administrator has initiated shutdown of this Virtual Machine. Virtual Machine is shutting down.','general');
@@ -1189,6 +1190,7 @@ select fn_db_update_config_value('MaxNumOfVmCpus', '{"x86":710,"ppc":384,"s390x"
 select fn_db_update_config_value('MaxNumOfCpuPerSocket', '254', '4.2');
 select fn_db_update_config_value_for_versions_from_up_to('VM64BitMaxMemorySizeInMB', '6291456', '4.2','4.5');
 select fn_db_update_config_value('VM64BitMaxMemorySizeInMB', '16777216', '4.6');
+select fn_db_update_config_value('VM64BitMaxMemorySizeInMB', '67108864', '4.8');
 select fn_db_update_config_value_for_versions_from_up_to('VMPpc64BitMaxMemorySizeInMB', '6291456', '4.4','4.6');
 select fn_db_update_config_value('MaxNumOfVmSockets', '10000', '4.6');
 


### PR DESCRIPTION
## Changes introduced with this PR

* According to https://access.redhat.com/articles/rhel-kvm-limits the limits of RAM are larger then previously set for the system. Updated the maximum and minimum for affected RHEL systems. Also updated the UI maximum to make it possible to enter larger values.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]