### PR TITLE
core: include MBS domains in dashboard storage count and totals

### DIFF
--- a/frontend/webadmin/modules/frontend/src/main/resources/org/ovirt/engine/ui/frontend/server/dashboard/dao/StorageDomainDwhDAO.properties
+++ b/frontend/webadmin/modules/frontend/src/main/resources/org/ovirt/engine/ui/frontend/server/dashboard/dao/StorageDomainDwhDAO.properties
@@ -11,7 +11,7 @@ storage.last24hours_average=SELECT \
           storage.history_id = resources.storage_configuration_version \
       WHERE \
           NOT(available_disk_size_gb IS NULL AND used_disk_size_gb IS NULL) AND \
-          storage_domain_type IN(0, 1) AND \
+          storage_domain_type IN(0, 1, 7) AND \
           resources.storage_domain_status = 1 AND \
           history_datetime >= (CURRENT_TIMESTAMP - INTERVAL '1 day') AND \
           history_datetime < CURRENT_TIMESTAMP \
@@ -31,7 +31,7 @@ storage.hourly_history=SELECT \
             ON \
                 domains.history_id = resources.storage_configuration_version \
             WHERE \
-                domains.storage_domain_type IN (0, 1) AND \
+                domains.storage_domain_type IN (0, 1, 7) AND \
                 resources.storage_domain_status = 1 AND \
                 history_datetime >=  date_trunc('hour',CURRENT_TIMESTAMP) - INTERVAL '24 hours' AND \
                 history_datetime < date_trunc('hour',CURRENT_TIMESTAMP) - INTERVAL '2 hour' \
@@ -54,7 +54,7 @@ storage.hourly_history=SELECT \
                 ON \
                     domains.history_id = samples.storage_configuration_version \
                 WHERE \
-                    domains.storage_domain_type IN (0, 1) AND \
+                    domains.storage_domain_type IN (0, 1, 7) AND \
                     samples.storage_domain_status = 1 AND \
                     history_datetime >=  date_trunc('hour',CURRENT_TIMESTAMP) - INTERVAL '2 hours' AND \
                     history_datetime < date_trunc('hour',CURRENT_TIMESTAMP) + INTERVAL '1 minute' \
@@ -87,7 +87,7 @@ storage.last5_minutes_average=SELECT \
             ON \
                 domains.history_id = samples.storage_configuration_version \
             WHERE \
-                domains.storage_domain_type IN (0, 1) AND \
+                domains.storage_domain_type IN (0, 1, 7) AND \
                 samples.storage_domain_status = 1 AND \
                 history_datetime >=  CURRENT_TIMESTAMP - INTERVAL '5 minute' AND \
                 history_datetime < CURRENT_TIMESTAMP \
@@ -109,7 +109,7 @@ storage.total_count=SELECT \
             ON \
                 domains.history_id = samples.storage_configuration_version \
             WHERE \
-                domains.storage_domain_type IN (0, 1) AND \
+                domains.storage_domain_type IN (0, 1, 7) AND \
                 samples.storage_domain_status = 1 AND \
                 history_datetime >=  CURRENT_TIMESTAMP - INTERVAL '5 minute' AND \
                 history_datetime < CURRENT_TIMESTAMP \
@@ -143,7 +143,7 @@ storage.utilization=SELECT \
                 domains.history_id = samples.storage_configuration_version \
             WHERE \
                 NOT (available_disk_size_gb IS NULL AND used_disk_size_gb IS NULL) AND \
-                storage_domain_type IN (0, 1) AND \
+                storage_domain_type IN (0, 1, 7) AND \
                 samples.storage_domain_status = 1 AND \
                 history_datetime >= (CURRENT_TIMESTAMP - INTERVAL '10 minute') AND \
                 history_datetime < (CURRENT_TIMESTAMP - INTERVAL '5 minute') \
@@ -154,7 +154,7 @@ storage.utilization=SELECT \
             domains.storage_domain_id = previous_trend.storage_domain_id \
         WHERE \
             NOT (available_disk_size_gb IS NULL AND used_disk_size_gb IS NULL) AND \
-            storage_domain_type IN (0, 1) AND \
+            storage_domain_type IN (0, 1, 7) AND \
             samples.storage_domain_status = 1 AND \
             history_datetime >= (CURRENT_TIMESTAMP - INTERVAL '5 minute') AND \
             history_datetime < CURRENT_TIMESTAMP \

--- a/frontend/webadmin/modules/frontend/src/main/resources/org/ovirt/engine/ui/frontend/server/dashboard/dao/StorageDomainEngineDAO.properties
+++ b/frontend/webadmin/modules/frontend/src/main/resources/org/ovirt/engine/ui/frontend/server/dashboard/dao/StorageDomainEngineDAO.properties
@@ -4,4 +4,4 @@ storage.inventory=SELECT \
       FROM \
           storage_domains \
       WHERE \
-          storage_domain_type IN (0,1)
+          storage_domain_type IN (0,1,7)

--- a/frontend/webadmin/modules/frontend/src/main/resources/org/ovirt/engine/ui/frontend/server/dashboard/dao/VmDwhDAO.properties
+++ b/frontend/webadmin/modules/frontend/src/main/resources/org/ovirt/engine/ui/frontend/server/dashboard/dao/VmDwhDAO.properties
@@ -21,7 +21,7 @@ vm.virtual_storage_count=SELECT \
           ON \
               vm_disks.vm_disk_id = samples.vm_disk_id \
           WHERE \
-              storage_domain_type IN (0, 1) AND \
+              storage_domain_type IN (0, 1, 7) AND \
               history_datetime >= CURRENT_TIMESTAMP - INTERVAL '5 minute' AND \
               history_datetime <= CURRENT_TIMESTAMP \
           GROUP BY \


### PR DESCRIPTION
- every storage figure on the Dashboard is driven by SQL queries in
  `StorageDomainDwhDAO.properties`, `StorageDomainEngineDAO.properties`,
  and `VmDwhDAO.properties`
- every query filtered by `storage_domain_type IN (0, 1)` (Master, Data),
  excluding Managed Block Storage (type 7); MBS-domain rows were silently
  dropped from the `N Data Storage Domains` count tile, the Global
  Utilization → Storage tile total, the storage utilization history
  chart, and the 5-minute / 24-hour utilization averages
- widen the filter to `(0, 1, 7)` across all 9 occurrences (3 files)

Found and fixed while improving oVirt's Managed Block Storage support. Affects any MBS backend (StorPool, Ceph, LINSTOR).

Fixes #1149

## Changes introduced with this PR

* `StorageDomainDwhDAO.properties`: 7 occurrences of `storage_domain_type IN (0, 1)` widened to `IN (0, 1, 7)` (last24hours_average, hourly_history × 2, last5_minutes_average, total_count, utilization × 2)
* `StorageDomainEngineDAO.properties`: `storage.inventory` widened similarly
* `VmDwhDAO.properties`: matching VM-side query widened similarly
* No engine code or schema changes; only the dashboard SQL filters

## Verification

Dashboard after the fix, with the MBS domain counted in the `N Data Storage Domains` tile and its capacity included in the Global Utilization → Storage tile total:

<img width="2158" height="1301" alt="image" src="https://github.com/user-attachments/assets/53fd1fb5-8fae-475c-a4c5-df688e158fe5" /><br />

Proof of 3 data domains (iSCSI + 2 MBS):

<img width="2158" height="589" alt="image" src="https://github.com/user-attachments/assets/b1aaa3f3-65a7-4ec2-b07f-11a56419dbb2" /><br />

## Are you the owner of the code you are sending in, or do you have permission of the owner?

Yes.
