### PR TITLE
ansible: fix lint violations in ovirt-host-deploy playbook and roles

### DIFF
--- a/build/ansible-check.sh
+++ b/build/ansible-check.sh
@@ -9,4 +9,8 @@ if ! command -v ansible-lint > /dev/null 2>&1; then
 fi
 
 # Run ansible-lint
-ansible-lint -c ${ANSIBLE_LINT_CONF} packaging/ansible-runner-service-project/project/roles/*
+ansible-lint -c ${ANSIBLE_LINT_CONF} packaging/ansible-runner-service-project/project/roles/* \
+  packaging/ansible-runner-service-project/project/roles/hc-gluster-cgroups/**/*.yml \
+  packaging/ansible-runner-service-project/project/roles/ovirt-host-deploy-kdump/**/*.yml \
+  packaging/ansible-runner-service-project/project/roles/ovirt-host-deploy-spice-encryption/**/*.yml
+

--- a/packaging/ansible-runner-service-project/project/ovirt-host-deploy.yml
+++ b/packaging/ansible-runner-service-project/project/ovirt-host-deploy.yml
@@ -1,9 +1,10 @@
-- hosts: all
+- name: Deploy oVirt host
+  hosts: all
   remote_user: root
 
   pre_tasks:
-    - name: set host_action var
-      set_fact:
+    - name: Set host_action var
+      ansible.builtin.set_fact:
         host_action: host_deploy
 
   roles:
@@ -20,22 +21,22 @@
 
   tasks:
     - name: Gather the rpm package facts
-      package_facts:
+      ansible.builtin.package_facts:
         manager: rpm
       delegate_to: localhost
 
     - name: Run metrics role if RPM package installed
-      include_role:
+      ansible.builtin.include_role:
         name: oVirt.metrics
-      when: "( 'ovirt-engine-metrics' in ansible_facts.packages ) or ( disable_metrics_rpm_check|d(false) )"
+      when: "('ovirt-engine-metrics' in ansible_facts.packages) or (disable_metrics_rpm_check | d(false))"
 
     - name: Check if post tasks file exists
-      stat:
+      ansible.builtin.stat:
         path: "{{ host_deploy_post_tasks }}"
       delegate_to: localhost
       register: stat_post_tasks
       when: "host_deploy_post_tasks is defined"
 
     - name: Executing post tasks defined by user
-      include_tasks: "{{ host_deploy_post_tasks }}"
+      ansible.builtin.include_tasks: "{{ host_deploy_post_tasks }}"
       when: "host_deploy_post_tasks is defined and stat_post_tasks.stat.exists"

--- a/packaging/ansible-runner-service-project/project/roles/hc-gluster-cgroups/tasks/main.yml
+++ b/packaging/ansible-runner-service-project/project/roles/hc-gluster-cgroups/tasks/main.yml
@@ -3,13 +3,13 @@
   ansible.builtin.file:
     path: /etc/systemd/system/glusterd.service.d/
     state: directory
-    mode: 0755
+    mode: "0755"
 
 - name: Create glusterd cgroups CPU configuration file
   ansible.builtin.copy:
     src: 99-cpu.conf
     dest: /etc/systemd/system/glusterd.service.d/99-cpu.conf
-    mode: 0644
+    mode: "0644"
   notify:
     - Restart glusterd
 
@@ -17,7 +17,7 @@
   ansible.builtin.template:
     src: glusterfs.slice.j2
     dest: /etc/systemd/system/glusterfs.slice
-    mode: 0644
+    mode: "0644"
   vars:
     gluster_cgroup_cpu_quota: "{{ [(ansible_processor_vcpus / 3) | int, 1] | max * 100 }}"
   notify:

--- a/packaging/ansible-runner-service-project/project/roles/ovirt-host-deploy-kdump/tasks/main.yml
+++ b/packaging/ansible-runner-service-project/project/roles/ovirt-host-deploy-kdump/tasks/main.yml
@@ -8,7 +8,7 @@
   failed_when: crashkernel_param.changed
 
 - name: Install kexec-tools package
-  ansible.builtin.yum:
+  ansible.builtin.package:
     name: kexec-tools
     state: present
 

--- a/packaging/ansible-runner-service-project/project/roles/ovirt-host-deploy-spice-encryption/tasks/main.yml
+++ b/packaging/ansible-runner-service-project/project/roles/ovirt-host-deploy-spice-encryption/tasks/main.yml
@@ -3,7 +3,7 @@
   ansible.builtin.file:
     dest: '/etc/pki/tls/spice.cnf'
     state: touch
-    mode: 0644
+    mode: "0644"
     owner: root
     group: root
 
@@ -11,7 +11,7 @@
   ansible.builtin.copy: # noqa template-instead-of-copy
     dest: '/etc/pki/tls/spice.cnf'
     backup: true
-    mode: 0644
+    mode: "0644"
     content: |
       CipherString = {{ host_deploy_spice_cipher_string }}
       Protocol = {{ host_deploy_spice_protocol }}


### PR DESCRIPTION
## Changes introduced with this PR

Bring the ovirt-host-deploy playbook and its directly-invoked roles
up to the `production` profile of ansible-lint.

ovirt-host-deploy.yml:
- Add a play-level `name:` and capitalise the `set host_action var`
  task name (name[play], name[casing]).
- Fully-qualify the builtin modules: set_fact, package_facts,
  include_role, stat, include_tasks (fqcn[action-core]).
- Tighten spacing inside the metrics `when:` Jinja expression so it
  reads `('x' in y) or (z | d(false))` (jinja[spacing]).

roles/hc-gluster-cgroups/tasks/main.yml,
roles/ovirt-host-deploy-spice-encryption/tasks/main.yml:
- Quote bare octal file modes (`0755`/`0644` -> `"0755"`/`"0644"`).
  Unquoted, YAML 1.1 parses a leading zero as decimal, so the value
  the file module receives silently differs from the permissions the
  author intended (yaml[octal-values]).

roles/ovirt-host-deploy-kdump/tasks/main.yml:
- Replace `ansible.builtin.yum` with `ansible.builtin.package`. Lint
  flags `yum` as deprecated in favour of `dnf`, but `dnf` is not
  available on EL7 and the same playbook still gates the
  spice-encryption role on EL7 -- the generic `package` module keeps
  the role portable across EL7/8/9.


Note:
ansible-lint --version                                                                                               
ansible-lint 26.4.0 using ansible-core:2.20.5 ansible-compat:26.3.0 ruamel-yaml:0.19.1 ruamel-yaml-clib:0.2.15


## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]