### PR TITLE
core: persist and refresh MBS storage domain capacity

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/managedblock/AddManagedBlockStorageDiskCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/managedblock/AddManagedBlockStorageDiskCommand.java
@@ -10,7 +10,6 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
-import org.ovirt.engine.core.bll.CommandBase;
 import org.ovirt.engine.core.bll.InternalCommandAttribute;
 import org.ovirt.engine.core.bll.NonTransactiveCommandAttribute;
 import org.ovirt.engine.core.bll.context.CommandContext;
@@ -43,7 +42,8 @@ import org.ovirt.engine.core.utils.transaction.TransactionSupport;
 
 @NonTransactiveCommandAttribute
 @InternalCommandAttribute
-public class AddManagedBlockStorageDiskCommand<T extends AddManagedBlockStorageDiskParameters> extends CommandBase<T> {
+public class AddManagedBlockStorageDiskCommand<T extends AddManagedBlockStorageDiskParameters>
+        extends ManagedBlockStorageDiskCommandBase<T> {
 
     @Inject
     private ManagedBlockStorageDao managedBlockStorageDao;
@@ -107,6 +107,7 @@ public class AddManagedBlockStorageDiskCommand<T extends AddManagedBlockStorageD
 
         saveDisk(volumeId);
         getReturnValue().setActionReturnValue(volumeId);
+        refreshAffectedDomain(getParameters().getStorageDomainId());
         setSucceeded(true);
         persistCommandIfNeeded();
     }

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/managedblock/CloneSingleManagedBlockDiskCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/managedblock/CloneSingleManagedBlockDiskCommand.java
@@ -10,7 +10,6 @@ import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.Typed;
 import javax.inject.Inject;
 
-import org.ovirt.engine.core.bll.CommandBase;
 import org.ovirt.engine.core.bll.ConcurrentChildCommandsExecutionCallback;
 import org.ovirt.engine.core.bll.InternalCommandAttribute;
 import org.ovirt.engine.core.bll.context.CommandContext;
@@ -42,7 +41,8 @@ import org.ovirt.engine.core.utils.JsonHelper;
 import org.ovirt.engine.core.utils.transaction.TransactionSupport;
 
 @InternalCommandAttribute
-public class CloneSingleManagedBlockDiskCommand<T extends ImagesContainterParametersBase> extends CommandBase<T> {
+public class CloneSingleManagedBlockDiskCommand<T extends ImagesContainterParametersBase>
+        extends ManagedBlockStorageDiskCommandBase<T> {
     @Inject
     private ManagedBlockStorageDao managedBlockStorageDao;
     @Inject
@@ -101,6 +101,7 @@ public class CloneSingleManagedBlockDiskCommand<T extends ImagesContainterParame
 
         unlockImage();
         getReturnValue().setActionReturnValue(clonedVolumeId);
+        refreshAffectedDomain(getParameters().getStorageDomainId());
         setSucceeded(true);
     }
 
@@ -178,6 +179,5 @@ public class CloneSingleManagedBlockDiskCommand<T extends ImagesContainterParame
     public CommandCallback getCallback() {
         return callbackProvider.get();
     }
-
 
 }

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/managedblock/CreateManagedBlockStorageDiskSnapshotCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/managedblock/CreateManagedBlockStorageDiskSnapshotCommand.java
@@ -6,7 +6,6 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import org.ovirt.engine.core.bll.CommandBase;
 import org.ovirt.engine.core.bll.NonTransactiveCommandAttribute;
 import org.ovirt.engine.core.bll.context.CommandContext;
 import org.ovirt.engine.core.bll.storage.disk.image.ImagesHandler;
@@ -36,7 +35,7 @@ import org.ovirt.engine.core.utils.transaction.TransactionSupport;
 
 @NonTransactiveCommandAttribute
 public class CreateManagedBlockStorageDiskSnapshotCommand<T extends CreateManagedBlockStorageDiskSnapshotParameters>
-        extends CommandBase<T> {
+        extends ManagedBlockStorageDiskCommandBase<T> {
 
     @Inject
     private ManagedBlockExecutor managedBlockExecutor;
@@ -102,6 +101,7 @@ public class CreateManagedBlockStorageDiskSnapshotCommand<T extends CreateManage
         // To be used later when rolling back
         getParameters().setImageId(snapshotId);
 
+        refreshAffectedDomain(getParameters().getStorageDomainId());
         setSucceeded(true);
     }
 

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/managedblock/ExtendManagedBlockStorageDiskSizeCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/managedblock/ExtendManagedBlockStorageDiskSizeCommand.java
@@ -14,6 +14,7 @@ import org.ovirt.engine.core.bll.ConcurrentChildCommandsExecutionCallback;
 import org.ovirt.engine.core.bll.InternalCommandAttribute;
 import org.ovirt.engine.core.bll.context.CommandContext;
 import org.ovirt.engine.core.bll.storage.disk.UpdateDiskCommand;
+import org.ovirt.engine.core.bll.storage.domain.ManagedBlockStorageDomainStatsRefresher;
 import org.ovirt.engine.core.bll.tasks.interfaces.CommandCallback;
 import org.ovirt.engine.core.common.VdcObjectType;
 import org.ovirt.engine.core.common.action.ExtendManagedBlockStorageDiskSizeParameters;
@@ -41,6 +42,9 @@ public class ExtendManagedBlockStorageDiskSizeCommand<T extends ExtendManagedBlo
 
     @Inject
     private ImageDao imageDao;
+
+    @Inject
+    private ManagedBlockStorageDomainStatsRefresher mbsStatsRefresher;
 
     @Inject
     @Typed(ConcurrentChildCommandsExecutionCallback.class)
@@ -84,6 +88,7 @@ public class ExtendManagedBlockStorageDiskSizeCommand<T extends ExtendManagedBlo
         }
 
         updateDisk();
+        mbsStatsRefresher.refresh(getParameters().getStorageDomainId());
         setSucceeded(true);
     }
 

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/managedblock/ManagedBlockStorageDiskCommandBase.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/managedblock/ManagedBlockStorageDiskCommandBase.java
@@ -1,0 +1,34 @@
+package org.ovirt.engine.core.bll.storage.disk.managedblock;
+
+import javax.inject.Inject;
+
+import org.ovirt.engine.core.bll.CommandBase;
+import org.ovirt.engine.core.bll.context.CommandContext;
+import org.ovirt.engine.core.bll.storage.domain.ManagedBlockStorageDomainStatsRefresher;
+import org.ovirt.engine.core.common.action.ActionParametersBase;
+import org.ovirt.engine.core.compat.Guid;
+
+/**
+ * Base class for MBS commands that mutate domain capacity. Subclasses call
+ * refreshAffectedDomain() at the end of executeCommand() once the adapter
+ * operation has succeeded - end methods are not reliably invoked across
+ * this command family.
+ */
+public abstract class ManagedBlockStorageDiskCommandBase<T extends ActionParametersBase> extends CommandBase<T> {
+
+    @Inject
+    private ManagedBlockStorageDomainStatsRefresher mbsStatsRefresher;
+
+    protected ManagedBlockStorageDiskCommandBase(Guid commandId) {
+        super(commandId);
+    }
+
+    protected ManagedBlockStorageDiskCommandBase(T parameters, CommandContext cmdContext) {
+        super(parameters, cmdContext);
+    }
+
+    /** Schedule an async capacity refresh for the domain this command mutated. */
+    protected void refreshAffectedDomain(Guid storageDomainId) {
+        mbsStatsRefresher.refresh(storageDomainId);
+    }
+}

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/managedblock/RemoveManagedBlockStorageDiskCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/managedblock/RemoveManagedBlockStorageDiskCommand.java
@@ -10,7 +10,6 @@ import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.Typed;
 import javax.inject.Inject;
 
-import org.ovirt.engine.core.bll.CommandBase;
 import org.ovirt.engine.core.bll.ConcurrentChildCommandsExecutionCallback;
 import org.ovirt.engine.core.bll.InternalCommandAttribute;
 import org.ovirt.engine.core.bll.context.CommandContext;
@@ -36,7 +35,8 @@ import org.ovirt.engine.core.utils.JsonHelper;
 import org.ovirt.engine.core.utils.transaction.TransactionSupport;
 
 @InternalCommandAttribute
-public class RemoveManagedBlockStorageDiskCommand<T extends RemoveDiskParameters> extends CommandBase<T> {
+public class RemoveManagedBlockStorageDiskCommand<T extends RemoveDiskParameters>
+        extends ManagedBlockStorageDiskCommandBase<T> {
 
     @Inject
     private ImageDao imageDao;
@@ -106,6 +106,7 @@ public class RemoveManagedBlockStorageDiskCommand<T extends RemoveDiskParameters
 
         removeDiskFromDb();
         getReturnValue().setActionReturnValue(true);
+        refreshAffectedDomain(getParameters().getStorageDomainId());
         setSucceeded(true);
         persistCommandIfNeeded();
     }

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/managedblock/RemoveManagedBlockStorageSnapshotCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/managedblock/RemoveManagedBlockStorageSnapshotCommand.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import org.ovirt.engine.core.bll.CommandBase;
 import org.ovirt.engine.core.bll.NonTransactiveCommandAttribute;
 import org.ovirt.engine.core.bll.context.CommandContext;
 import org.ovirt.engine.core.bll.utils.PermissionSubject;
@@ -23,7 +22,8 @@ import org.ovirt.engine.core.utils.JsonHelper;
 import org.ovirt.engine.core.utils.transaction.TransactionSupport;
 
 @NonTransactiveCommandAttribute
-public class RemoveManagedBlockStorageSnapshotCommand<T extends ImagesContainterParametersBase> extends CommandBase<T> {
+public class RemoveManagedBlockStorageSnapshotCommand<T extends ImagesContainterParametersBase>
+        extends ManagedBlockStorageDiskCommandBase<T> {
 
     @Inject
     private ManagedBlockExecutor managedBlockExecutor;
@@ -78,6 +78,7 @@ public class RemoveManagedBlockStorageSnapshotCommand<T extends ImagesContainter
         }
 
         removeSnapshotFromDB();
+        refreshAffectedDomain(getParameters().getStorageDomainId());
         setSucceeded(true);
     }
 

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/domain/AddManagedBlockStorageDomainCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/domain/AddManagedBlockStorageDomainCommand.java
@@ -19,6 +19,9 @@ public class AddManagedBlockStorageDomainCommand<T extends AddManagedBlockStorag
     @Inject
     private ManagedBlockStorageDao managedBlockStorageDao;
 
+    @Inject
+    private ManagedBlockStorageDomainStatsRefresher mbsStatsRefresher;
+
     public AddManagedBlockStorageDomainCommand(Guid commandId) {
         super(commandId);
     }
@@ -53,6 +56,7 @@ public class AddManagedBlockStorageDomainCommand<T extends AddManagedBlockStorag
         managedBlockStorage.setDriverOptions(parameters.getDriverOptions());
         managedBlockStorage.setDriverSensitiveOptions(parameters.getDriverSensitiveOptions());
         managedBlockStorageDao.save(managedBlockStorage);
+        mbsStatsRefresher.refresh(getStorageDomainId());
         setSucceeded(true);
     }
 

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/domain/GetManagedBlockStorageStatsCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/domain/GetManagedBlockStorageStatsCommand.java
@@ -40,9 +40,17 @@ public class GetManagedBlockStorageStatsCommand<T extends AddManagedBlockStorage
 
     @Override
     protected void executeCommand() {
-        Map<String, Object> driverOptions = new HashMap<>(getParameters().getDriverOptions());
+        Map<String, Object> driverOptions = new HashMap<>();
+        if (getParameters().getDriverOptions() != null) {
+            driverOptions.putAll(getParameters().getDriverOptions());
+        }
         if (getParameters().getDriverSensitiveOptions() != null) {
             driverOptions.putAll(getParameters().getDriverSensitiveOptions());
+        }
+        if (driverOptions.isEmpty()) {
+            log.warn("No driver options for MBS domain '{}'; cannot fetch stats",
+                    getParameters().getStorageDomainId());
+            return;
         }
 
         ManagedBlockReturnValue returnValue = null;

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/domain/ManagedBlockStorageDomainStatsRefresher.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/domain/ManagedBlockStorageDomainStatsRefresher.java
@@ -1,0 +1,174 @@
+package org.ovirt.engine.core.bll.storage.domain;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.ejb.Singleton;
+import javax.enterprise.concurrent.ManagedScheduledExecutorService;
+import javax.inject.Inject;
+
+import org.ovirt.engine.core.bll.interfaces.BackendInternal;
+import org.ovirt.engine.core.common.action.ActionReturnValue;
+import org.ovirt.engine.core.common.action.ActionType;
+import org.ovirt.engine.core.common.action.AddManagedBlockStorageDomainParameters;
+import org.ovirt.engine.core.common.businessentities.StorageDomainDynamic;
+import org.ovirt.engine.core.common.businessentities.storage.ManagedBlockStorage;
+import org.ovirt.engine.core.compat.Guid;
+import org.ovirt.engine.core.dao.ManagedBlockStorageDao;
+import org.ovirt.engine.core.dao.StorageDomainDynamicDao;
+import org.ovirt.engine.core.utils.threadpool.ThreadPools;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Re-invoke GetManagedBlockStorageStats for an MBS domain and persist the
+ * returned capacity into storage_domain_dynamic. Used by:
+ *   - AddManagedBlockStorageDomainCommand (post-create)
+ *   - Backend.initialize() (post-startup, for existing Active domains)
+ *   - Disk-mutating MBS commands (post-execute, lazy refresh)
+ *
+ * Failure is non-fatal: callers continue regardless. Capacity is best-effort
+ * eventually-consistent, never load-bearing.
+ */
+@Singleton
+public class ManagedBlockStorageDomainStatsRefresher {
+
+    private static final Logger log = LoggerFactory.getLogger(ManagedBlockStorageDomainStatsRefresher.class);
+
+    @Inject
+    private BackendInternal backend;
+
+    @Inject
+    private ManagedBlockStorageDao managedBlockStorageDao;
+
+    @Inject
+    private StorageDomainDynamicDao storageDomainDynamicDao;
+
+    @Inject
+    @ThreadPools(ThreadPools.ThreadPoolType.EngineScheduledThreadPool)
+    private ManagedScheduledExecutorService executor;
+
+    private enum RefreshState {
+        RUNNING,
+        RERUN_REQUESTED
+    }
+
+    private final ConcurrentHashMap<Guid, RefreshState> refreshStates = new ConcurrentHashMap<>();
+
+    public void refresh(Guid storageDomainId) {
+        if (storageDomainId == null) {
+            return;
+        }
+        // Claim the per-domain slot - if a refresh is already in flight it may
+        // have sampled stats before the caller's operation took effect, so
+        // request a trailing rerun instead of scheduling a concurrent one
+        if (refreshStates.compute(storageDomainId,
+                (id, state) -> state == null ? RefreshState.RUNNING : RefreshState.RERUN_REQUESTED)
+                == RefreshState.RUNNING) {
+            executor.execute(() -> runRefreshLoop(storageDomainId));
+        }
+    }
+
+    private void runRefreshLoop(Guid storageDomainId) {
+        try {
+            while (true) {
+                doRefresh(storageDomainId);
+                if (refreshStates.remove(storageDomainId, RefreshState.RUNNING)) {
+                    return;
+                }
+                refreshStates.put(storageDomainId, RefreshState.RUNNING);
+            }
+        } catch (Throwable t) {
+            refreshStates.remove(storageDomainId);
+            throw t;
+        }
+    }
+
+    private void doRefresh(Guid storageDomainId) {
+        try {
+            ManagedBlockStorage mbs = managedBlockStorageDao.get(storageDomainId);
+            if (mbs == null) {
+                log.warn("MBS domain '{}' has no driver options row; skipping stats refresh",
+                        storageDomainId);
+                return;
+            }
+            if (mbs.getDriverOptions() == null && mbs.getDriverSensitiveOptions() == null) {
+                log.warn("MBS domain '{}' has no driver options; skipping stats refresh",
+                        storageDomainId);
+                return;
+            }
+            AddManagedBlockStorageDomainParameters params =
+                    new AddManagedBlockStorageDomainParameters();
+            params.setStorageDomainId(storageDomainId);
+            params.setDriverOptions(mbs.getDriverOptions());
+            params.setDriverSensitiveOptions(mbs.getDriverSensitiveOptions());
+
+            ActionReturnValue rv = backend.runInternalAction(
+                    ActionType.GetManagedBlockStorageStats, params);
+            if (rv == null || !rv.getSucceeded() || rv.getActionReturnValue() == null) {
+                log.warn("Could not retrieve stats for MBS domain '{}'", storageDomainId);
+                return;
+            }
+            Map<String, Object> stats = rv.getActionReturnValue();
+            Object totalRaw = stats.get("total_capacity_gb");
+            Object freeRaw = stats.get("free_capacity_gb");
+            Integer totalGb = parseCapacityGb(totalRaw);
+            Integer freeGb = parseCapacityGb(freeRaw);
+            if (totalGb == null || freeGb == null) {
+                if (isCapacitySentinel(totalRaw) || isCapacitySentinel(freeRaw)) {
+                    // expected per the Cinder volume-stats spec - keep the last persisted values
+                    log.debug("MBS domain '{}' reports non-numeric capacity (total={}, free={})",
+                            storageDomainId, totalRaw, freeRaw);
+                } else {
+                    log.warn("Stats for MBS domain '{}' missing usable capacity fields (total={}, free={})",
+                            storageDomainId, totalRaw, freeRaw);
+                }
+                return;
+            }
+            StorageDomainDynamic dynamic = storageDomainDynamicDao.get(storageDomainId);
+            boolean isNewRow = dynamic == null;
+            if (isNewRow) {
+                dynamic = new StorageDomainDynamic();
+                dynamic.setId(storageDomainId);
+            }
+            dynamic.setAvailableDiskSize(freeGb);
+            dynamic.setUsedDiskSize(Math.max(0, totalGb - freeGb));
+            if (isNewRow) {
+                storageDomainDynamicDao.save(dynamic);
+            } else {
+                storageDomainDynamicDao.update(dynamic);
+            }
+            log.info("Refreshed capacity for MBS domain '{}': total={}GB free={}GB",
+                    storageDomainId, totalGb, freeGb);
+        } catch (Exception e) {
+            log.warn("Could not refresh stats for MBS domain '{}': {}",
+                    storageDomainId, e.getMessage());
+        }
+    }
+
+    /**
+     * Cinder drivers report capacity as a number, a numeric string (possibly
+     * fractional), or the sentinels 'unknown' / 'infinite'.
+     */
+    private static Integer parseCapacityGb(Object v) {
+        if (v == null || isCapacitySentinel(v)) {
+            return null;
+        }
+        if (v instanceof Number) {
+            return ((Number) v).intValue();
+        }
+        try {
+            return (int) Double.parseDouble(v.toString().trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private static boolean isCapacitySentinel(Object v) {
+        if (!(v instanceof String)) {
+            return false;
+        }
+        String s = ((String) v).trim();
+        return "unknown".equalsIgnoreCase(s) || "infinite".equalsIgnoreCase(s);
+    }
+}

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/domain/ManagedBlockStorageStatsRefreshOnStartup.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/domain/ManagedBlockStorageStatsRefreshOnStartup.java
@@ -1,0 +1,63 @@
+package org.ovirt.engine.core.bll.storage.domain;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.annotation.PostConstruct;
+import javax.ejb.DependsOn;
+import javax.ejb.Singleton;
+import javax.ejb.Startup;
+import javax.inject.Inject;
+
+import org.ovirt.engine.core.common.businessentities.StorageDomain;
+import org.ovirt.engine.core.common.businessentities.StorageDomainStatus;
+import org.ovirt.engine.core.common.businessentities.storage.StorageType;
+import org.ovirt.engine.core.compat.Guid;
+import org.ovirt.engine.core.dao.StorageDomainDao;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Refresh capacity stats for every Active Managed Block Storage domain
+ * once at engine startup. Without this, MBS domains show stale or [N/A]
+ * capacity in the UI after an engine restart, because the SPM-style
+ * storage monitor does not cover MBS domains.
+ *
+ * Runs after Backend.@PostConstruct via @DependsOn("Backend"), so the
+ * helper's call into BackendInternal.runInternalAction is safe (no
+ * recursive entry into Backend's @PostConstruct).
+ *
+ * Per-domain failures are non-fatal: each is best-effort.
+ */
+@Singleton
+@Startup
+@DependsOn("Backend")
+public class ManagedBlockStorageStatsRefreshOnStartup {
+
+    private static final Logger log = LoggerFactory.getLogger(ManagedBlockStorageStatsRefreshOnStartup.class);
+
+    @Inject
+    private StorageDomainDao storageDomainDao;
+
+    @Inject
+    private ManagedBlockStorageDomainStatsRefresher refresher;
+
+    @PostConstruct
+    public void refreshAll() {
+        try {
+            List<Guid> domainIds = storageDomainDao.getAll().stream()
+                    .filter(domain -> domain.getStorageType() == StorageType.MANAGED_BLOCK_STORAGE)
+                    .filter(domain -> domain.getStatus() == StorageDomainStatus.Active)
+                    .map(StorageDomain::getId)
+                    .distinct()
+                    .collect(Collectors.toList());
+            domainIds.forEach(refresher::refresh);
+            if (!domainIds.isEmpty()) {
+                log.info("Triggered startup capacity refresh for {} Active MBS domain(s)",
+                        domainIds.size());
+            }
+        } catch (Exception e) {
+            log.warn("Could not refresh MBS domain stats at startup: {}", e.getMessage());
+        }
+    }
+}

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/AddManagedBlockStorageDomainParameters.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/AddManagedBlockStorageDomainParameters.java
@@ -31,7 +31,7 @@ public class AddManagedBlockStorageDomainParameters extends StorageDomainManagem
         this.driverOptions = driverOptions;
     }
 
-    public void setSriverSensitiveOptions(Map<String, Object> driverSensitiveOptions) {
+    public void setDriverSensitiveOptions(Map<String, Object> driverSensitiveOptions) {
         this.driverSensitiveOptions = driverSensitiveOptions;
     }
 

--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendStorageDomainsResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendStorageDomainsResource.java
@@ -569,7 +569,7 @@ public class BackendStorageDomainsResource
         Map<String, Object> driverOptionsMap = new HashMap<>(CustomPropertiesParser.toObjectsMap(driverOptions, mapper));
         driverOptionsMap.put(AddManagedBlockStorageDomainParameters.VOLUME_BACKEND_NAME, entity.getName());
         params.setDriverOptions(driverOptionsMap);
-        params.setSriverSensitiveOptions(CustomPropertiesParser.toObjectsMap(driverSensitiveOptions));
+        params.setDriverSensitiveOptions(CustomPropertiesParser.toObjectsMap(driverSensitiveOptions));
         entity.setStorage(Guid.Empty.toString());
         params.setStorageDomain(entity);
         return params;

--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/storage/StorageListModel.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/storage/StorageListModel.java
@@ -1188,7 +1188,7 @@ public class StorageListModel extends ListWithSimpleDetailsModel<Void, StorageDo
         Map<String, Object> driverOptions = ManagedBlockStorageModel.getDriverOptions().serializeToMap();
         driverOptions.put(AddManagedBlockStorageDomainParameters.VOLUME_BACKEND_NAME, storageDomain.getStorageName());
         parameter.setDriverOptions(driverOptions);
-        parameter.setSriverSensitiveOptions(ManagedBlockStorageModel.getDriverSensitiveOptions().serializeToMap());
+        parameter.setDriverSensitiveOptions(ManagedBlockStorageModel.getDriverSensitiveOptions().serializeToMap());
 
         parameters.add(parameter);
 


### PR DESCRIPTION
The `storage_domain_dynamic` capacity fields (`total_disk_size`, `available_disk_size`) for Managed Block Storage domains stay NULL forever because the engine has no hook that fetches capacity from the MBS adapter and persists it. The SPM-style periodic storage monitor doesn't cover MBS. Operators see `[N/A]` for Total / Free in _Storage → Domains_ for every MBS row, with no way to recover.

This PR adds the three missing refresh hooks. Three commits, one per hook, kept separate to aid review:

1. **Post-create persist** (`96f1147`). `AddManagedBlockStorageDomainCommand.canDoAction()` already calls `GetManagedBlockStorageStats` to validate the domain at create time. Persist the result to `storage_domain_dynamic` after `executeCommand` so the UI shows real numbers immediately when the domain goes Active.
2. **Engine-startup refresh** (`e3a275d9`). On engine boot, iterate Active MBS domains and refresh capacity for each. Without this, capacity stays frozen across restarts (or remains NULL if create-time persist never ran).
3. **Refresh on capacity-mutating events** (`e3d74c3c`). Add / remove / extend / clone disk, create / remove snapshot — six commands hook into a shared `ManagedBlockStorageDomainStatsRefresher` singleton that re-runs `GetManagedBlockStorageStats` and persists.

Found and fixed while improving oVirt's Managed Block Storage support. Affects any MBS backend (StorPool, Ceph, LINSTOR).

Fixes #1154

## Changes introduced with this PR

* `ManagedBlockStorageDomainStatsRefresher` (new `@Singleton`): shared helper that re-fetches capacity via `GetManagedBlockStorageStats` and persists into `storage_domain_dynamic`. Failures non-fatal.
* `ManagedBlockStorageStatsRefreshOnStartup` (new `@Startup @DependsOn("Backend") @Singleton`): runs after Backend's `@PostConstruct` finishes, refreshes every Active MBS domain. The startup refresh is split into a separate singleton because calling `BackendInternal.runInternalAction` from inside `Backend.@PostConstruct` itself trips WildFly's `WFLYEJB0132` recursive-entry rejection; depending on `Backend` rather than living inside it sidesteps that.
* `AddManagedBlockStorageDomainCommand`: post-create call to the refresher so the new domain gets real capacity immediately.
* Six MBS disk / snapshot commands hook into the refresher in `executeCommand`: `AddManagedBlockStorageDiskCommand`, `RemoveManagedBlockStorageDiskCommand`, `ExtendManagedBlockStorageDiskSizeCommand`, `CloneSingleManagedBlockDiskCommand`, `CreateManagedBlockStorageDiskSnapshotCommand`, `RemoveManagedBlockStorageSnapshotCommand`.
* `Backend.java`: net `-105` lines from removing the inline refresh that got moved into the new singletons.
* No SPI change, no vdsm change, no schema change.

## Verification

Reproduced and verified end-to-end on a dev cluster with a LINSTOR-backed MBS domain.

Storage → Domains, MBS row showing real Total / Free / Allocated after the fix:

<img width="2158" height="569" alt="image" src="https://github.com/user-attachments/assets/a16b0a28-916b-448c-9954-1d3c1314fa7e" /><br />

End-to-end checks:

* Add MBS domain → row appears Active with real capacity (no longer `[N/A]`)
* Restart `ovirt-engine` → existing MBS rows still show real capacity within seconds of `Backend.initialize()` completing
* Create a 5 GiB disk on the MBS domain → Free drops by ~5 GiB within seconds
* Remove the disk → Free returns to original
* Extend a disk by 5 GiB → Free drops by ~5 GiB within seconds
* Adapter returns a transient error → existing capacity is left in place rather than blanked back to NULL (failure-non-fatal)

## Are you the owner of the code you are sending in, or do you have permission of the owner?

Yes.
