### PR TITLE
Remove checkpoints on disk detach

### DIFF
--- a/.automation/build-srpm.sh
+++ b/.automation/build-srpm.sh
@@ -17,6 +17,7 @@ EXTRA_BUILD_FLAGS="${EXTRA_BUILD_FLAGS} --no-transfer-progress"
 EXTRA_BUILD_FLAGS="${EXTRA_BUILD_FLAGS} -Dgwt.userAgent=gecko1_8,safari"
 EXTRA_BUILD_FLAGS="${EXTRA_BUILD_FLAGS} -Dgwt.compiler.localWorkers=1"
 EXTRA_BUILD_FLAGS="${EXTRA_BUILD_FLAGS} -Dgwt.jvmArgs='-Xms1G -Xmx3G'"
+[ "${GITHUB_ACTIONS:-}" = "true" ] && EXTRA_BUILD_FLAGS="${EXTRA_BUILD_FLAGS} -P enable-dao-tests"
 
 export MAVEN_OPTS="-Xms1G -Xmx2G"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,18 @@ jobs:
 
     container:
       image: quay.io/ovirt/buildcontainer:${{ matrix.container-name }}
+    services:
+      postgres:
+        image: postgres:13
+        env:
+          POSTGRES_PASSWORD: ovirt
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
 
     steps:
     - name: Install required PyPI packages
@@ -35,15 +47,29 @@ jobs:
     - name: Ensure required packages are available for linting
       run: dnf -y install otopi python3-ovirt-setup-lib python3-daemon
 
+    - name: Install PostgreSQL client
+      run: dnf -y install postgresql
+
     - name: Checkout sources
       uses: ovirt/checkout-action@main
+
+    - name: Initialize test DB
+      run: |
+        # Initialize DB 
+        until pg_isready -h postgres -p 5432 -U postgres; do sleep 1; done
+        # set needed password and role for the tests
+        PGPASSWORD='ovirt' psql -h postgres -U postgres \
+          -c "DO \$\$ BEGIN IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = 'ovirt') THEN CREATE ROLE ovirt LOGIN PASSWORD 'ovirt'; ELSE ALTER ROLE ovirt WITH LOGIN PASSWORD 'ovirt'; END IF; END \$\$;"
+        PGPASSWORD='ovirt' psql -h postgres -U postgres \
+          -c "CREATE DATABASE engine_dao_tests OWNER ovirt;"
+        PGPASSWORD='ovirt' psql -h postgres -U postgres -d engine_dao_tests \
+          -c 'CREATE EXTENSION IF NOT EXISTS "uuid-ossp";'
+        # Run db schema scripts
+        PGPASSWORD='ovirt' ./packaging/dbscripts/schema.sh -d engine_dao_tests -u ovirt -s postgres -p 5432 -c apply
 
     - name: Perform build
       run: |
         .automation/build-rpm.sh $ARTIFACTS_DIR
-
-    - name: Run python check
-      run: build/python-check.sh
 
     - name: Create DNF repository
       run: |

--- a/README.adoc
+++ b/README.adoc
@@ -517,21 +517,34 @@ world, add `${PREFIX}/etc/ovirt-engine/engine.conf.d/20-setup-jmx-debug.conf` wi
 
 === DAO tests
 
-Create empty database for DAO tests refer to <<Database creation>>.
+In /etc/ovirt-engine/ a file named 'engine.conf' needs to be created with the following content:
 
-Provided user is `engine`, password is `engine` and database is
+```
+ENGINE_PKI_TRUST_STORE_TYPE=dummy
+ENGINE_PKI_TRUST_STORE=dummy
+ENGINE_PKI_TRUST_STORE_PASSWORD=
+ENGINE_PKI_ENGINE_STORE_TYPE=PKCS12
+ENGINE_PKI_ENGINE_STORE=/workspace/backend/manager/modules/dal/src/test/resources/key.p12
+ENGINE_PKI_ENGINE_STORE_PASSWORD=NoSoup4U
+ENGINE_PKI_ENGINE_STORE_ALIAS=1
+ENGINE_DB_CONNECTION_TIMEOUT=0
+ENGINE_DB_CHECK_INTERVAL=0
+```
+
+Create empty database for DAO tests:
+
+```
+  psql -h localhost -U postgres -c "CREATE DATABASE engine_dao_tests OWNER ovirt;"
+```
+
+Provided user is `ovirt`, password is `ovirt` and database is
 `engine_dao_tests`.
 
-  $ PGPASSWORD=engine \
-    ./packaging/dbscripts/schema.sh \
-      -c apply -u engine -d engine_dao_tests
+  $  PGPASSWORD='ovirt' ./packaging/dbscripts/schema.sh -d engine_dao_tests -u ovirt -s postgres -p 5432 -c apply
 
 Run build as:
 
-  $ make maven BUILD_GWT=0 BUILD_UT=1 EXTRA_BUILD_FLAGS="-P enable-dao-tests \
-    -D engine.db.username=engine \
-    -D engine.db.password=engine \
-    -D engine.db.url=jdbc:postgresql://localhost/engine_dao_tests"
+  $ make install-dev EXTRA_BUILD_FLAGS="-P enable-dao-tests"
 
 === VM console
 

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/VmCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/VmCommand.java
@@ -30,6 +30,7 @@ import org.ovirt.engine.core.common.action.ActionType;
 import org.ovirt.engine.core.common.action.RemoveDiskParameters;
 import org.ovirt.engine.core.common.action.VmLeaseParameters;
 import org.ovirt.engine.core.common.action.VmOperationParameterBase;
+import org.ovirt.engine.core.common.action.VolumeBitmapCommandParameters;
 import org.ovirt.engine.core.common.asynctasks.AsyncTaskType;
 import org.ovirt.engine.core.common.asynctasks.EntityInfo;
 import org.ovirt.engine.core.common.businessentities.OriginType;
@@ -39,6 +40,7 @@ import org.ovirt.engine.core.common.businessentities.StorageDomain;
 import org.ovirt.engine.core.common.businessentities.TagsVmMap;
 import org.ovirt.engine.core.common.businessentities.VM;
 import org.ovirt.engine.core.common.businessentities.VMStatus;
+import org.ovirt.engine.core.common.businessentities.VdsmImageLocationInfo;
 import org.ovirt.engine.core.common.businessentities.VmBackup;
 import org.ovirt.engine.core.common.businessentities.VmPayload;
 import org.ovirt.engine.core.common.businessentities.VmStatic;
@@ -645,5 +647,36 @@ public abstract class VmCommand<T extends VmOperationParameterBase> extends Comm
 
     protected VdsManager getVdsManager(Guid vdsId) {
         return resourceManager.getVdsManager(vdsId);
+    }
+
+    public void clearDiskBitmaps(List<DiskImage> diskImages) {
+        // Remove the bitmap from all the disk snapshots.
+        for (DiskImage image : diskImages) {
+            // RAW volumes do not support bitmaps
+            if (!image.isQcowFormat()) {
+                continue;
+            }
+
+            log.info("Clear all bitmaps from VM '{}' for volume '{}'.", getVmName(), image.getId());
+            VdsmImageLocationInfo locationInfo = new VdsmImageLocationInfo(
+                    image.getStorageIds().get(0),
+                    image.getId(),
+                    image.getImageId(),
+                    null);
+
+            VolumeBitmapCommandParameters parameters =
+                    new VolumeBitmapCommandParameters(
+                            getStoragePoolId(),
+                            locationInfo,
+                            null);
+            parameters.setEndProcedure(ActionParametersBase.EndProcedure.COMMAND_MANAGED);
+            parameters.setParentCommand(getActionType());
+            parameters.setParentParameters(getParameters());
+
+            ActionReturnValue returnValue = runInternalActionWithTasksContext(ActionType.ClearVolumeBitmaps, parameters);
+            if (!returnValue.getSucceeded()) {
+                log.error("Failed to remove all bitmaps for VM '{}' volume '{}'", getVmName(), image.getId());
+            }
+        }
     }
 }

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/backup/DeleteAllVmCheckpointsCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/backup/DeleteAllVmCheckpointsCommand.java
@@ -16,13 +16,8 @@ import org.ovirt.engine.core.bll.SerialChildExecutingCommand;
 import org.ovirt.engine.core.bll.VmCommand;
 import org.ovirt.engine.core.bll.context.CommandContext;
 import org.ovirt.engine.core.bll.tasks.interfaces.CommandCallback;
-import org.ovirt.engine.core.common.action.ActionParametersBase;
-import org.ovirt.engine.core.common.action.ActionReturnValue;
-import org.ovirt.engine.core.common.action.ActionType;
 import org.ovirt.engine.core.common.action.DeleteAllVmCheckpointsParameters;
 import org.ovirt.engine.core.common.action.LockProperties;
-import org.ovirt.engine.core.common.action.VolumeBitmapCommandParameters;
-import org.ovirt.engine.core.common.businessentities.VdsmImageLocationInfo;
 import org.ovirt.engine.core.common.businessentities.storage.DiskImage;
 import org.ovirt.engine.core.common.errors.EngineMessage;
 import org.ovirt.engine.core.common.locks.LockingGroup;
@@ -73,43 +68,12 @@ public class DeleteAllVmCheckpointsCommand<T extends DeleteAllVmCheckpointsParam
             });
             return false;
         }
+        List<DiskImage> diskImages = diskImageDao.getAllSnapshotsForLeaf(getParameters().getCurrentDisk().getImageId());
 
-        clearDiskBitmaps(getParameters().getDiskImages().get(getParameters().getCompletedDisksCount()));
-        getParameters().setCompletedDisksCount(getParameters().getCompletedDisksCount() + 1);
+        clearDiskBitmaps(diskImages);
+        getParameters().advanceToNextDisk();
         persistCommandIfNeeded();
         return true;
-    }
-
-    private void clearDiskBitmaps(DiskImage diskImage) {
-        List<DiskImage> diskImages = diskImageDao.getAllSnapshotsForLeaf(diskImage.getImageId());
-        // Remove the bitmap from all the disk snapshots.
-        for (DiskImage image : diskImages) {
-            // RAW volumes do not support bitmaps
-            if (!image.isQcowFormat()) {
-                continue;
-            }
-
-            log.info("Clear all bitmaps from VM '{}' volume '{}'.", getVmName(), image.getId());
-            VdsmImageLocationInfo locationInfo = new VdsmImageLocationInfo(
-                    image.getStorageIds().get(0),
-                    image.getId(),
-                    image.getImageId(),
-                    null);
-
-            VolumeBitmapCommandParameters parameters =
-                    new VolumeBitmapCommandParameters(
-                            getStoragePoolId(),
-                            locationInfo,
-                            null);
-            parameters.setEndProcedure(ActionParametersBase.EndProcedure.COMMAND_MANAGED);
-            parameters.setParentCommand(getActionType());
-            parameters.setParentParameters(getParameters());
-
-            ActionReturnValue returnValue = runInternalActionWithTasksContext(ActionType.ClearVolumeBitmaps, parameters);
-            if (!returnValue.getSucceeded()) {
-                log.error("Failed to remove all bitmaps for VM '{}' volume '{}'", getVmName(), image.getId());
-            }
-        }
     }
 
     @Override

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/DetachDiskFromVmCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/DetachDiskFromVmCommand.java
@@ -22,6 +22,7 @@ import org.ovirt.engine.core.compat.Guid;
 import org.ovirt.engine.core.dao.DiskImageDao;
 import org.ovirt.engine.core.dao.DiskVmElementDao;
 import org.ovirt.engine.core.dao.ImageDao;
+import org.ovirt.engine.core.dao.VmCheckpointDao;
 import org.ovirt.engine.core.dao.VmDeviceDao;
 import org.ovirt.engine.core.dao.VmStaticDao;
 import org.ovirt.engine.core.utils.transaction.TransactionSupport;
@@ -41,6 +42,8 @@ public class DetachDiskFromVmCommand<T extends AttachDetachVmDiskParameters> ext
     private ImageDao imageDao;
     @Inject
     private VmStaticDao vmStaticDao;
+    @Inject
+    private VmCheckpointDao vmCheckpointDao;
 
     private Disk disk;
     private VmDevice vmDevice;
@@ -130,7 +133,8 @@ public class DetachDiskFromVmCommand<T extends AttachDetachVmDiskParameters> ext
                     // clears snapshot ID
                     imageDao.updateImageVmSnapshotId(((DiskImage) disk).getImageId(), null);
                 }
-
+                clearDiskBitmaps(diskImageDao.getAllSnapshotsForImageGroup(disk.getId()));
+                vmCheckpointDao.removeAllCheckpointsByDiskId(disk.getId());
                 vmStaticDao.incrementDbGeneration(getVm().getId());
                 return null;
             });

--- a/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/DeleteAllVmCheckpointsCommandTest.java
+++ b/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/DeleteAllVmCheckpointsCommandTest.java
@@ -1,0 +1,67 @@
+package org.ovirt.engine.core.bll;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.ovirt.engine.core.bll.storage.backup.DeleteAllVmCheckpointsCommand;
+import org.ovirt.engine.core.common.action.ActionParametersBase;
+import org.ovirt.engine.core.common.action.ActionReturnValue;
+import org.ovirt.engine.core.common.action.ActionType;
+import org.ovirt.engine.core.common.action.DeleteAllVmCheckpointsParameters;
+import org.ovirt.engine.core.common.action.VolumeBitmapCommandParameters;
+import org.ovirt.engine.core.common.businessentities.storage.DiskImage;
+import org.ovirt.engine.core.common.businessentities.storage.VolumeFormat;
+import org.ovirt.engine.core.compat.Guid;
+
+public class DeleteAllVmCheckpointsCommandTest {
+
+    @Test
+    public void clearDiskBitmapsCallsInternalActionOnlyForQcow() {
+        Guid vmId = Guid.newGuid();
+        DeleteAllVmCheckpointsParameters params =
+                new DeleteAllVmCheckpointsParameters(vmId, new ArrayList<>());
+        DeleteAllVmCheckpointsCommand<DeleteAllVmCheckpointsParameters> cmd =
+                spy(new DeleteAllVmCheckpointsCommand<>(params, null));
+
+        doReturn(Guid.newGuid()).when(cmd).getStoragePoolId();
+
+        ActionReturnValue ok = new ActionReturnValue();
+        ok.setSucceeded(true);
+        doReturn(ok).when(cmd).runInternalActionWithTasksContext(
+                eq(ActionType.ClearVolumeBitmaps), any(VolumeBitmapCommandParameters.class));
+
+        DiskImage raw = new DiskImage();
+        raw.setVolumeFormat(VolumeFormat.RAW);
+        raw.setId(Guid.newGuid());
+        raw.setImageId(Guid.newGuid());
+        raw.setStorageIds(List.of(Guid.newGuid()));
+
+        DiskImage qcow = new DiskImage();
+        qcow.setVolumeFormat(VolumeFormat.COW);
+        qcow.setId(Guid.newGuid());
+        qcow.setImageId(Guid.newGuid());
+        qcow.setStorageIds(List.of(Guid.newGuid()));
+
+        cmd.clearDiskBitmaps(List.of(raw, qcow));
+
+        ArgumentCaptor<VolumeBitmapCommandParameters> captor =
+                ArgumentCaptor.forClass(VolumeBitmapCommandParameters.class);
+
+        verify(cmd, times(1)).runInternalActionWithTasksContext(
+                eq(ActionType.ClearVolumeBitmaps), captor.capture());
+
+        VolumeBitmapCommandParameters sent = captor.getValue();
+        assertEquals(ActionParametersBase.EndProcedure.COMMAND_MANAGED, sent.getEndProcedure());
+        assertEquals(params, sent.getParentParameters());
+    }
+}

--- a/backend/manager/modules/bll/src/test/resources/test-database.properties
+++ b/backend/manager/modules/bll/src/test/resources/test-database.properties
@@ -1,3 +1,3 @@
-engine.db.url=jdbc:postgresql://localhost/engine_dao_tests
-engine.db.username=engine
-engine.db.password=engine
+engine.db.url=jdbc:postgresql://postgres/engine_dao_tests
+engine.db.username=ovirt
+engine.db.password=ovirt

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/DeleteAllVmCheckpointsParameters.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/action/DeleteAllVmCheckpointsParameters.java
@@ -41,4 +41,12 @@ public class DeleteAllVmCheckpointsParameters extends VmOperationParameterBase {
     public void setCompletedDisksCount(int completedDisksCount) {
         this.completedDisksCount = completedDisksCount;
     }
+
+    public DiskImage getCurrentDisk() {
+        return diskImages.get(completedDisksCount);
+    }
+
+    public void advanceToNextDisk() {
+        completedDisksCount++;
+    }
 }

--- a/backend/manager/modules/dal/README
+++ b/backend/manager/modules/dal/README
@@ -24,35 +24,16 @@ To run the DAO tests manually you can either do:
 
   $> mvn -P enable-dao-tests test
 
-or enable them using your ~/.m2/settings.xml:
-
-   <activeProfiles>
-     <activeProfile>enable-dao-tests</activeProfile>
-   </activeProfiles>
 
 You can also choose to run individual tests:
 
-  $> mvn -D test=VdcOptionDAOTest test
+  $> mvn -pl backend/manager/modules/dal -Dtest=VdcOptionDaoTest -P enable-dao-tests test
 
 By default, this will run the tests using the JDBC implementation
 against a PostgreSQL database called 'engine_dao_tests' on the
-localhost using the username 'engine' and password 'engine'.
+localhost using the username 'ovirt' and password 'ovirt'.
 
-You can change the database configuration in ~/.m2/settings.xml e.g.
-
-  <profile>
-    <id>my-engine-db</id>
-    <activation>
-      <activeByDefault>true</activeByDefault>
-    </activation>
-    <properties>
-      <engine.db.username>foo</engine.db.username>
-      <engine.db.password>bar</engine.db.password>
-      <engine.db.url>jdbc:postgresql://my-db-host/mydb</engine.db.url>
-      <engine.db.url.escaped>jdbc:postgresql://localhost/mydb</engine.db.url.escaped>
-      <engine.db.driver>org.postgresql.Driver</engine.db.driver>
-    </properties>
-  </profile>
+You can choose your own database but then the values that are present in `backend/manager/modules/bll/src/test/resources/test-database.properties` and `backend/manager/modules/dal/src/test/filters/pgsql.properties` must be updated to match your database configuration.
 
 == More on Impl DAOs ==
 

--- a/backend/manager/modules/dal/pom.xml
+++ b/backend/manager/modules/dal/pom.xml
@@ -12,6 +12,7 @@
   <properties>
     <engine.dao>jdbc</engine.dao>
     <engine.db>pgsql</engine.db>
+    <dal.test.excludedGroups>dao</dal.test.excludedGroups>
   </properties>
   <dependencies>
     <dependency>
@@ -156,7 +157,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <excludedGroups>dao</excludedGroups>
+          <excludedGroups>${dal.test.excludedGroups}</excludedGroups>
           <systemPropertyVariables>
             <java.util.logging.config.file>src/test/resources/logging.properties</java.util.logging.config.file>
           </systemPropertyVariables>
@@ -167,6 +168,9 @@
   <profiles>
     <profile>
       <id>enable-dao-tests</id>
+      <properties>
+        <dal.test.excludedGroups></dal.test.excludedGroups>
+      </properties>
       <build>
         <plugins>
           <plugin>

--- a/backend/manager/modules/dal/src/main/java/org/ovirt/engine/core/dao/VmCheckpointDao.java
+++ b/backend/manager/modules/dal/src/main/java/org/ovirt/engine/core/dao/VmCheckpointDao.java
@@ -51,6 +51,13 @@ public interface VmCheckpointDao extends GenericDao<VmCheckpoint, Guid> {
     void removeAllCheckpointsByVmId(Guid vmId);
 
     /**
+     * Remove all checkpoints of a disk
+     *
+     * @param diskId the disk id
+     */
+    void removeAllCheckpointsByDiskId(Guid diskId);
+
+    /**
      * Invalidate all checkpoints of a VM
      *
      * @param vmId the VM id

--- a/backend/manager/modules/dal/src/main/java/org/ovirt/engine/core/dao/VmCheckpointDaoImpl.java
+++ b/backend/manager/modules/dal/src/main/java/org/ovirt/engine/core/dao/VmCheckpointDaoImpl.java
@@ -102,6 +102,12 @@ public class VmCheckpointDaoImpl extends DefaultGenericDao<VmCheckpoint, Guid> i
     }
 
     @Override
+    public void removeAllCheckpointsByDiskId(Guid diskId) {
+        getCallsHandler().executeModification("DeleteAllCheckpointsByDiskId",
+                getCustomMapSqlParameterSource().addValue("disk_id", diskId));
+    }
+
+    @Override
     public void invalidateAllCheckpointsByVmId(Guid vmId) {
         getCallsHandler().executeModification("InvalidateAllCheckpointsByVmId",
                 getCustomMapSqlParameterSource()

--- a/backend/manager/modules/dal/src/test/filters/pgsql.properties
+++ b/backend/manager/modules/dal/src/test/filters/pgsql.properties
@@ -1,6 +1,6 @@
-engine.db.username = engine
-engine.db.password = engine
-engine.db.url = jdbc:postgresql://localhost/engine_dao_tests
+engine.db.username = ovirt
+engine.db.password = ovirt
+engine.db.url = jdbc:postgresql://postgres/engine_dao_tests
 engine.db.driver = org.postgresql.Driver
 engine.db.datafactory=org.dbunit.ext.postgresql.PostgresqlDataTypeFactory
 engine.db.initsql = 

--- a/backend/manager/modules/dal/src/test/java/org/ovirt/engine/core/dao/FixturesTool.java
+++ b/backend/manager/modules/dal/src/test/java/org/ovirt/engine/core/dao/FixturesTool.java
@@ -983,4 +983,10 @@ public class FixturesTool {
      * Predefined VM with mounted ISO
      */
     protected static final String VM_NAME_WITH_MOUNTED_ISO = "vm1-with-iso";
+
+    /**
+     * Predefined checkpoint ID that is linked to one disk
+     */
+    public static final Guid CHECKPOINT_ID_1 = new Guid("e28a8195-1659-42fc-a94c-59f744687124");
+
 }

--- a/backend/manager/modules/dal/src/test/java/org/ovirt/engine/core/dao/VmCheckpointDaoTest.java
+++ b/backend/manager/modules/dal/src/test/java/org/ovirt/engine/core/dao/VmCheckpointDaoTest.java
@@ -1,0 +1,63 @@
+package org.ovirt.engine.core.dao;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.ovirt.engine.core.compat.Guid;
+
+public class VmCheckpointDaoTest extends BaseDaoTestCase<VmCheckpointDao> {
+
+    @Test
+    public void testGetAllForVmReturnsEmptyListForNonExistingVm() {
+        var result = dao.getAllForVm(Guid.newGuid());
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testIsDiskIncludedInCheckpointReturnsFalseForNonExistingDisk() {
+        var result = dao.isDiskIncludedInCheckpoint(Guid.newGuid());
+        assertFalse(result);
+    }
+
+    @Test
+    public void testIsDiskIncludedInCheckpointReturnsTrueForExistingDisk() {
+        var result = dao.isDiskIncludedInCheckpoint(FixturesTool.DISK_ID_3);
+        assertTrue(result);
+    }
+
+    @Test
+    public void testGetAllDisksByCheckpointIdReturnsEmptyListForNonExistingCheckpoint() {
+        var result = dao.getDisksByCheckpointId(Guid.newGuid());
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testGetAllDisksByCheckpointIdReturnsNonEmptyListForExistingCheckpoint() {
+        var result = dao.getDisksByCheckpointId(FixturesTool.CHECKPOINT_ID_1);
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    public void testRemoveDiskFromCheckpointClearsCheckpoint() {
+        var before = dao.getAllForVm(FixturesTool.VM_VM2_SHARED_NONBOOTABLE_DISK);
+        assertEquals(1, before.size());
+        dao.removeAllCheckpointsByDiskId(FixturesTool.BOOTABLE_SHARED_DISK_ID);
+        var result = dao.getAllForVm(FixturesTool.VM_VM2_SHARED_NONBOOTABLE_DISK);
+        assertEquals(0, result.size());
+    }
+
+    @Test
+    public void getAllForVmReturnsNonEmptyListForExistingVm() {
+        var result = dao.getAllForVm(FixturesTool.VM_RHEL5_POOL_60);
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertEquals(1, result.size());
+    }
+}

--- a/backend/manager/modules/dal/src/test/resources/fixtures.xml
+++ b/backend/manager/modules/dal/src/test/resources/fixtures.xml
@@ -999,4 +999,12 @@
 
   <provider_binding_host_id  vds_id="afce7a39-8e8c-4819-ba9c-796d316592e8" plugin_type="OVIRT_PROVIDER_OVN" binding_host_id="1ce-c01d-bee2-15-a5-900d-a5-11fe"/>
 
+  <vm_checkpoints vm_id="77296e00-0cad-4e5a-9299-008a7b6f4360" checkpoint_id="e28a8195-1659-42fc-a94c-59f744687124" _create_date="2026-05-05 12:12:42.806609" state="Created"/>
+
+  <vm_checkpoint_disk_map checkpoint_id="e28a8195-1659-42fc-a94c-59f744687124" disk_id="1b26a52b-b60f-44cb-9f46-3ef333b04a49"/>
+
+  <vm_checkpoints vm_id="77296e00-0cad-4e5a-9299-008a7b6f4362" checkpoint_id="b842d5c4-cb3b-426e-8255-3e7b070e0ef6" _create_date="2026-05-05 12:12:42.806609" state="Created"/>
+
+  <vm_checkpoint_disk_map checkpoint_id="b842d5c4-cb3b-426e-8255-3e7b070e0ef6" disk_id="1b26a52b-b60f-44cb-9f46-3ef333b04a47"/>
+
 </dataset>

--- a/packaging/dbscripts/vm_checkpoints_sp.sql
+++ b/packaging/dbscripts/vm_checkpoints_sp.sql
@@ -181,3 +181,21 @@ BEGIN
            );
 END;$FUNCTION$
 LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION DeleteAllCheckpointsByDiskId (
+    v_disk_id UUID
+)
+RETURNS VOID AS $FUNCTION$
+BEGIN
+    DELETE
+    FROM vm_checkpoint_disk_map
+    WHERE disk_id = v_disk_id;
+
+    -- Delete checkpoints that no longer have any associated disks
+    DELETE FROM vm_checkpoints
+    WHERE checkpoint_id NOT IN (
+        SELECT DISTINCT checkpoint_id
+        FROM vm_checkpoint_disk_map
+    );
+END;$FUNCTION$
+LANGUAGE plpgsql;


### PR DESCRIPTION
## Changes introduced with this PR

When a backup of a VM is created, a checkpoint entry is created in vm_checkpoints and also entries in vm_checkpoint_disk_map for each disk pointing to that entry in vm_checkpoints. 
On checkpoint removal, the code checks all disks for that checkpoint in vm_checkpoint_disk_map, and removes the checkpoint on those relevant disks. If the VM is online, this happens via libvirt, if the VM is offline, this happens via qemu-img. All fine!

An issue occurs when one detaches a disk with one or more checkpoints from VM 1 and attaches it to for example VM Then the entry in vm_checkpoint_disk_map remains the same. So from a checkpoint point of view, the disk is still linked to VM 1.
Now if we remove the checkpoint on VM 1, the code looks up all disks linked to that checkpoint, and the disk now linked to VM 2 is still included! This will cause this command to do actions on a disk linked to VM 2, while the action should only execute actions on VM 1. If VM 1 is down, and VM 2 is down, this has no impact. But if VM 1 is down, and VM 2 is up, then the checkpoint of the disk linked to VM 2 will be removed by qemu-img, causing corruption on that qcow2 image.

 In order to resolve this issue, we remove all the bitmaps on the disk during the disk detach command. Also clean up the entries in the vm_checkpoint_disk_map table. This ensures that the image is clean again when it would be attached to another VM, and no links exist anymore between the checkpoint and that disk.

Also updated deleteAllVmCheckpointsCommand to improve readability.

While writing tests for this newly added functionality also restored the functionality of the dao tests so that now it can be run during CI and updated documentation about how to run the dao tests locally.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]