### PR TITLE
core: fix discard-no-unref for VM Compatibility Version

### DIFF
--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/FeatureSupported.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/FeatureSupported.java
@@ -455,4 +455,16 @@ public class FeatureSupported {
     public static boolean isVirtioVgaSupported(Version version) {
         return supportedInConfig(ConfigValues.VirtioVgaSupported, version);
     }
+
+    /**
+     * Check if 'discard-no-unref' is supported.
+     * This is the case when running on compatibility version 4.8 or higher
+     * and the 'EnableQemuDiscardNoUnref' is enabled in the configuration.
+     *
+     * @param version Compatibility version to check for.
+     * @return true if 'discard-no-unref' is supported
+     */
+    public static boolean isDiscardNoUnrefSupported(Version version) {
+        return Version.v4_8.lessOrEquals(version) && supportedInConfig(ConfigValues.EnableQemuDiscardNoUnref, version);
+    }
 }

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/builder/vminfo/LibvirtVmXmlBuilder.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/builder/vminfo/LibvirtVmXmlBuilder.java
@@ -2292,7 +2292,7 @@ public class LibvirtVmXmlBuilder {
         writer.writeAttributeString("name", "qemu");
         if (dve.isPassDiscard()) {
             writer.writeAttributeString("discard", "unmap");
-            if ((boolean) Config.getValue(ConfigValues.EnableQemuDiscardNoUnref, vm.getClusterCompatibilityVersion().toString())) {
+            if (FeatureSupported.isDiscardNoUnrefSupported(vm.getCompatibilityVersion())) {
                 writer.writeAttributeString("discard_no_unref", "on");
             }
         }


### PR DESCRIPTION
Currently, discard-no-unref is enabled when the ConfigValue 'EnableQemuDiscardNoUnref' is set to true for the cluster compatibility version.

But if the cluster is for example still running 4.7, but a custom compatibility version on the VM is set to 4.8, this doesn't work.

Therefor we adjust the condition to check the VM its compatibility version, and when that is >= 4.8 and EnableQemuDiscardNoUnref is enabled, then we enable 'discard-no-unref'.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]