### PR TITLE
core: Fix leaked source LV on template clone measure

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/CopyImageGroupWithDataCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/storage/disk/image/CopyImageGroupWithDataCommand.java
@@ -254,7 +254,7 @@ public class CopyImageGroupWithDataCommand<T extends CopyImageGroupWithDataComma
                     sourceImage.getImageId(),
                     destFormat.getValue());
             parameters.setParentCommand(getActionType());
-            parameters.setEndProcedure(EndProcedure.PARENT_MANAGED);
+            parameters.setEndProcedure(EndProcedure.COMMAND_MANAGED);
             parameters.setVdsRunningOn(hostId);
             parameters.setCorrelationId(getCorrelationId());
             ActionReturnValue actionReturnValue =


### PR DESCRIPTION
When collapsing a copy (e.g. AddVmFromTemplate on block storage), CopyImageGroupWithDataCommand.determineTotalImageInitialSize() runs a MeasureVolume child on the source image to size the new volume. That child prepares (activates) the source image and defers its teardown to MeasureVolumeCommand.endSuccessfully().

The measure was launched with EndProcedure.PARENT_MANAGED, but this command never ends the measure child (it is not tracked among the children it ends). As a result endSuccessfully() never runs, the teardownImage is never issued, and the source volume is left activated on the measurement host as an active-but-unused LV.

Use EndProcedure.COMMAND_MANAGED so the framework ends the measure command on both success and failure paths, guaranteeing the source image is torn down. This matches the sibling commands that measure a source image for sizing (CloneImageGroupVolumesStructureCommand and ConvertDiskCommand), which already use COMMAND_MANAGED.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]