### PR TITLE
webadmin/core: expose MBS disk snapshots in WebAdmin

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/GetAllDiskSnapshotsQuery.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/GetAllDiskSnapshotsQuery.java
@@ -38,7 +38,9 @@ public class GetAllDiskSnapshotsQuery<P extends DiskSnapshotsQueryParameters> ex
         // Unless 'include_active' flag requested - filter out the active snapshot
         Predicate<Disk> filter = getParameters().getIncludeActive() ?
                 DisksFilter.ONLY_DISK_SNAPSHOT.or(DisksFilter.ONLY_ACTIVE) : DisksFilter.ONLY_DISK_SNAPSHOT;
+        // Include snapshots from all disk types
         List<DiskImage> imagesToReturn = DisksFilter.filterImageDisks(allDiskSnapshots, filter);
+        imagesToReturn.addAll(DisksFilter.filterManagedBlockStorageDisks(allDiskSnapshots, filter));
 
         // If the 'include_template' flag requested - check if one of the disk images' parents is a template disk,
         // fetch it and add to the result

--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/storage/StorageListModel.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/storage/StorageListModel.java
@@ -910,7 +910,7 @@ public class StorageListModel extends ListWithSimpleDetailsModel<Void, StorageDo
             templateRegisterListModel.setIsAvailable(isRegisterSubtabsAvailable);
             diskImageRegisterListModel.setIsAvailable(isRegisterSubtabsAvailable);
             diskListModel.setIsAvailable(isDataStorage || isManagedBlockStorage);
-            snapshotListModel.setIsAvailable(isDataStorage);
+            snapshotListModel.setIsAvailable(isDataStorage || isManagedBlockStorage);
             diskProfileListModel.setIsAvailable(isDataStorage);
             drListModel.setIsAvailable(isGlusterStorage);
             leaseListModel.setIsAvailable(isDataStorage);


### PR DESCRIPTION
This PR has two small commits that together make MBS disk snapshots visible in WebAdmin:

1. `core: surface MBS disk snapshots in disk-snapshots view` -> the backing `GetAllDiskSnapshotsQuery` was filtering out MBS rows from its result set; widen so MBS snapshot rows are returned alongside other storage types.
2. `webadmin: show disk snapshots sub-tab on MBS storage domains` -> the per-domain drill-in did not expose the Disk Snapshots sub-tab when the selected domain is MBS; flip the sub-tab availability predicate.

The two layers cooperate to hide the data from WebAdmin: even fixing one alone leaves the user with either an empty tab or no entry point. Landing both fixes together gives the user a coherent end-to-end fix: take a snapshot of an MBS disk, see the snapshot row in WebAdmin.

Found and fixed while improving oVirt's Managed Block Storage support. Affects any MBS backend (StorPool, Ceph, LINSTOR).

Fixes #1147

## Changes introduced with this PR

* `GetAllDiskSnapshotsQuery`: widen the result-set filter to include MBS-backed disk snapshot rows (~10 LOC, 1 file)
* `StorageListModel`: widen the Disk Snapshots sub-tab availability predicate to include the MBS storage domain type (~5 LOC, 1 file)

## Verification

_MBS storage domain detail with Disk Snapshots tab present and populated:_
<img width="2158" height="756" alt="image" src="https://github.com/user-attachments/assets/35b46f8d-a5d8-4508-9b29-06edae358a17" /><br />

## Are you the owner of the code you are sending in, or do you have permission of the owner?

Yes.
