### PR TITLE
webadmin: Update generation of tagged search string

### DIFF
--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/SearchableListModel.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/SearchableListModel.java
@@ -176,8 +176,8 @@ public abstract class SearchableListModel<E, T> extends SortedListModel<T> imple
             //Nothing added, we can append the tags.
             return getSearchString() + tags.toString();
         } else {
-            //Have a search string with something already, append with OR.
-            return getSearchString() + " OR " + tags.toString(); // $NON-NLS-1$
+            // Apply the already present search string on the tags only
+            return getSearchString() + " AND " + tags.toString(); // $NON-NLS-1$
         }
     }
 


### PR DESCRIPTION
## Changes introduced with this PR

* On creating a taggedSearchString, use the AND operand instead of the OR when combining searchString and the tags. Thus instead of returning all the items of 2 filters on the same base, return the result of a filter upon the first filtered result.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]