### PR TITLE
ansible: fix kdump role crashkernel check using literal regexp instead of variable

### DIFF
--- a/packaging/ansible-runner-service-project/project/roles/ovirt-host-deploy-kdump/tasks/main.yml
+++ b/packaging/ansible-runner-service-project/project/roles/ovirt-host-deploy-kdump/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Verify if crashkernel parameter is set
   ansible.builtin.lineinfile:
     dest: /proc/cmdline
-    regexp: crashkernel_regexp
+    regexp: "{{ crashkernel_regexp }}"
   check_mode: true
   register: crashkernel_param
   failed_when: crashkernel_param.changed


### PR DESCRIPTION
## Changes introduced with this PR

Interpolate the `crashkernel_regexp` variable in the kdump role's
`lineinfile` task (`roles/ovirt-host-deploy-kdump/tasks/main.yml`).
The regexp was previously the bare token `crashkernel_regexp`, so
`lineinfile` searched `/proc/cmdline` for that literal string, never
matched, and in `check_mode: true` always reported `changed=True`.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

y