### PR TITLE
core: Implicit narrowing conversion from long to int

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/pending/PendingCpuCores.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/pending/PendingCpuCores.java
@@ -34,7 +34,7 @@ public class PendingCpuCores extends PendingResource {
         this.cpuPinningPolicy = vm.getCpuPinningPolicy();
     }
 
-    public long getCpuCount() {
+    public int getCpuCount() {
         return cpuCount;
     }
 

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/pending/PendingMemory.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/pending/PendingMemory.java
@@ -10,23 +10,23 @@ import org.ovirt.engine.core.compat.Guid;
  * by not yet started VM on a specified host
  */
 public class PendingMemory extends PendingResource {
-    private long sizeInMb;
+    private int sizeInMb;
 
-    public PendingMemory(VDS host, VM vm, long sizeInMb) {
+    public PendingMemory(VDS host, VM vm, int sizeInMb) {
         super(host, vm);
         this.sizeInMb = sizeInMb;
     }
 
-    public PendingMemory(Guid host, VM vm, long sizeInMb) {
+    public PendingMemory(Guid host, VM vm, int sizeInMb) {
         super(host, vm);
         this.sizeInMb = sizeInMb;
     }
 
-    public long getSizeInMb() {
+    public int getSizeInMb() {
         return sizeInMb;
     }
 
-    public void setSizeInMb(long sizeInMb) {
+    public void setSizeInMb(int sizeInMb) {
         this.sizeInMb = sizeInMb;
     }
 

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/pending/PendingOvercommitMemory.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/pending/PendingOvercommitMemory.java
@@ -12,12 +12,12 @@ import org.ovirt.engine.core.compat.Guid;
  */
 public class PendingOvercommitMemory extends PendingMemory {
     public PendingOvercommitMemory(VDS host,
-            VM vm, long sizeInMb) {
+            VM vm, int sizeInMb) {
         super(host, vm, sizeInMb);
     }
 
     public PendingOvercommitMemory(Guid host,
-            VM vm, long sizeInMb) {
+            VM vm, int sizeInMb) {
         super(host, vm, sizeInMb);
     }
 

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/utils/VdsCpuUnitPinningHelper.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/scheduling/utils/VdsCpuUnitPinningHelper.java
@@ -112,7 +112,7 @@ public class VdsCpuUnitPinningHelper {
         List<VdsCpuUnit> cpusToBeAllocated = allocateExclusiveCpus(cpuTopology, vm, hostId);
         if (vm.getCpuPinningPolicy() == CpuPinningPolicy.ISOLATE_THREADS) {
             List<Integer> socketsUsed = cpusToBeAllocated.stream().map(VdsCpuUnit::getSocket).distinct().collect(Collectors.toList());
-            int pCores = 0;
+            long pCores = 0;
             for (int socket: socketsUsed) {
                 pCores += getCoresInSocket(cpusToBeAllocated, socket).stream().map(VdsCpuUnit::getCore).distinct().count();
             }

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/validator/VmValidator.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/validator/VmValidator.java
@@ -323,7 +323,7 @@ public class VmValidator {
 
         // this adds: monitors + 2 * (interfaces with type rtl_pv) + (all other
         // interfaces) + (all disks that are not IDE)
-        int pciInUse = monitorsNumber;
+        long pciInUse = monitorsNumber;
 
         // Balloon controller requires one PCI slot
         pciInUse += 1;

--- a/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/scheduling/pending/PendingResourceManagerTest.java
+++ b/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/scheduling/pending/PendingResourceManagerTest.java
@@ -195,6 +195,6 @@ public class PendingResourceManagerTest {
         assertThat(memories)
                 .hasSize(1)
                 .extracting(PendingMemory::getSizeInMb)
-                .containsOnly(768L);
+                .containsOnly(768);
     }
 }

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/builder/vminfo/LibvirtVmXmlBuilder.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/builder/vminfo/LibvirtVmXmlBuilder.java
@@ -779,7 +779,7 @@ public class LibvirtVmXmlBuilder {
         boolean acpiEnabled = vm.getAcpiEnable();
         boolean kaslrEnabled = vmInfoBuildUtils.isKASLRDumpEnabled(vm.getVmOsId());
         boolean secureBootEnabled = vm.getBiosType() == BiosType.Q35_SECURE_BOOT;
-        Integer tsegSize = vmInfoBuildUtils.tsegSizeMB(vm, hostDevicesSupplier);
+        Long tsegSize = vmInfoBuildUtils.tsegSizeMB(vm, hostDevicesSupplier);
         if (!acpiEnabled && !hypervEnabled && !kaslrEnabled && !secureBootEnabled && tsegSize == null) {
             return;
         }

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/builder/vminfo/VmInfoBuildUtils.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/builder/vminfo/VmInfoBuildUtils.java
@@ -1700,7 +1700,7 @@ public class VmInfoBuildUtils {
      * - Confirmation that 48 MB may not be enough for really large VMs:
      *   https://bugzilla.redhat.com/show_bug.cgi?id=2074149#c28
      **/
-    public Integer tsegSizeMB(VM vm, MemoizingSupplier<Map<String, HostDevice>> hostDevicesSupplier) {
+    public Long tsegSizeMB(VM vm, MemoizingSupplier<Map<String, HostDevice>> hostDevicesSupplier) {
         // If UEFI is not used, we should be safe and use the default value.
         if (vm.getBiosType() == null || !vm.getBiosType().isOvmf()) {
             return null;
@@ -1717,7 +1717,7 @@ public class VmInfoBuildUtils {
         // and additional value per memory) for VMs with many vCPUs and 8 MB per each (even partial)
         // TB of RAM. This is probably a bit wasteful but it's better than risking the VM won't
         // start.
-        int size = DEFAULT_TSEG_SIZE_MB;
+        long size = DEFAULT_TSEG_SIZE_MB;
         if (maxNumberOfVcpus(vm) >= cpuLimit) {
             size += MANY_VCPUS_TSEG_SIZE_INCREASE_MB;
         }


### PR DESCRIPTION
## Changes introduced with this PR

Previously compound assignment resulted in an implicit narrowing conversion from long to int.
This can result in information loss and numeric errors such as overflows.
By using Math toIntExact silent truncation can be avoided, if an overflow occurs an error is returned.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]