### PR TITLE
Remove vdsm-compat flag from virt-v2v imports

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ImportVmFromExternalProviderCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/exportimport/ImportVmFromExternalProviderCommand.java
@@ -87,8 +87,6 @@ public class ImportVmFromExternalProviderCommand<T extends ImportVmFromExternalP
     private static final Pattern DISK_ALIAS_ILLEGAL_CHARS_PATTERN =
             Pattern.compile("[^" + ValidationUtils.NO_SPECIAL_CHARACTER_CLASS_I18N + "]");
 
-    private static final String VDSM_COMPAT_VERSION_1_1 = "1.1";
-
     @Inject
     private DiskProfileHelper diskProfileHelper;
     @Inject
@@ -455,11 +453,6 @@ public class ImportVmFromExternalProviderCommand<T extends ImportVmFromExternalP
     }
 
     private String getCompatVersion() {
-        int version = Integer.parseInt(getStoragePool().getStoragePoolFormatType().getValue());
-        // compat version 1.1 supported from storage version 4
-        if (version >= 4 && getVm().getOrigin() != OriginType.KVM) {
-            return VDSM_COMPAT_VERSION_1_1;
-        }
         return null;
     }
 


### PR DESCRIPTION
virt-v2v 2.7.1 on RHEL 9.7 doesn't recognize the --vdsm-compat option. Remove the logic that passes it since it's not supported anymore. Fixes oVirt/vdsm#461.