### PR TITLE
core: Update transferImageStatusCommand to check on storage level when storage available

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/TransferImageStatusCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/TransferImageStatusCommand.java
@@ -117,9 +117,11 @@ public class TransferImageStatusCommand<T extends TransferImageStatusParameters>
         );
 
         // Only check generic permissions because the command and/or ImageUpload entity may be missing
+        // If a storage domain id is available, check permissions on the storage domain; otherwise, check system-level permissions
+        VdcObjectType objectType = getStorageDomainId() != null ? VdcObjectType.Storage : VdcObjectType.System;
         return Collections.singletonList(new PermissionSubject(
                 objectId,
-                VdcObjectType.System,
+                objectType,
                 ActionGroup.CREATE_DISK));
     }
 


### PR DESCRIPTION
## Changes introduced with this PR

* Previously the user needed System level permissions to upload a disk but actually a Storage level is adequate if a storage domain is present.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]