### PR TITLE
webadmin: show Storage sub-tab on managed block and Cinder disks

### DIFF
--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/disks/DiskListModel.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/disks/DiskListModel.java
@@ -296,7 +296,7 @@ public class DiskListModel extends ListWithSimpleDetailsModel<Void, Disk> {
 
             vmListModel.setIsAvailable(!isTemplateDisk(disk));
             templateListModel.setIsAvailable(isTemplateDisk(disk));
-            storageListModel.setIsAvailable(disk.getDiskStorageType() == DiskStorageType.IMAGE);
+            storageListModel.setIsAvailable(disk.getDiskStorageType().isInternal());
         }
     }
 


### PR DESCRIPTION
- per-disk Storage sub-tab was gated to `DiskStorageType.IMAGE` only

Found and fixed while improving oVirt's Managed Block Storage support. Affects any MBS backend (StorPool, Ceph, LINSTOR) and Cinder disks.

Fixes #1145, now consistent with non-MBS storage view:

<img width="2158" height="756" alt="image" src="https://github.com/user-attachments/assets/104969d8-9f59-4c4a-a523-e69a6451ec58" />


## Changes introduced with this PR

* `DiskListModel`: widen the Storage sub-tab availability predicate from `DiskStorageType.IMAGE` only to also include `MANAGED_BLOCK_STORAGE` and `CINDER`
* no engine or query changes; the data was already returned by `GetStorageDomainsByImageId`

## Are you the owner of the code you are sending in, or do you have permission of the owner?

Yes.
