### PR TITLE
core: No release of locks on createsnapshot when it is a subpart of a livemigrate

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/snapshots/CreateSnapshotForVmCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/snapshots/CreateSnapshotForVmCommand.java
@@ -837,4 +837,11 @@ public class CreateSnapshotForVmCommand<T extends CreateSnapshotForVmParameters>
     public CommandCallback getCallback() {
         return callbackProvider.get();
     }
+
+    @Override
+    protected void freeLock() {
+        if (getParameters().getParentCommand() != ActionType.LiveMigrateDisk) {
+            super.freeLock();
+        }
+    }
 }


### PR DESCRIPTION
## Changes introduced with this PR

As part of the execution of LiveMigrateDiskCommand the internal action CreateSnapshotForVm is executed. 
Due to the parent and the sub action both being based on the class CommandBase this triggers the same freeLock function on end of both commands. 
With the CreateSnapshotForVm command having knowledge of the parent lock it had the ability to release this lock.
 After this, LiveMigrateDiskCommand continues with other actions and on completion tries to release the lock which now does not exist anymore due to previous actions. 
Deny CreateSnapshotForVmCommand to release locks belonging to LiveMigrateDiskCommand so it does not result in the parent command trying to release the lock later on and failing.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]