### PR TITLE
webadmin: trim OVA path before submit on import dialog

### DIFF
--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/templates/ImportTemplatesModel.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/templates/ImportTemplatesModel.java
@@ -430,7 +430,8 @@ public class ImportTemplatesModel extends ListWithSimpleDetailsModel {
                 break;
             case OVA:
                 importFromOvaModel.init(templates, getDataCenters().getSelectedItem().getId());
-                importFromOvaModel.setIsoName(getOvaPath().getEntity());
+                String ovaPathEntity = getOvaPath().getEntity();
+                importFromOvaModel.setIsoName(ovaPathEntity == null ? null : ovaPathEntity.trim());
                 importFromOvaModel.setHostId(getHosts().getSelectedItem().getId());
                 importFromOvaModel.setTemplateNameToOva(getTemplateNameToOva());
                 selectedImportVmModel = importFromOvaModel;

--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/ImportVmsModel.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/vms/ImportVmsModel.java
@@ -230,7 +230,8 @@ public class ImportVmsModel extends ListWithSimpleDetailsModel {
                 break;
             case OVA:
                 importFromOvaModel.init(getVmsToImport(), getDataCenters().getSelectedItem().getId());
-                importFromOvaModel.setIsoName(getOvaPath().getEntity());
+                String ovaPathEntity = getOvaPath().getEntity();
+                importFromOvaModel.setIsoName(ovaPathEntity == null ? null : ovaPathEntity.trim());
                 importFromOvaModel.setHostId(getHosts().getSelectedItem().getId());
                 importFromOvaModel.setVmNameToOva(getVmNameToOva());
                 selectedImportVmModel = importFromOvaModel;


### PR DESCRIPTION
- pasted paths with leading/trailing whitespace were sent verbatim, causing FileNotFoundError from the ovirt-ova-query ansible role
- trim at the model boundary (ImportVmsModel + ImportTemplatesModel) so user input never reaches the engine with whitespace
- null-safe; null paths still pass through unchanged

Fixes #1143 - Discovered while testing the upstream MBS feature push (#1138, #1133, #1125, oVirt/vdsm#459). The bug itself is not MBS-specific. Affects any OVA import.

## Changes introduced with this PR

* `ImportVmsModel`: trim the OVA path before passing to `setIsoName`
* `ImportTemplatesModel`: same trim before passing to `setIsoName`
* null-safe: null paths pass through unchanged

## Are you the owner of the code you are sending in, or do you have permission of the owner?

Yes