### PR TITLE
core: mark MBS Copy destination as zero-initialized

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/CopyManagedBlockDiskCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/CopyManagedBlockDiskCommand.java
@@ -182,12 +182,14 @@ public class CopyManagedBlockDiskCommand<T extends CopyImageGroupWithDataCommand
                         getParameters().getImageGroupID(),
                         getParameters().getImageId(),
                         getParameters().getSourcePath(),
-                        getParameters().getLeaseStorageId()),
+                        getParameters().getLeaseStorageId(),
+                        false),
                 buildEndpoint(getParameters().getDestDomain(),
                         getParameters().getDestImageGroupId(),
                         getParameters().getDestinationImageId(),
                         getParameters().getTargetPath(),
-                        getParameters().getLeaseStorageId()),
+                        getParameters().getLeaseStorageId(),
+                        true),
                 false);
         parameters.setStorageJobId(getJobId());
         parameters.setVdsId(getParameters().getVdsRunningOn());
@@ -293,7 +295,8 @@ public class CopyManagedBlockDiskCommand<T extends CopyImageGroupWithDataCommand
             Guid diskId,
             Guid imageId,
             String path,
-            Guid leaseStorageDomainId) {
+            Guid leaseStorageDomainId,
+            boolean isDestination) {
         if (storageDomainDao.get(storageDomainId).getStorageType() == StorageType.MANAGED_BLOCK_STORAGE) {
             Map<String, Object> lease = new HashMap<>();
             lease.put("lease_id", getJobId().toString());
@@ -302,7 +305,7 @@ public class CopyManagedBlockDiskCommand<T extends CopyImageGroupWithDataCommand
                     lease,
                     0,
                     VolumeFormat.RAW,
-                    false,
+                    isDestination,
                     getParameters().getDestDomain());
         }
         return new VdsmImageLocationInfo(storageDomainId, diskId, imageId, null);

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/utils/LocationInfoHelper.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/utils/LocationInfoHelper.java
@@ -50,6 +50,7 @@ public class LocationInfoHelper {
             infoMap.put("generation", info.getGeneration());
             infoMap.put("format", volumeFormatToString(info.getFormat()));
             infoMap.put("is_zero", info.isZeroed());
+            infoMap.put("create", false);
             infoMap.put("endpoint_type", "external");
 
             return infoMap;


### PR DESCRIPTION
I pushed #1158 too soon before testing, this is the proper fix and survives block-for-block copy verification with `md5sum` verified volumes.

core: mark MBS Copy destination as zero-initialized

- buildEndpoint marked source and destination zeroed=false on MBS Copy
- LocationInfoHelper sent the MBS endpoint with no create field
- vdsm defaulted create=True so qemu-img skipped -n and --target-is-zero
- thread isDestination through buildEndpoint, set zeroed only on dest
- LocationInfoHelper now also sends create=false for MBS endpoints
- vdsm now runs qemu-img with -n --target-is-zero, dest stays thin

Found and fixed while improving oVirt's Managed Block Storage support. Affects any MBS backend (StorPool, Ceph, LINSTOR) and Cinder disks.

Fixes #1157

## Changes introduced with this PR

- `CopyManagedBlockDiskCommand.buildEndpoint` now takes an `isDestination` boolean. The source-side call passes `false`, the destination-side call passes `true`. Flag flows into `ManagedBlockStorageLocationInfo.zeroed`.
- `LocationInfoHelper.prepareLocationInfoForVdsCommand` now sets `create=false` on the MBS endpoint map, matching the fact that the destination block device already exists by the time `qemu-img convert` runs (the engine's `addManagedBlockDisk` + `attachVolume` calls earlier in `CopyManagedBlockDiskCommand.createVolumes` ensure that). Vdsm's `qemuimg.convert` only emits `--target-is-zero` when `create=False`, so this is required for the `is_zero=true` to take effect.
- No vdsm change, no SPI change, no adapter change. Single one-commit engine fix touching two files.

## Verification

Tested end-to-end on `ovirt-engine-4.5.8-0.master.20260424...` + `vdsm-4.50.7-202604291142...` against a thin LINSTOR pool. All four cells of the Copy matrix:

| Path | Result |
|---|---|
| MBS thin -> MBS thin same domain | Dest stayed thin (~tens of MiB) instead of inflating to the full 1 GiB logical size |
| iSCSI -> MBS thin | Dest stayed thin (~tens of MiB) for a 1 GiB destination of a small qcow2 source; `qemu-img compare` confirms identical content |
| MBS thin -> MBS thick | Dest fully allocated as expected for thick; md5 of the destination DRBD device matches the source byte-for-byte, so `is_zero=true` does not leak residual data on thick LVs |
| iSCSI -> iSCSI (regression check) | Goes through `CopyImageGroupWithDataCommand`, never enters the modified code path; completes unchanged |

Pre-fix evidence is in #1157: same Copy on cinderlib MBS produced a 1.00 GiB destination on every replica.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

Yes.
