### PR TITLE
setup: ask for password when activating keycloak

### DIFF
--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/config/aaa.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine/config/aaa.py
@@ -116,9 +116,21 @@ class Plugin(plugin.PluginBase):
         condition=lambda self: (
             self.environment[
                 oenginecons.CoreEnv.ENABLE
-            ] and self.environment[
-                oenginecons.EngineDBEnv.NEW_DATABASE
-            ] and self.environment[
+            ]
+            and (
+                self.environment[
+                    oenginecons.EngineDBEnv.NEW_DATABASE
+                ]
+                or (
+                    self.environment[
+                        oengcommcons.KeycloakEnv.ENABLE
+                    ]
+                    and not self.environment[
+                        oengcommcons.KeycloakEnv.CONFIGURED
+                    ]
+                )
+            )
+            and self.environment[
                 oenginecons.ConfigEnv.ADMIN_PASSWORD
             ] is None
         ),


### PR DESCRIPTION
When we have an existing ovirt installation without keycloak, and we want to activate keycloak, this needs to be done via the following setup command:
engine-setup --otopi-environment="OVESETUP_CONFIG/keycloakEnable=bool:True"

Now when this is executed, we need to ask the password to the user for the new 'admin@ovirt' user that is created in keycloak. Otherwise the provisioning of keycloak is incomplete, and no realm/user is created inside of keycloak, and the setup is broken.

This broke since commit 015cadc in ovirt-engine-keycloak.

## Additional info

This supersedes https://github.com/oVirt/ovirt-engine-keycloak/pull/62
Better have the change in ovirt-engine, as here we already have the logic for a admin password.

Fixes: https://github.com/oVirt/ovirt-engine-keycloak/issues/61

Commit that broke it: https://github.com/oVirt/ovirt-engine-keycloak/commit/015cadc3dcd37567439c6371432bed404898bb5f

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]