### PR TITLE
core: fix next-run apply failure after template rename

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/VmHandler.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/VmHandler.java
@@ -1593,6 +1593,11 @@ public class VmHandler implements BackendService {
         newVm.setStaticData(newVmStatic);
         newVm.setClusterBiosType(existingVm.getClusterBiosType());
         newVm.setClusterArch(existingVm.getClusterArch());
+        // The original template fields are not editable, so they are not part of the update
+        // parameters; carry them over from the existing VM, otherwise they would be missing
+        // from the snapshot configuration and fail the validation when it is applied.
+        newVm.getStaticData().setOriginalTemplateName(existingVm.getOriginalTemplateName());
+        newVm.getStaticData().setOriginalTemplateGuid(existingVm.getOriginalTemplateGuid());
 
         Set<String> changedFields = getChangedFieldsForStatus(
                 existingVm.getStaticData(),

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/snapshots/SnapshotsManager.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/snapshots/SnapshotsManager.java
@@ -569,6 +569,14 @@ public class SnapshotsManager {
             vm.setCpuProfileId(oldVmStatic.getCpuProfileId());
             vm.setClusterId(oldVmStatic.getClusterId());
 
+            // The original template fields are not editable, so the value in the DB is authoritative.
+            // The configuration (e.g. a next-run snapshot taken before the original template was
+            // renamed) may carry a stale or missing value; applying it as-is would fail the
+            // UpdateVmCommand validation (VM_CANNOT_UPDATE_ILLEGAL_FIELD), so always take the
+            // current values from the DB.
+            vm.getStaticData().setOriginalTemplateName(oldVmStatic.getOriginalTemplateName());
+            vm.getStaticData().setOriginalTemplateGuid(oldVmStatic.getOriginalTemplateGuid());
+
             // The VM configuration does not hold the vds group Id.
             // It is necessary to fetch the vm static from the Db, in order to get this information
             VmStatic vmStaticFromDb = vmStaticDao.get(vm.getId());


### PR DESCRIPTION
When a VM's original template is renamed between the creation of a next-run snapshot and its application, the internal UpdateVmCommand triggered by ProcessDownVmCommand fails validation with VM_CANNOT_UPDATE_ILLEGAL_FIELD:

- the next-run OVF stores a frozen copy of originalTemplateName/ originalTemplateGuid at snapshot time,
- renaming the template updates vm_static but not the stored snapshot configuration,
- applying the snapshot then compares the stale OVF value against the current DB value, which ObjectIdentityChecker rejects since these fields are not editable.

As a result the next-run configuration is never applied. This is especially visible after a cluster upgrade: the next-run snapshot is supposed to clear the temporary custom compatibility version set on running VMs, so the failure leaves the VM with a stale (lower) compatibility version and RunVm is rejected with
ACTION_TYPE_FAILED_VM_COMPATIBILITY_VERSION_NOT_SUPPORTED, leaving the VM down after a guest-initiated reboot.

Fix in two places:

- SnapshotsManager.updateVmFromConfiguration(): the DB values are authoritative for these non-editable fields; always take them instead of the possibly stale or missing values from the imported configuration. This also covers configurations whose OVF lacks the elements entirely (e.g. written from update parameters that don't carry them).
- VmHandler.createNextRunSnapshot(): carry the original template fields from the existing VM into the next-run snapshot so the configuration is complete going forward.

The same hardening applies to regular snapshot preview/restore, which uses the same code path.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]