### PR TITLE
core: notify all HSM hosts after manual master storage domain switch

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/pool/SwitchMasterStorageDomainCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/pool/SwitchMasterStorageDomainCommand.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
 
 import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.Typed;
@@ -31,6 +33,9 @@ import org.ovirt.engine.core.common.businessentities.StorageDomainType;
 import org.ovirt.engine.core.common.businessentities.StoragePoolIsoMap;
 import org.ovirt.engine.core.common.errors.EngineException;
 import org.ovirt.engine.core.common.errors.EngineMessage;
+import org.ovirt.engine.core.common.eventqueue.Event;
+import org.ovirt.engine.core.common.eventqueue.EventResult;
+import org.ovirt.engine.core.common.eventqueue.EventType;
 import org.ovirt.engine.core.common.locks.LockingGroup;
 import org.ovirt.engine.core.common.utils.Pair;
 import org.ovirt.engine.core.common.vdscommands.DeactivateStorageDomainVDSCommandParameters;
@@ -44,7 +49,9 @@ import org.ovirt.engine.core.dao.StorageDomainDao;
 import org.ovirt.engine.core.dao.StorageDomainStaticDao;
 import org.ovirt.engine.core.dao.StoragePoolDao;
 import org.ovirt.engine.core.dao.StoragePoolIsoMapDao;
+import org.ovirt.engine.core.utils.threadpool.ThreadPoolUtil;
 import org.ovirt.engine.core.utils.transaction.TransactionSupport;
+import org.ovirt.engine.core.vdsbroker.storage.StoragePoolDomainHelper;
 
 @NonTransactiveCommandAttribute
 public class SwitchMasterStorageDomainCommand<T extends SwitchMasterStorageDomainCommandParameters>
@@ -62,6 +69,8 @@ public class SwitchMasterStorageDomainCommand<T extends SwitchMasterStorageDomai
     private StoragePoolDao storagePoolDao;
     @Inject
     private StoragePoolIsoMapDao storagePoolIsoMapDao;
+    @Inject
+    private StoragePoolDomainHelper storagePoolDomainHelper;
     @Inject
     private CommandCoordinatorUtil commandCoordinatorUtil;
     @Inject
@@ -274,9 +283,28 @@ public class SwitchMasterStorageDomainCommand<T extends SwitchMasterStorageDomai
         addAuditLogCustomValues();
         auditLogDirector.log(this, AuditLogType.SWITCH_MASTER_STORAGE_DOMAIN_ON_SPM);
         updateStoragePoolOnDB();
+        notifyAllHostsOfNewMaster();
         commandCoordinatorUtil.removeAllCommandsInHierarchy(getCommandId());
         auditLogDirector.log(this, AuditLogType.SWITCH_MASTER_STORAGE_DOMAIN);
         setSucceeded(true);
+    }
+
+    protected void notifyAllHostsOfNewMaster() {
+        getEventQueue().submitEventSync(
+                new Event(getStoragePoolId(), getStorageDomainId(), null, EventType.POOLREFRESH, ""),
+                () -> {
+                    List<StoragePoolIsoMap> storagePoolIsoMap =
+                            storagePoolIsoMapDao.getAllForStoragePool(getStoragePoolId());
+                    ThreadPoolUtil.invokeAll(
+                            getAllRunningVdssInPool().stream()
+                                    .map(vds -> (Callable<Void>) () -> {
+                                        storagePoolDomainHelper.refreshHostPoolMetadata(
+                                                vds, getStoragePool(), getStorageDomainId(), storagePoolIsoMap);
+                                        return null;
+                                    })
+                                    .collect(Collectors.toList()));
+                    return new EventResult(true, EventType.POOLREFRESH);
+                });
     }
 
     @Override

--- a/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/storage/pool/SwitchMasterStorageDomainCommandTest.java
+++ b/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/storage/pool/SwitchMasterStorageDomainCommandTest.java
@@ -1,12 +1,17 @@
 package org.ovirt.engine.core.bll.storage.pool;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.Callable;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -17,19 +22,28 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.ovirt.engine.core.bll.BaseCommandTest;
 import org.ovirt.engine.core.bll.ValidateTestUtils;
+import org.ovirt.engine.core.bll.tasks.CommandCoordinatorUtil;
 import org.ovirt.engine.core.common.action.SwitchMasterStorageDomainCommandParameters;
 import org.ovirt.engine.core.common.businessentities.StorageDomain;
 import org.ovirt.engine.core.common.businessentities.StorageDomainStatus;
 import org.ovirt.engine.core.common.businessentities.StorageDomainType;
 import org.ovirt.engine.core.common.businessentities.StoragePool;
 import org.ovirt.engine.core.common.businessentities.StoragePoolIsoMap;
+import org.ovirt.engine.core.common.businessentities.VDS;
+import org.ovirt.engine.core.common.businessentities.VDSStatus;
 import org.ovirt.engine.core.common.errors.EngineMessage;
+import org.ovirt.engine.core.common.eventqueue.Event;
+import org.ovirt.engine.core.common.eventqueue.EventQueue;
+import org.ovirt.engine.core.common.eventqueue.EventResult;
 import org.ovirt.engine.core.compat.Guid;
 import org.ovirt.engine.core.compat.Version;
+import org.ovirt.engine.core.dal.dbbroker.auditloghandling.AuditLogDirector;
 import org.ovirt.engine.core.dao.StorageDomainDao;
 import org.ovirt.engine.core.dao.StorageDomainStaticDao;
 import org.ovirt.engine.core.dao.StoragePoolDao;
 import org.ovirt.engine.core.dao.StoragePoolIsoMapDao;
+import org.ovirt.engine.core.dao.VdsDao;
+import org.ovirt.engine.core.vdsbroker.storage.StoragePoolDomainHelper;
 
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class SwitchMasterStorageDomainCommandTest extends BaseCommandTest {
@@ -42,7 +56,16 @@ public class SwitchMasterStorageDomainCommandTest extends BaseCommandTest {
     private StorageDomainStaticDao storageDomainStaticDao;
     @Mock
     private StoragePoolIsoMapDao storagePoolIsoMapDao;
-
+    @Mock
+    private EventQueue eventQueue;
+    @Mock
+    private StoragePoolDomainHelper storagePoolDomainHelper;
+    @Mock
+    private VdsDao vdsDao;
+    @Mock
+    private AuditLogDirector auditLogDirector;
+    @Mock
+    private CommandCoordinatorUtil commandCoordinatorUtil;
     private static final int MASTER_VERSION = 100;
     private Guid storagePoolId = Guid.newGuid();
     private Guid currentMasterStorageDomainId = Guid.newGuid();
@@ -117,6 +140,46 @@ public class SwitchMasterStorageDomainCommandTest extends BaseCommandTest {
     @Test
     public void testValidateSuccess() {
         ValidateTestUtils.runAndAssertValidateSuccess(command);
+    }
+
+    @Test
+    public void testEndSuccessfullyNotifiesAllHosts() {
+        // updateStoragePoolOnDB() and removeAllCommandsInHierarchy() are not
+        // the focus here -- stub them out so the test stays unit-level.
+        doNothing().when(command).updateStoragePoolOnDB();
+        doNothing().when(command).notifyAllHostsOfNewMaster();
+
+        command.endSuccessfully();
+
+        verify(command).notifyAllHostsOfNewMaster();
+    }
+
+    @Test
+    public void testNotifyAllHostsRefreshesEachHost() {
+        VDS host1 = new VDS();
+        host1.setId(Guid.newGuid());
+        VDS host2 = new VDS();
+        host2.setId(Guid.newGuid());
+        List<VDS> hosts = Arrays.asList(host1, host2);
+        List<StoragePoolIsoMap> isoMaps = Arrays.asList(newMasterStorageDomain.getStoragePoolIsoMapData());
+
+        // eventQueue is auto-injected into the command via @InjectMocks; run the
+        // queued supplier inline so the fan-out actually executes.
+        when(eventQueue.submitEventSync(any(Event.class), any())).thenAnswer(inv -> {
+            inv.<Callable<EventResult>>getArgument(1).call();
+            return null;
+        });
+        doReturn(hosts).when(vdsDao).getAllForStoragePoolAndStatus(storagePoolId, VDSStatus.Up);
+        doReturn(isoMaps).when(storagePoolIsoMapDao).getAllForStoragePool(storagePoolId);
+
+        command.notifyAllHostsOfNewMaster();
+
+        verify(storagePoolDomainHelper).refreshHostPoolMetadata(eq(host1), eq(storagePool),
+                eq(newMasterStorageDomainId), eq(isoMaps));
+        verify(storagePoolDomainHelper).refreshHostPoolMetadata(eq(host2), eq(storagePool),
+                eq(newMasterStorageDomainId), eq(isoMaps));
+        verify(storagePoolDomainHelper, times(hosts.size())).refreshHostPoolMetadata(
+                any(VDS.class), any(StoragePool.class), any(Guid.class), any());
     }
 
     @Test


### PR DESCRIPTION
## Changes introduced with this PR

Background
----------
A storage pool has exactly one master domain at a time. The master domain holds pool-level metadata and, critically, the SPM<->HSM mailbox volumes: the SPM writes extend-grant responses into each HSM's outbox, and each HSM polls its inbox via a dd(1) command that resolves a stable "mastersd" symlink on its local mount.

Before commit 111a61e1c (2020, BZ 1576923) the only way the master changed was through deactivation of the current master domain, which already needed to loop over every running host to disconnect it from the departing domain. The per-host ConnectStoragePool(newMaster) refresh was piggy-backed onto that mandatory disconnect loop, so all HSMs were naturally kept in sync.

Commit 111a61e1c introduced SwitchMasterStorageDomainCommand: an operator-initiated verb that moves the master role to a chosen active domain without taking the old master offline. The command calls the SPM via the IRS layer (switchMaster -> sp.masterMigrate), which atomically re-creates the master metadata and mailbox volumes on the new domain. The SPM itself is left with a consistent view. However the command never performed the per-host ConnectStoragePool fan-out that the deactivation path relied on.

The bug
-------
After a manual switch, HSM hosts continued to resolve their "mastersd" symlink to the old master domain. The symlink is only updated by VDSM's pool.refresh() -> _refreshDomainLinks() call, which happens during ConnectStoragePool. Without a refresh the HSM mailbox dd commands kept hitting the old master's inbox/outbox volumes. The SPM was now watching the new master's inbox, so extend requests from HSMs were silently dropped. Thin-provisioned disk extension would stall until vdsmd was restarted on the affected host, because host re-activation sends a fresh ConnectStoragePool with the current master.

The automatic reconstruct path (ReconstructMasterDomainCommand) is not affected: it already fans out ConnectStoragePool to all hosts explicitly (ReconstructMasterDomainCommand.java:278).

The fix
-------
After updateStoragePoolOnDB() completes (which increments masterDomainVersion and flips domain roles in the DB), call notifyAllHostsOfNewMaster(), which sends ConnectStoragePool(refresh) carrying the new master ID to every host currently in status Up.

The per-host work is delegated to
StoragePoolDomainHelper.refreshHostPoolMetadata(), the same helper used by the periodic IRS refresh timer and the deactivate flow. It is best-effort per host: failures are logged and swallowed, with an automatic fall-back to a full ConnectStoragePool (non-refresh) if the host returns StoragePoolUnknown. Hosts that are Down at switch time need no special handling; they receive a correct ConnectStoragePool when they next come up and activate.

The fan-out is wrapped in getEventQueue().submitEventSync() with event type POOLREFRESH, serializing it on the pool's dedicated event queue. This is the same pattern DeactivateStorageDomainCommand uses. The reason this matters: reconstruct and recovery are triggered by IRS monitoring threads, not by BLL command locks, so the command's own exclusive locks on the pool and storage domains do not prevent a concurrent reconstruct from starting. The event queue ensures our refresh cannot interleave with a reconstruct or recovery for the same pool. If a reconstruct is already in progress, EventQueueMonitor cancels queued POOLREFRESH events automatically, which is correct: reconstruct rebuilds the master links itself and a stale refresh running afterwards would be wrong.

Individual host calls are run in parallel via ThreadPoolUtil.invokeAll and the method blocks until all hosts have responded or timed out, so the subsequent audit log entry reflects the actual outcome.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

y