### PR TITLE
core: surface MBS adapter snapshot rejection cleanly

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/managedblock/CreateManagedBlockStorageDiskSnapshotCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/managedblock/CreateManagedBlockStorageDiskSnapshotCommand.java
@@ -76,7 +76,6 @@ public class CreateManagedBlockStorageDiskSnapshotCommand<T extends CreateManage
         List<String> extraParams = new ArrayList<>();
         extraParams.add(getParameters().getVolumeId().toString());
         ManagedBlockReturnValue returnValue;
-        Guid snapshotId;
 
         try {
             ManagedBlockCommandParameters params =
@@ -87,13 +86,24 @@ public class CreateManagedBlockStorageDiskSnapshotCommand<T extends CreateManage
                             getCorrelationId());
             returnValue =
                     managedBlockExecutor.runCommand(ManagedBlockExecutor.ManagedBlockCommand.CREATE_SNAPSHOT, params);
-            snapshotId = Guid.createGuidFromString(returnValue.getOutput());
         } catch (Exception e) {
             log.error("Failed executing snapshot creation", e);
             return;
         }
 
         if (!returnValue.getSucceed()) {
+            log.error("Snapshot creation rejected by managed block adapter for volume '{}': {}",
+                    getParameters().getVolumeId(),
+                    returnValue.getOutput() == null ? "" : returnValue.getOutput().trim());
+            return;
+        }
+
+        Guid snapshotId;
+        try {
+            snapshotId = Guid.createGuidFromString(returnValue.getOutput());
+        } catch (IllegalArgumentException e) {
+            log.error("Managed block create_snapshot returned non-UUID output for volume '{}': '{}'",
+                    getParameters().getVolumeId(), returnValue.getOutput());
             return;
         }
 


### PR DESCRIPTION
- `CreateManagedBlockStorageDiskSnapshotCommand` parsed the adapter
  output as a UUID before checking `returnValue.getSucceed()`. On
  adapter rejection, the output is the error text rather than a UUID;
  the parse throws `IllegalArgumentException` and the surrounding
  `catch` logs the parse exception itself, so the actual rejection
  reason never reaches `engine.log`.
- Reorder: check `getSucceed()` first; on failure, log the adapter
  output verbatim. On success, parse the UUID inside a narrow
  `try`/`catch` that handles the genuinely-malformed-output edge case.

Found and fixed while improving oVirt's Managed Block Storage support. Affects any MBS backend whose adapter can reject snapshots such LINSTOR with LVM (non-thin) storage pools.

Fixes #1151

## Changes introduced with this PR

* `CreateManagedBlockStorageDiskSnapshotCommand`: check the adapter's success flag before parsing its output as a UUID; log the adapter's verbatim message on rejection; narrow the UUID-parse `try`/`catch` to the success path
* No new `AuditLogType`; the diagnostic lands in `engine.log`. Surfacing it in the WebAdmin audit log UI would require a frontend GWT rebuild and is intentionally deferred to a follow-up

## Verification

Reproduced and verified end-to-end on a dev cluster using a LINSTOR-backed MBS domain whose resource group used a thick-LVM storage pool (the LINSTOR `LVM` driver does not support snapshots).

Before the fix, `engine.log` (the rejection text is *not present* — `UUID.fromString` throws on length before looking at the input, and the exception message does not echo it):

```
ERROR ... Failed executing snapshot creation
java.lang.IllegalArgumentException: UUID string too large
    at java.base/java.util.UUID.fromString(UUID.java:212)
    at org.ovirt.engine.core.compat.Guid.createGuidFromString(...)
```

After the fix, `engine.log` (rejection text from the adapter, no Java stack trace):

```
ERROR ... Snapshot creation rejected by managed block adapter for volume 'X': ERRO:Storage driver 'LVM' does not support snapshots
```

The UI still shows a generic failure for the snapshot, but at least the user can find a relevant error message inside `engine.log`.

UI of the snapshot failure:

<img width="2158" height="1156" alt="image" src="https://github.com/user-attachments/assets/b08d929e-3c1d-433c-86bb-029b1cbd578f" /><br />

## Are you the owner of the code you are sending in, or do you have permission of the owner?

Yes.
