### PR TITLE
core: MBS / Cinder code path parity

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/GetAllDisksByStorageDomainIdQuery.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/GetAllDisksByStorageDomainIdQuery.java
@@ -30,7 +30,11 @@ public class GetAllDisksByStorageDomainIdQuery<P extends IdQueryParameters> exte
     @Override
     protected void executeQueryCommand() {
         StorageDomain storageDomain = storageDomainDao.get(getParameters().getId());
-        if (storageDomain.getStorageType().isCinderDomain()) {
+        // Cinder and Managed Block Storage domains store one volume per disk
+        // with no qcow2 snapshot chain to aggregate, so they take the simple
+        // listing path. SPM-managed domains need the snapshot-aggregation
+        // pass to fold the snapshot chain into per-disk rows.
+        if (storageDomain.getStorageType().isVendorManagedBlock()) {
             List<DiskImage> diskImages = diskImageDao.getAllForStorageDomain(getParameters().getId());
             getQueryReturnValue().setReturnValue(diskImages);
         } else {

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/validator/storage/StorageDomainValidator.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/validator/storage/StorageDomainValidator.java
@@ -97,7 +97,7 @@ public class StorageDomainValidator {
     }
 
     public ValidationResult isDomainWithinThresholds() {
-        if (storageDomain.getStorageType().isCinderDomain()) {
+        if (storageDomain.getStorageType().isVendorManagedBlock()) {
             return ValidationResult.VALID;
         }
         StorageDomainDynamic dynamicData = storageDomain.getStorageDynamicData();
@@ -207,7 +207,7 @@ public class StorageDomainValidator {
      * Validate space for new, empty disks. Used for a new Active Image.
      */
     public ValidationResult hasSpaceForNewDisks(Collection<DiskImage> diskImages) {
-        if (storageDomain.getStorageType().isCinderDomain()) {
+        if (storageDomain.getStorageType().isVendorManagedBlock()) {
             return ValidationResult.VALID;
         }
         Long availableSize = storageDomain.getAvailableDiskSizeInBytes();
@@ -220,7 +220,7 @@ public class StorageDomainValidator {
      * Validate space for a cloned disk with the collapse option.
      */
     public ValidationResult hasSpaceForClonedDisks(Collection<DiskImage> diskImages) {
-        if (storageDomain.getStorageType().isCinderDomain()) {
+        if (storageDomain.getStorageType().isVendorManagedBlock()) {
             return ValidationResult.VALID;
         }
         Long availableSize = storageDomain.getAvailableDiskSizeInBytes();
@@ -230,7 +230,7 @@ public class StorageDomainValidator {
     }
 
     public ValidationResult hasSpaceForMerge(List<SubchainInfo> subchains, ActionType snapshotActionType) {
-        if (storageDomain.getStorageType().isCinderDomain() || storageDomain.getStorageType().isManagedBlockStorage()) {
+        if (storageDomain.getStorageType().isVendorManagedBlock()) {
             return ValidationResult.VALID;
         }
         Long availableSize = storageDomain.getAvailableDiskSizeInBytes();
@@ -243,7 +243,7 @@ public class StorageDomainValidator {
      * Validate space for cloned disks without the collapse option. Every snapshot will be cloned.
      */
     public ValidationResult hasSpaceForDisksWithSnapshots(Collection<DiskImage> diskImages) {
-        if (storageDomain.getStorageType().isCinderDomain()) {
+        if (storageDomain.getStorageType().isVendorManagedBlock()) {
             return ValidationResult.VALID;
         }
         Long availableSize = storageDomain.getAvailableDiskSizeInBytes();
@@ -259,7 +259,7 @@ public class StorageDomainValidator {
      * so there's no method for this.
      */
     public ValidationResult hasSpaceForAllDisks(Collection<DiskImage> newDiskImages, Collection<DiskImage> clonedDiskImages) {
-        if (storageDomain.getStorageType().isCinderDomain()) {
+        if (storageDomain.getStorageType().isVendorManagedBlock()) {
             return ValidationResult.VALID;
         }
         Long availableSize = storageDomain.getAvailableDiskSizeInBytes();

--- a/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/validator/storage/StorageDomainValidatorFreeSpaceTest.java
+++ b/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/validator/storage/StorageDomainValidatorFreeSpaceTest.java
@@ -58,10 +58,17 @@ public class StorageDomainValidatorFreeSpaceTest {
                         sd.setStorageType(storageType);
                         sd.setAvailableDiskSize(107); // GB
 
+                        boolean shortCircuitForVendorManaged = storageType.isManagedBlockStorage();
+                        boolean isValidForNew = shortCircuitForVendorManaged
+                                || volumeFormat == VolumeFormat.COW || volumeType == VolumeType.Sparse;
+                        boolean isValidForCloned = shortCircuitForVendorManaged
+                                || volumeFormat == VolumeFormat.RAW && volumeType == VolumeType.Sparse;
+                        boolean isValidForSnapshots = shortCircuitForVendorManaged
+                                || volumeFormat == VolumeFormat.RAW && volumeType == VolumeType.Sparse;
                         params.add(Arguments.of(disk, sd,
-                                volumeFormat == VolumeFormat.RAW && volumeType == VolumeType.Sparse,
-                                volumeFormat == VolumeFormat.COW || volumeType == VolumeType.Sparse,
-                                volumeFormat == VolumeFormat.RAW && volumeType == VolumeType.Sparse
+                                isValidForCloned,
+                                isValidForNew,
+                                isValidForSnapshots
                         ));
                     }
                 }

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/storage/StorageType.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/storage/StorageType.java
@@ -85,4 +85,28 @@ public enum StorageType implements Identifiable {
     public boolean isManagedBlockStorage() {
         return this == MANAGED_BLOCK_STORAGE;
     }
+
+    /**
+     * Returns true for any vendor-managed-block storage backend
+     * (Cinder, Managed Block Storage), where the volume lifecycle
+     * is owned by the storage backend rather than by the SPM. Both
+     * have one volume per disk with no qcow2 snapshot chain to
+     * aggregate, and both use vendor-side capacity accounting, which
+     * is why they take the same code path across the engine.
+     *
+     * Many places historically checked only {@code isCinderDomain()}
+     * and never got the parallel {@code isManagedBlockStorage()}
+     * added when MBS landed, causing MBS domains to fall through to
+     * SPM-style code paths that don't match their semantics. This
+     * helper names the combined case and replaces the partially-
+     * applied checks.
+     *
+     * When Cinder is fully removed (CentOS Stream 10 already dropped
+     * it) this helper collapses to {@code isManagedBlockStorage()}
+     * and the {@code isCinderDomain} machinery can be deleted as a
+     * single follow-up.
+     */
+    public boolean isVendorManagedBlock() {
+        return isCinderDomain() || isManagedBlockStorage();
+    }
 }


### PR DESCRIPTION
More MBS quality-of-life improvements:

- engine has many places that need to treat both Cinder and MBS as one
  case (`isCinderDomain() || isManagedBlockStorage()`) because the two
  share the relevant traits: one volume per disk, no qcow2 chain to
  aggregate, vendor-side capacity accounting
- many places historically checked only `isCinderDomain()` and never got
  the parallel `isManagedBlockStorage()` added when MBS landed, causing
  MBS domains to fall through to SPM-style code paths that don't match
  their semantics
- add `StorageType.isVendorManagedBlock()` to name that combined case as
  a single concept; replace 7 partially-applied checks with the helper:
    * 6 methods in `StorageDomainValidator` (`hasSpaceFor*` / threshold
      methods that previously skipped engine-side space checks for
      Cinder but ran the check on MBS)
    * 1 check in `GetAllDisksByStorageDomainIdQuery` (previously ran
      SPM-style snapshot aggregation on MBS instead of the simple list
      path)
- update `StorageDomainValidatorFreeSpaceTest` to recognize MBS as a
  short-circuit case for the cloned / snapshots / all-disks checks,
  matching the validator's actual behavior after the helper widens the
  skip from Cinder-only to vendor-managed
- when Cinder is fully removed (CentOS Stream 10 already dropped it)
  the helper collapses to `isManagedBlockStorage()` and the
  `isCinderDomain` machinery can be deleted in a single follow-up

Found and addressed while improving oVirt's Managed Block Storage support. No user-visible bug fixed — this is code-hygiene and latent-correctness for shared engine code paths.

Part of an ongoing series of MBS improvements:
* #1144 — webadmin: trim OVA path before submit on import dialog
* #1146 — webadmin: show Storage sub-tab on managed block and Cinder disks
* #1148 — webadmin/core: expose MBS disk snapshots in WebAdmin
* #1150 — core: include MBS domains in dashboard storage count and totals
* #1152 — core: surface MBS adapter snapshot rejection cleanly

## Changes introduced with this PR

* `StorageType`: new helper `isVendorManagedBlock()` returning true for either Cinder or MBS, with a doc comment explaining the shared semantics
* `StorageDomainValidator`: 6 methods changed from `isCinderDomain()` (or `isCinderDomain() || isManagedBlockStorage()`) to `isVendorManagedBlock()`
* `GetAllDisksByStorageDomainIdQuery`: 1 check changed similarly, with a comment noting the simple list path applies to vendor-managed-block domains generally, not just Cinder
* `StorageDomainValidatorFreeSpaceTest`: parameterization aligned so MBS is recognized as a short-circuit case in the cloned / snapshots / all-disks tests, matching the validator's actual behavior

## Are you the owner of the code you are sending in, or do you have permission of the owner?

Yes.
