### PR TITLE
backend: fix race during Live Migration

### DIFF
--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/monitoring/VmAnalyzer.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/monitoring/VmAnalyzer.java
@@ -195,7 +195,7 @@ public class VmAnalyzer {
         }
         boolean migratingToThisVds = vdsmVm.getVmDynamic().getStatus() == VMStatus.MigratingTo
                 && vdsManager.getVdsId().equals(dbVm.getMigratingToVds());
-        if (!migratingToThisVds) {
+        if (!migratingToThisVds && vdsmVm.getVmDynamic().getStatus() != VMStatus.MigratingFrom) {
             logVmDetectedOnUnexpectedHost();
         }
         return false;
@@ -330,6 +330,18 @@ public class VmAnalyzer {
                 }
 
                 break;
+
+            case Up:
+                /*
+                 * VM was already set to Up by the VmAnalyzer job on the new VDS.
+                 * If the MigrationSucceeded (set by VDSM), then we can safely ignore this here
+                 * and not set the VM to down, otherwise we might end up with
+                 * the VM being set to down state while it is already up on the destination host.
+                 */
+                if (vdsmVm.getVmDynamic().getExitStatus() == VmExitStatus.Normal &&
+                        vdsmVm.getVmDynamic().getExitReason() == VmExitReason.MigrationSucceeded) {
+                    break;
+                }
 
             default:
                 switch (vdsmVm.getVmDynamic().getExitStatus()) {

--- a/backend/manager/modules/vdsbroker/src/test/java/org/ovirt/engine/core/vdsbroker/monitoring/VmAnalyzerTest.java
+++ b/backend/manager/modules/vdsbroker/src/test/java/org/ovirt/engine/core/vdsbroker/monitoring/VmAnalyzerTest.java
@@ -118,7 +118,7 @@ public class VmAnalyzerTest {
 
     @ParameterizedTest
     @EnumSource(VmTestPairs.class)
-    public void proceedDownVmsNormalExistReason_MIGRATION_HANDOVER(VmTestPairs data) {
+    public void proceedDownVmsNormalExitReason_MIGRATION_HANDOVER(VmTestPairs data) {
         //given
         initMocks(data, false);
 
@@ -140,7 +140,53 @@ public class VmAnalyzerTest {
 
     @ParameterizedTest
     @EnumSource(VmTestPairs.class)
-    public void proceedDownVmsNormalExistReason(VmTestPairs data) {
+    public void proceedDownVmsNormalExitReason_MIGRATION_UP_Early(VmTestPairs data) {
+        //given
+        initMocks(data, false);
+
+        when(vdsManager.getVdsId()).thenReturn(VmTestPairs.DST_HOST_ID);
+
+        //when
+        assumeTrue(data.dbVm() != null);
+        assumeTrue(data.vdsmVm() != null);
+        assumeTrue(data.dbVm().getStatus() == VMStatus.MigratingTo);
+        assumeTrue(data.vdsmVm().getVmDynamic().getStatus() == VMStatus.Up);
+        //then
+        vmAnalyzer.analyze();
+        verify(resourceManager, never()).removeAsyncRunningVm(data.dbVm().getId());
+        assertEquals(data.dbVm().getDynamicData(), vmAnalyzer.getVmDynamicToSave());
+        assertNull(data.dbVm().getMigratingToVds());
+        assertEquals(VmTestPairs.DST_HOST_ID, data.dbVm().getRunOnVds());
+    }
+
+    @ParameterizedTest
+    @EnumSource(VmTestPairs.class)
+    public void proceedDownVmsNormalExitReason_MIGRATION_DONE_Already_UP(VmTestPairs data) {
+        //given
+        initMocks(data, false);
+
+        //when
+        assumeTrue(data.dbVm() != null);
+        assumeTrue(data.vdsmVm() != null);
+        assumeTrue(data.dbVm().getStatus() == VMStatus.Up);
+        assumeTrue(data.vdsmVm().getVmDynamic().getStatus() == VMStatus.Down);
+        assumeTrue(data.vdsmVm().getVmDynamic().getExitReason() == VmExitReason.MigrationSucceeded);
+        assumeTrue(data.vdsmVm().getVmDynamic().getExitStatus() == VmExitStatus.Normal);
+        //then
+        vmAnalyzer.analyze();
+        verify(resourceManager, never()).internalSetVmStatus(data.dbVm().getDynamicData(), VMStatus.Down);
+        verify(vmAnalyzer).runVdsCommand(vdsCommandTypeCaptor.capture(), vdsParamsCaptor.capture());
+        verify(auditLogDirector, never()).log(loggableCaptor.capture(), logTypeCaptor.capture());
+        assertEquals(VDSCommandType.Destroy, vdsCommandTypeCaptor.getValue());
+        assertEquals(DestroyVmVDSCommandParameters.class, vdsParamsCaptor.getValue().getClass());
+        assertFalse(logTypeCaptor.getAllValues().contains(AuditLogType.VM_DOWN));
+        assertNull(data.dbVm().getMigratingToVds());
+        assertEquals(VmTestPairs.DST_HOST_ID, data.dbVm().getRunOnVds());
+    }
+
+    @ParameterizedTest
+    @EnumSource(VmTestPairs.class)
+    public void proceedDownVmsNormalExitReason(VmTestPairs data) {
         //given
         initMocks(data, false);
 
@@ -150,6 +196,7 @@ public class VmAnalyzerTest {
         assumeTrue(data.dbVm().getStatus() != VMStatus.MigratingFrom);
         assumeTrue(data.vdsmVm().getVmDynamic().getStatus() == VMStatus.Down);
         assumeTrue(data.vdsmVm().getVmDynamic().getExitStatus() == VmExitStatus.Normal);
+        assumeTrue(data.vdsmVm().getVmDynamic().getExitReason() != VmExitReason.MigrationSucceeded);
         //then
         vmAnalyzer.analyze();
         verify(auditLogDirector, atLeastOnce()).log(loggableCaptor.capture(), logTypeCaptor.capture());

--- a/backend/manager/modules/vdsbroker/src/test/java/org/ovirt/engine/core/vdsbroker/monitoring/VmTestPairs.java
+++ b/backend/manager/modules/vdsbroker/src/test/java/org/ovirt/engine/core/vdsbroker/monitoring/VmTestPairs.java
@@ -140,6 +140,18 @@ public enum VmTestPairs {
             pair.getSecond().getVmDynamic().setStatus(VMStatus.WaitForLaunch);
             return pair;
         }
+    },
+    VM_MIGRATED_UP_EARLY("12") {
+        @Override
+        Pair<VM, VdsmVm> build() {
+            return createMigrationDoneEarly();
+        }
+    },
+    VM_MIGRATED_UP_EARLY_END("13") {
+        @Override
+        Pair<VM, VdsmVm> build() {
+            return createMigrationDoneEarlyEnd();
+        }
     };
     public static final Guid DST_HOST_ID = Guid.newGuid();
     public static final Guid SRC_HOST_ID = Guid.newGuid();
@@ -201,6 +213,23 @@ public enum VmTestPairs {
         pair.getSecond().getVmDynamic().setExitStatus(VmExitStatus.Normal);
         pair.getSecond().getVmDynamic().setExitReason(VmExitReason.MigrationSucceeded);
         setDstHost(pair);
+        return pair;
+    }
+
+    Pair<VM, VdsmVm> createMigrationDoneEarly() {
+        Pair<VM, VdsmVm> pair = createPair();
+        setPairStatuses(pair, VMStatus.MigratingTo, VMStatus.Up);
+        setDstHost(pair);
+        pair.getFirst().setRunOnVds(SRC_HOST_ID);
+        return pair;
+    }
+
+    Pair<VM, VdsmVm> createMigrationDoneEarlyEnd() {
+        Pair<VM, VdsmVm> pair = createPair();
+        setPairStatuses(pair, VMStatus.Up, VMStatus.Down);
+        pair.getFirst().setRunOnVds(DST_HOST_ID);
+        pair.getSecond().getVmDynamic().setExitStatus(VmExitStatus.Normal);
+        pair.getSecond().getVmDynamic().setExitReason(VmExitReason.MigrationSucceeded);
         return pair;
     }
 


### PR DESCRIPTION
We had some race condition in the live migration flow of a VM.

Before:
- Vm live migration started
- Vm state set to Migrating
- Vdsm reports Up state for the Vm on destination
- VmAnalyzer sets DB state to Up
- Migration ends on the source
- Vdsm reports Down state of the Vm on the source
- VmAnalyzer sets DB state of the Vm to Down

And until VmAnalyzer runs on the destination, the Vm is set to 'Down' in the engine. If we then run for example a snapshot, this can cause issues as an offline snapshot is triggered.

Therefor we need to handle the case where the Vm is already Up, but migration is still not fully finished.

After:
- Vm live migration started
- Vm state set to Migrating
- Vdsm reports Up state for the Vm on destination
- VmAnalyzer sets DB state to Up
- Migration ends on the source
- Vdsm reports Down state of the Vm on the source
- VmAnalyzer sees the cause is VmExitReason.MigrationSucceeded, and handles the down accordingly. Without setting the Vm State to Down.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]