### PR TITLE
core: mark MBS Copy destination as zero-initialized

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/CopyManagedBlockDiskCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/CopyManagedBlockDiskCommand.java
@@ -182,12 +182,14 @@ public class CopyManagedBlockDiskCommand<T extends CopyImageGroupWithDataCommand
                         getParameters().getImageGroupID(),
                         getParameters().getImageId(),
                         getParameters().getSourcePath(),
-                        getParameters().getLeaseStorageId()),
+                        getParameters().getLeaseStorageId(),
+                        false),
                 buildEndpoint(getParameters().getDestDomain(),
                         getParameters().getDestImageGroupId(),
                         getParameters().getDestinationImageId(),
                         getParameters().getTargetPath(),
-                        getParameters().getLeaseStorageId()),
+                        getParameters().getLeaseStorageId(),
+                        true),
                 false);
         parameters.setStorageJobId(getJobId());
         parameters.setVdsId(getParameters().getVdsRunningOn());
@@ -293,7 +295,8 @@ public class CopyManagedBlockDiskCommand<T extends CopyImageGroupWithDataCommand
             Guid diskId,
             Guid imageId,
             String path,
-            Guid leaseStorageDomainId) {
+            Guid leaseStorageDomainId,
+            boolean isDestination) {
         if (storageDomainDao.get(storageDomainId).getStorageType() == StorageType.MANAGED_BLOCK_STORAGE) {
             Map<String, Object> lease = new HashMap<>();
             lease.put("lease_id", getJobId().toString());
@@ -302,7 +305,7 @@ public class CopyManagedBlockDiskCommand<T extends CopyImageGroupWithDataCommand
                     lease,
                     0,
                     VolumeFormat.RAW,
-                    false,
+                    isDestination,
                     getParameters().getDestDomain());
         }
         return new VdsmImageLocationInfo(storageDomainId, diskId, imageId, null);


### PR DESCRIPTION
core: mark MBS Copy destination as zero-initialized

- buildEndpoint marked both source and destination zeroed=false
- qemu-img convert wrote zeros to dest, never promised target-is-zero
- on thin MBS pools the destination materialized at full logical size
- thread isDestination through buildEndpoint, set zeroed only on dest
- source stays zeroed=false; it still has to be read for real content
- MBS adapters create zero-initialized volumes by convention

Found and fixed while improving oVirt's Managed Block Storage support. Affects any MBS backend (StorPool, Ceph, LINSTOR) and Cinder disks.

Fixes #1157

## Changes introduced with this PR

- Add `isDestination` parameter to `CopyManagedBlockDiskCommand.buildEndpoint`. Source-side call passes `false`, destination-side call passes `true`.
- The flag flows into `ManagedBlockStorageLocationInfo.zeroed`. Vdsm's `CopyDataExternalEndpoint` already reads this and passes `--target-is-zero` to `qemu-img convert` accordingly.
- No vdsm change, no SPI change, no adapter change. Single one-file engine commit.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

Yes.
