### PR TITLE
core: Validate total disk space for QCOW Preallocated disks

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/validator/storage/StorageDomainValidator.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/validator/storage/StorageDomainValidator.java
@@ -122,9 +122,10 @@ public class StorageDomainValidator {
      * according to the following table:
      *
      *      | File Domain                             | Block Domain
-     * -----|-----------------------------------------|-------------
-     * qcow | 1M (header size)                        | 1G
-     * -----|-----------------------------------------|-------------
+     * -----|-----------------------------------------|------------------------------------------
+     * qcow | preallocated: disk capacity (getSize()) | preallocated: disk capacity (getSize())
+     *      | sparse: 1M (header size)                | sparse: 1G
+     * -----|-----------------------------------------|------------------------------------------
      * raw  | preallocated: disk capacity (getSize()) | disk capacity
      *      | thin (sparse): 1M                       | (there is no raw sparse on
      *      |                                         | block domains)
@@ -132,17 +133,17 @@ public class StorageDomainValidator {
      */
     private double getTotalSizeForNewDisks(Collection<DiskImage> diskImages) {
         return getTotalSizeForDisksByMethod(diskImages, diskImage -> {
-            double sizeForDisk = diskImage.getSize();
             if (diskImage.getVolumeFormat() == VolumeFormat.COW) {
-                if (storageDomain.getStorageType().isFileDomain()) {
-                    sizeForDisk = EMPTY_QCOW_HEADER_SIZE;
-                } else {
-                    sizeForDisk = INITIAL_BLOCK_ALLOCATION_SIZE;
+                if (diskImage.getVolumeType() == VolumeType.Preallocated) {
+                    return diskImage.getSize();
                 }
-            } else if (diskImage.getVolumeType() == VolumeType.Sparse) {
-                sizeForDisk = EMPTY_QCOW_HEADER_SIZE;
+                return storageDomain.getStorageType().isFileDomain()
+                        ? EMPTY_QCOW_HEADER_SIZE
+                        : INITIAL_BLOCK_ALLOCATION_SIZE;
             }
-            return sizeForDisk;
+            return diskImage.getVolumeType() == VolumeType.Sparse
+                    ? EMPTY_QCOW_HEADER_SIZE
+                    : diskImage.getSize();
         });
     }
 

--- a/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/validator/storage/StorageDomainValidatorFreeSpaceTest.java
+++ b/backend/manager/modules/bll/src/test/java/org/ovirt/engine/core/bll/validator/storage/StorageDomainValidatorFreeSpaceTest.java
@@ -52,7 +52,11 @@ public class StorageDomainValidatorFreeSpaceTest {
                         disk.setVolumeType(volumeType);
                         disk.setStorageIds(Collections.singletonList(Guid.newGuid()));
                         disk.setSizeInGigabytes(200);
-                        disk.setActualSize(100); // GB
+                        if (volumeType == VolumeType.Preallocated) {
+                            disk.setActualSize(200); // GB
+                        } else {
+                            disk.setActualSize(100); // GB
+                        }
 
                         StorageDomain sd = new StorageDomain();
                         sd.setStorageType(storageType);
@@ -60,7 +64,7 @@ public class StorageDomainValidatorFreeSpaceTest {
 
                         boolean shortCircuitForVendorManaged = storageType.isManagedBlockStorage();
                         boolean isValidForNew = shortCircuitForVendorManaged
-                                || volumeFormat == VolumeFormat.COW || volumeType == VolumeType.Sparse;
+                                || volumeType == VolumeType.Sparse;
                         boolean isValidForCloned = shortCircuitForVendorManaged
                                 || volumeFormat == VolumeFormat.RAW && volumeType == VolumeType.Sparse;
                         boolean isValidForSnapshots = shortCircuitForVendorManaged
@@ -131,5 +135,39 @@ public class StorageDomainValidatorFreeSpaceTest {
         assertEquals(isValidForCloned, sdValidator.hasSpaceForAllDisks(null, disksList).isValid(), assertData);
         assertEquals(isValidForNew && isValidForCloned, sdValidator.hasSpaceForAllDisks(disksList, disksList).isValid(),
                 assertData);
+    }
+
+    public static Stream<Arguments> createCowPreallocatedParams() {
+        return Stream.of(
+                // disk below threshold: valid
+                Arguments.of(50, 107, StorageType.NFS, true),
+                Arguments.of(50, 107, StorageType.ISCSI, true),
+                // exact boundary (disk == available): valid
+                Arguments.of(107, 107, StorageType.NFS, true),
+                Arguments.of(107, 107, StorageType.ISCSI, true),
+                // one GB over threshold: invalid
+                Arguments.of(108, 107, StorageType.NFS, false),
+                Arguments.of(108, 107, StorageType.ISCSI, false)
+        );
+    }
+
+    @MockedConfig("mockConfiguration")
+    @ParameterizedTest
+    @MethodSource("createCowPreallocatedParams")
+    public void testValidateNewCowPreallocatedDisk
+    (int diskSizeGb, int availableSizeGb, StorageType storageType, boolean expectedValid) {
+        DiskImage disk = new DiskImage();
+        disk.setVolumeFormat(VolumeFormat.COW);
+        disk.setVolumeType(VolumeType.Preallocated);
+        disk.setStorageIds(Collections.singletonList(Guid.newGuid()));
+        disk.setSizeInGigabytes(diskSizeGb);
+
+        StorageDomain sd = new StorageDomain();
+        sd.setStorageType(storageType);
+        sd.setAvailableDiskSize(availableSizeGb);
+
+        StorageDomainValidator sdValidator = new StorageDomainValidator(sd);
+        assertEquals(expectedValid, sdValidator.hasSpaceForNewDisk(disk).isValid(),
+                "COW Preallocated: " + diskSizeGb + "GB disk, " + availableSizeGb + "GB available, " + storageType);
     }
 }


### PR DESCRIPTION
## Changes introduced with this PR

* Previously it was not checked that the requested space for a preallocated disk was available on the storage domain. If there was less space on a storage domain than the disk required, it would cause a locked disk instead of validating and stopping the disk from being created. Ensure that the needed space is available, also extend testing to cover this new functionality.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]